### PR TITLE
[common] added QMutex to NQLogger

### DIFF
--- a/common/nqlogger.cc
+++ b/common/nqlogger.cc
@@ -21,6 +21,7 @@
 #include <iostream>
 
 #include <QDateTime>
+#include <QMutexLocker>
 
 #include "nqlogger.h"
 
@@ -97,6 +98,7 @@ void NQLogger::write(const QString& module, NQLog::LogLevel level, const QString
   for (std::pair<NQLog::LogLevel,QTextStream*> v : destinations_) {
     if (level>=v.first) {
       QTextStream* stream = v.second;
+      QMutexLocker locker(&mutex_);
       stream->operator <<(message);
       stream->flush();
     }

--- a/common/nqlogger.h
+++ b/common/nqlogger.h
@@ -28,6 +28,7 @@
 #include <QObject>
 #include <QIODevice>
 #include <QTextStream>
+#include <QMutex>
 
 /** @addtogroup common
  *  @{
@@ -152,6 +153,8 @@ protected:
 
     explicit NQLogger(QObject *parent = 0);
     static NQLogger* instance_;
+
+    QMutex mutex_;
 
     std::set<std::pair<QString,bool> > activeModules_;
     std::vector<std::pair<NQLog::LogLevel,QTextStream*> > destinations_;


### PR DESCRIPTION
Added a `QMutexLocker` object in `NQLogger::write` to avoid multi-thread access conflicts. 
Fixes crashes observed e.g. when stress-testing the Emergency Stop button, and potentially other related issues (rare random crashes during multi-pickup calibration test, etc.)