### PR TITLE
update to c++17 standard in all compiler calls

### DIFF
--- a/assembly/assembly/assembly.pro.in
+++ b/assembly/assembly/assembly.pro.in
@@ -31,7 +31,7 @@ PKGCONFIG += opencv
 
 QMAKE = @qmake@
 
-QMAKE_CXXFLAGS += -std=c++11
+QMAKE_CXXFLAGS += -std=c++17
 macx {
   QMAKE_CXXFLAGS += -DAPPLICATIONVERSIONSTR=\\\"unknown\\\"
 }

--- a/assembly/assemblyCommon/assemblyCommon.pro.in
+++ b/assembly/assemblyCommon/assemblyCommon.pro.in
@@ -38,7 +38,7 @@ PKGCONFIG += opencv
 
 QMAKE = @qmake@
 
-QMAKE_CXXFLAGS += -std=c++11
+QMAKE_CXXFLAGS += -std=c++17
 
 macx {
   QMAKE_CXXFLAGS += -DAPPLICATIONVERSIONSTR=\\\"unknown\\\"

--- a/assembly/motion/motionCommander/motionCommander.pro.in
+++ b/assembly/motion/motionCommander/motionCommander.pro.in
@@ -38,7 +38,7 @@ PKGCONFIG += opencv
 
 QMAKE = @qmake@
 
-QMAKE_CXXFLAGS += -std=c++11
+QMAKE_CXXFLAGS += -std=c++17
 macx {
   QMAKE_CXXFLAGS += -DAPPLICATIONVERSIONSTR=\\\"unknown\\\"
 }

--- a/assembly/testingArea/Testing/Testing.pro
+++ b/assembly/testingArea/Testing/Testing.pro
@@ -25,7 +25,7 @@ macx {
 CONFIG += link_pkgconfig
 PKGCONFIG += opencv
 
-QMAKE_CXXFLAGS += -std=c++11
+QMAKE_CXXFLAGS += -std=c++17
 macx {
   QMAKE_CXXFLAGS += -DAPPLICATIONVERSIONSTR=\\\"unknown\\\"
 }

--- a/assembly/vision/circleCalibration/circleCalibration.pro.in
+++ b/assembly/vision/circleCalibration/circleCalibration.pro.in
@@ -31,7 +31,7 @@ PKGCONFIG += opencv
 
 QMAKE = @qmake@
 
-QMAKE_CXXFLAGS += -std=c++11
+QMAKE_CXXFLAGS += -std=c++17
 macx {
   QMAKE_CXXFLAGS += -DAPPLICATIONVERSIONSTR=\\\"unknown\\\"
 }

--- a/common_test/common_test.pro.in
+++ b/common_test/common_test.pro.in
@@ -22,8 +22,8 @@ macx {
   QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
 }
 
-CONFIG+=c++11
-QMAKE_CXXFLAGS += -std=c++11
+CONFIG+=c++17
+QMAKE_CXXFLAGS += -std=c++17
 macx {
   QMAKE_CXXFLAGS += -DAPPLICATIONVERSIONSTR=\\\"unknown\\\"
 } else {

--- a/defo/defoCalib/defoCalib.pro.in
+++ b/defo/defoCalib/defoCalib.pro.in
@@ -29,8 +29,8 @@ macx {
 CONFIG += link_pkgconfig
 PKGCONFIG += opencv exiv2 libgphoto2
 
-CONFIG+=c++11
-QMAKE_CXXFLAGS += -std=c++11
+CONFIG+=c++17
+QMAKE_CXXFLAGS += -std=c++17
 macx {
   QMAKE_CXXFLAGS += -DAPPLICATIONVERSIONSTR=\\\"unknown\\\"
 } else {

--- a/defo/defoCommon/defoCommon.pro.in
+++ b/defo/defoCommon/defoCommon.pro.in
@@ -23,8 +23,8 @@ macx {
 CONFIG += link_pkgconfig
 PKGCONFIG += opencv exiv2 libgphoto2
 
-CONFIG+=c++11
-QMAKE_CXXFLAGS += -std=c++11
+CONFIG+=c++17
+QMAKE_CXXFLAGS += -std=c++17
 macx {
   QMAKE_CXXFLAGS += -DAPPLICATIONVERSIONSTR=\\\"unknown\\\"
 } else {

--- a/defo/defoDAQ/defoDAQ.pro.in
+++ b/defo/defoDAQ/defoDAQ.pro.in
@@ -27,8 +27,8 @@ macx {
 CONFIG += link_pkgconfig
 PKGCONFIG += opencv exiv2 libgphoto2
 
-CONFIG+=c++11
-QMAKE_CXXFLAGS += -std=c++11
+CONFIG+=c++17
+QMAKE_CXXFLAGS += -std=c++17
 macx {
   QMAKE_CXXFLAGS += -DAPPLICATIONVERSIONSTR=\\\"unknown\\\"
 } else {

--- a/defo/defoDAQ2Root/defoDAQ2Root.pro.in
+++ b/defo/defoDAQ2Root/defoDAQ2Root.pro.in
@@ -3,8 +3,8 @@ LIBS += @rootlibs@
 
 QMAKE = @qmake@
 
-CONFIG+=c++11
-QMAKE_CXXFLAGS += -std=c++11
+CONFIG+=c++17
+QMAKE_CXXFLAGS += -std=c++17
 macx {
   QMAKE_CXXFLAGS += -DAPPLICATIONVERSIONSTR=\\\"unknown\\\"
 } else {

--- a/defo/defoDisplay/defoDisplay.pro.in
+++ b/defo/defoDisplay/defoDisplay.pro.in
@@ -21,8 +21,8 @@ macx {
   LIBS += -framework Cocoa
 }
 
-CONFIG+=c++11
-QMAKE_CXXFLAGS += -std=c++11
+CONFIG+=c++17
+QMAKE_CXXFLAGS += -std=c++17
 macx {
   QMAKE_CXXFLAGS += -DAPPLICATIONVERSIONSTR=\\\"unknown\\\"
 } else {

--- a/defo/defoReco/defoReco.pro.in
+++ b/defo/defoReco/defoReco.pro.in
@@ -27,8 +27,8 @@ macx {
 CONFIG += link_pkgconfig
 PKGCONFIG += opencv exiv2 libgphoto2
 
-CONFIG+=c++11
-QMAKE_CXXFLAGS += -std=c++11
+CONFIG+=c++17
+QMAKE_CXXFLAGS += -std=c++17
 macx {
   QMAKE_CXXFLAGS += -DAPPLICATIONVERSIONSTR=\\\"unknown\\\"
 } else {

--- a/devices/Makefile.common.in
+++ b/devices/Makefile.common.in
@@ -1,6 +1,6 @@
 CC            = @cc@
 CXX           = @cxx@
-CXXFLAGS      = -fPIC -std=c++11
+CXXFLAGS      = -fPIC -std=c++17
 LD            = @cxx@
 SOFLAGS       = @soflags@
 

--- a/external/math/Makefile.in
+++ b/external/math/Makefile.in
@@ -11,7 +11,7 @@ MODULES       = TkMLVector \
 
 CC            = @cc@
 CXX           = @cxx@
-CXXFLAGS      = -fPIC -std=c++11 -I.
+CXXFLAGS      = -fPIC -std=c++17 -I.
 LD            = @cxx@
 SOFLAGS       = @soflags@
 

--- a/plasma/plasmacleaner.pro.in
+++ b/plasma/plasmacleaner.pro.in
@@ -20,7 +20,7 @@ macx {
 CONFIG += link_pkgconfig
 PKGCONFIG += 
 
-QMAKE_CXXFLAGS += -std=c++11
+QMAKE_CXXFLAGS += -std=c++17
 macx {
   QMAKE_CXXFLAGS += -DAPPLICATIONVERSIONSTR=\\\"unknown\\\"
 }

--- a/pumpstation/analysis/PumpStationAnalysis.pro.in
+++ b/pumpstation/analysis/PumpStationAnalysis.pro.in
@@ -20,7 +20,7 @@ macx {
 CONFIG += link_pkgconfig
 PKGCONFIG += 
 
-QMAKE_CXXFLAGS += -std=c++11
+QMAKE_CXXFLAGS += -std=c++17
 macx {
   QMAKE_CXXFLAGS += -DAPPLICATIONVERSIONSTR=\\\"unknown\\\"
 }

--- a/pumpstation/app/CMSPumpStationControl.pro
+++ b/pumpstation/app/CMSPumpStationControl.pro
@@ -13,7 +13,7 @@ win32 {
 CONFIG += link_pkgconfig
 PKGCONFIG += 
 
-QMAKE_CXXFLAGS += -std=c++11
+QMAKE_CXXFLAGS += -std=c++17
 
 QT += core gui network script svg
 greaterThan(QT_MAJOR_VERSION, 4) {

--- a/pumpstation/controller/PumpStationControl.pro.in
+++ b/pumpstation/controller/PumpStationControl.pro.in
@@ -17,7 +17,7 @@ macx {
 CONFIG += link_pkgconfig
 PKGCONFIG += 
 
-QMAKE_CXXFLAGS += -std=c++11
+QMAKE_CXXFLAGS += -std=c++17
 macx {
   QMAKE_CXXFLAGS += -DAPPLICATIONVERSIONSTR=\\\"unknown\\\"
 }

--- a/pumpstation/daemon/DataLogger.h
+++ b/pumpstation/daemon/DataLogger.h
@@ -18,6 +18,7 @@
 #include <QFile>
 #include <QMutex>
 #include <QTimer>
+#include <QDir>
 #include <QDateTime>
 #include <QXmlStreamWriter>
 #include <QSocketNotifier>

--- a/pumpstation/daemon/PumpStationDaemon.pro.in
+++ b/pumpstation/daemon/PumpStationDaemon.pro.in
@@ -21,7 +21,7 @@ macx {
 CONFIG += link_pkgconfig
 PKGCONFIG += 
 
-QMAKE_CXXFLAGS += -std=c++11
+QMAKE_CXXFLAGS += -std=c++17
 macx {
   QMAKE_CXXFLAGS += -DAPPLICATIONVERSIONSTR=\\\"unknown\\\"
 }

--- a/python/Makefile.in
+++ b/python/Makefile.in
@@ -12,7 +12,7 @@ PYTHONINC    := $(shell python-config --cflags)
 
 CC            = @cc@
 CXX           = @cxx@
-CXXFLAGS      = -fPIC -std=c++11
+CXXFLAGS      = -fPIC -std=c++17
 LD            = @cxx@
 SOFLAGS       = @soflags@
 

--- a/thermo/microDAQ/microDAQ.pro.in
+++ b/thermo/microDAQ/microDAQ.pro.in
@@ -22,8 +22,8 @@ macx {
   #LIBS += -framework Cocoa
 }
 
-CONFIG+=c++11
-QMAKE_CXXFLAGS += -std=c++11
+CONFIG+=c++17
+QMAKE_CXXFLAGS += -std=c++17
 
 macx {
   QMAKE_CXXFLAGS += -DAPPLICATIONVERSIONSTR=\\\"unknown\\\"

--- a/thermo/microDisplay/microDisplay.pro.in
+++ b/thermo/microDisplay/microDisplay.pro.in
@@ -20,8 +20,8 @@ macx {
   #LIBS += -framework Cocoa
 }
 
-CONFIG+=c++11
-QMAKE_CXXFLAGS += -std=c++11
+CONFIG+=c++17
+QMAKE_CXXFLAGS += -std=c++17
 macx {
   QMAKE_CXXFLAGS += -DAPPLICATIONVERSIONSTR=\\\"unknown\\\"
 } else {

--- a/thermo/thermoDAQ/thermoDAQ.pro.in
+++ b/thermo/thermoDAQ/thermoDAQ.pro.in
@@ -20,8 +20,8 @@ macx {
   #LIBS += -framework Cocoa
 }
 
-CONFIG+=c++11
-QMAKE_CXXFLAGS += -std=c++11
+CONFIG+=c++17
+QMAKE_CXXFLAGS += -std=c++17
 
 macx {
   QMAKE_CXXFLAGS += -DAPPLICATIONVERSIONSTR=\\\"unknown\\\"

--- a/thermo/thermoDAQ2Log/thermoDAQ2Log.pro.in
+++ b/thermo/thermoDAQ2Log/thermoDAQ2Log.pro.in
@@ -6,8 +6,8 @@
 
 QMAKE = @qmake@
 
-CONFIG+=c++11
-QMAKE_CXXFLAGS += -std=c++11
+CONFIG+=c++17
+QMAKE_CXXFLAGS += -std=c++17
 macx {
   QMAKE_CXXFLAGS += -DAPPLICATIONVERSIONSTR=\\\"unknown\\\"
 } else {

--- a/thermo/thermoDAQ2Plots/thermoDAQ2Plots.pro.in
+++ b/thermo/thermoDAQ2Plots/thermoDAQ2Plots.pro.in
@@ -20,8 +20,8 @@ macx {
   #LIBS += -framework Cocoa
 }
 
-CONFIG+=c++11
-QMAKE_CXXFLAGS += -std=c++11
+CONFIG+=c++17
+QMAKE_CXXFLAGS += -std=c++17
 macx {
   QMAKE_CXXFLAGS += -DAPPLICATIONVERSIONSTR=\\\"unknown\\\"
 } else {

--- a/thermo/thermoDAQ2Root/thermoDAQ2Root.pro.in
+++ b/thermo/thermoDAQ2Root/thermoDAQ2Root.pro.in
@@ -9,8 +9,8 @@ LIBS += @rootlibs@
 
 QMAKE = @qmake@
 
-CONFIG+=c++11
-QMAKE_CXXFLAGS += -std=c++11
+CONFIG+=c++17
+QMAKE_CXXFLAGS += -std=c++17
 macx {
   QMAKE_CXXFLAGS += -DAPPLICATIONVERSIONSTR=\\\"unknown\\\"
 } else {

--- a/thermo/thermoDisplay/thermoDisplay.pro.in
+++ b/thermo/thermoDisplay/thermoDisplay.pro.in
@@ -20,8 +20,8 @@ macx {
   #LIBS += -framework Cocoa
 }
 
-CONFIG+=c++11
-QMAKE_CXXFLAGS += -std=c++11
+CONFIG+=c++17
+QMAKE_CXXFLAGS += -std=c++17
 
 macx {
   QMAKE_CXXFLAGS += -DAPPLICATIONVERSIONSTR=\\\"unknown\\\"

--- a/tools/ReadKeithley2700/Makefile.in
+++ b/tools/ReadKeithley2700/Makefile.in
@@ -10,7 +10,7 @@ SOURCE        = ReadKeithley2700
 
 ARCHITECTURE := @architecture@
 
-CXXFLAGS      = -Wall -fPIC -std=c++0x -I$(BASEPATH)/devices/Keithley
+CXXFLAGS      = -Wall -fPIC -std=c++17 -I$(BASEPATH)/devices/Keithley
 
 ifeq ($(USEFAKEDEVICES),1)
 CXXFLAGS     += -DUSE_FAKEIO

--- a/tools/TkModLabRoot/Makefile.in
+++ b/tools/TkModLabRoot/Makefile.in
@@ -34,7 +34,7 @@ endif
 
 CC            = @cc@
 CXX           = @cxx@
-CXXFLAGS      = -fPIC -std=c++11
+CXXFLAGS      = -fPIC -std=c++17
 LD            = @cxx@
 SOFLAGS       = @soflags@
 


### PR DESCRIPTION
* follow-up to #148: updated to c++17 standard for all compiler calls, except for `common/` (which was already updated in #148):

  - changed all occurrences of `c++0x` and `c++11` to `c++17`

  - added include in `pumpstation/daemon/DataLogger.h` to fix a compilation error (see 
c45d5ad)

* tested on a laptop with `./configure --nopumpstation --noueye`
