### PR TITLE
[common] fix in Conrad model to check all ttyUSB ports

### DIFF
--- a/common/ConradModel.cc
+++ b/common/ConradModel.cc
@@ -102,23 +102,21 @@ void ConradModel::initialize( void )
   	// Only loop over list when not empty
   	if (!list.empty()) {
 
-  		// browse and try initialize() until conradController_ gets an answer
-  		QStringList::const_iterator it = list.begin();
-  		QString port = QString( "/dev/" ) + *it;
+                // browse and try initialize() until ConradController gets an answer
+                bool controller_initialized(false);
 
-  		renewController( port );
+                for(const auto& port : list)
+                {
+                  renewController("/dev/"+port);
 
-  		while (it < list.end() && !controller_->initialize()) {
+                  controller_initialized = controller_->initialize();
 
-  			// Compose full absolute location of USB device
-  			port = QString( "/dev/" ) + *it;
-  			renewController( port );
-
-  			++it;
-  		}
+                  // Conrad controller initialized successfully, break loop and proceed
+                  if(controller_initialized == true){ break; }
+                }
 
   		// check communication; if it is not at the end, switch was found
-  		if (it != list.end()) {
+  		if (controller_initialized) {
 
   			// read and init status
   			std::vector<bool> status = controller_->queryStatus();
@@ -133,11 +131,11 @@ void ConradModel::initialize( void )
   				//    if( debugLevel_ >= 1 )
   				NQLog("ConradModel::initialize()", NQLog::Message)
   				<< "connection to conrad via: "
-					<< port.toStdString() << ".";
+					<< controller_->comPort() << ".";
 
   			} else {
 
-  				/*
+ 				/*
 	    would be 0 if query failed (according to ConradController::queryStatus)
 	    This means device malfunction, so set state accordingly
   				 */

--- a/devices/Conrad/ConradCommunication.h
+++ b/devices/Conrad/ConradCommunication.h
@@ -29,6 +29,8 @@ public:
   bool sendCommand(unsigned char command, unsigned char address, unsigned char data) const;
   bool receiveAnswer(unsigned char* answer, unsigned char* address, unsigned char* data) const;
 
+  const char* comPort() const { return m_comPort; }
+
 private:
   const char* m_comPort;
   int m_ioPort;

--- a/devices/Conrad/ConradController.cpp
+++ b/devices/Conrad/ConradController.cpp
@@ -70,6 +70,14 @@ bool ConradController::initialize()
   return true;
 }
 
+//! Return name of port used to initialize ConradCommunication
+const char* ConradController::comPort() const
+{
+  assert(m_communication);
+
+  return m_communication->comPort();
+}
+
 //! Internal helper function
 static inline bool isBitSet(unsigned char data, unsigned bit)
 {

--- a/devices/Conrad/ConradController.h
+++ b/devices/Conrad/ConradController.h
@@ -33,6 +33,8 @@ public:
   bool setChannel(unsigned channel, bool value) const;
   bool setSingleChannel(unsigned channel, bool value) const;
 
+  const char* comPort() const;
+
 private:
   bool queryRawStatus(unsigned char& status) const;
 


### PR DESCRIPTION
* noticed that when the Conrad was not connected to `ttyUSB0`, its initialization didn't work;

* from looking at the code (before this PR), the call to `++it` prevents `ConradModel::initialize` to run for the last entry of the list (because the call to `++it` makes the `it < list.end()` condition fail); for example, with Lang connected to `ttyUSB0` and Conrad to `ttyUSB1`, the latter wouldn't be checked by `ConradModel::initialize` and the Conrad wouldn't work;

* I've tried to implement a fix in this PR; the idea is that everything should work out of the box, regardless of the order with which the devices are connected (right now for the Lang we specify the port we use in `assembly.cfg`; we could implement the automatic browsing of the available ports for the LStep model as well, if it's not already there);

* tested in the DAF, works as expected;

* not an expert of these internal classes, so comments on the implementation are welcomed (it could have been enough to move the `++it` call at the beginning of the `while` block; the implementation in the PR is what I found to be most clear, and what I tested so far).

@Negusbuk 