### PR TITLE
Opencv4 on Ubuntu

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,7 @@ find_package(ROOT 6.16 REQUIRED)
 message(STATUS ${ROOT_INCLUDE_DIRS})
 
 pkg_check_modules(LIBGPHOTO2 REQUIRED IMPORTED_TARGET libgphoto2)
-pkg_check_modules(OPENCV REQUIRED IMPORTED_TARGET opencv)
+pkg_check_modules(OPENCV4 REQUIRED IMPORTED_TARGET opencv4)
 pkg_check_modules(EXIV2 REQUIRED IMPORTED_TARGET exiv2)
 
 if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Darwin")

--- a/assembly/assemblyCommon/AssemblyImageView.cc
+++ b/assembly/assemblyCommon/AssemblyImageView.cc
@@ -251,7 +251,7 @@ void AssemblyImageView::load_image()
   const QString filename = QFileDialog::getOpenFileName(this, tr("Load Image"), QString::fromStdString(Config::CMSTkModLabBasePath+"/share/assembly"), tr("PNG Files (*.png);;All Files (*)"));
   if(filename.isNull() || filename.isEmpty()){ return; }
 
-  const cv::Mat img = assembly::cv_imread(filename, CV_LOAD_IMAGE_COLOR);
+  const cv::Mat img = assembly::cv_imread(filename, cv::IMREAD_COLOR);
 
   if(img.empty())
   {
@@ -349,15 +349,15 @@ void AssemblyImageView::modify_image_axesConventions()
   cv::Mat img = image_.clone(); //Use current image (possibly with center lines displayed), not raw image
 
   //See: https://docs.opencv.org/2.4/modules/core/doc/drawing_functions.html#puttext
-  //CV_AA = anti-aliased linetype
+  //cv::LINE_AA = anti-aliased linetype
   //Text position is hardcoded
   int fontFace = cv::FONT_HERSHEY_PLAIN; //FONT_HERSHEY_SIMPLEX, ...
   double fontScale = 8;
   int linethick = 3;
-  putText(img, "+x", cv::Point(img.cols/2.0+padding, 2*padding), fontFace, fontScale, cv::Scalar(255,0,0), linethick, CV_AA);
-  putText(img, "-x", cv::Point(img.cols/2.0+padding, img.rows-padding), fontFace, fontScale, cv::Scalar(255,0,0), linethick, CV_AA);
-  putText(img, "+y", cv::Point(padding, img.rows/2.0+2*padding), fontFace, fontScale, cv::Scalar(255,0,0), linethick, CV_AA);
-  putText(img, "-y", cv::Point(img.cols-5*padding, img.rows/2.0+2*padding), fontFace, fontScale, cv::Scalar(255,0,0), linethick, CV_AA);
+  putText(img, "+x", cv::Point(img.cols/2.0+padding, 2*padding), fontFace, fontScale, cv::Scalar(255,0,0), linethick, cv::LINE_AA);
+  putText(img, "-x", cv::Point(img.cols/2.0+padding, img.rows-padding), fontFace, fontScale, cv::Scalar(255,0,0), linethick, cv::LINE_AA);
+  putText(img, "+y", cv::Point(padding, img.rows/2.0+2*padding), fontFace, fontScale, cv::Scalar(255,0,0), linethick, cv::LINE_AA);
+  putText(img, "-y", cv::Point(img.cols-5*padding, img.rows/2.0+2*padding), fontFace, fontScale, cv::Scalar(255,0,0), linethick, cv::LINE_AA);
 
   //Add line/label for distance scale
   line   (img, cv::Point(0, 125), cv::Point(0+167, 125), cv::Scalar(0,255,0), 2, 8, 0);
@@ -365,7 +365,7 @@ void AssemblyImageView::modify_image_axesConventions()
 
   //Add line/label for rotation angle convention (positive angle <-> anti-clockwise)
   line   (img, cv::Point(10, img.rows-180), cv::Point(150, img.rows-80), cv::Scalar(255,0,0), 2, 8, 0);
-  putText(img, "+a", cv::Point(180, img.rows-15), fontFace, fontScale, cv::Scalar(255,0,0), linethick, CV_AA);
+  putText(img, "+a", cv::Point(180, img.rows-15), fontFace, fontScale, cv::Scalar(255,0,0), linethick, cv::LINE_AA);
 
   this->update_image(img, false);
 
@@ -442,7 +442,7 @@ void AssemblyImageView::update_image_zscan(const QString& img_path)
 {
   if(assembly::IsFile(img_path))
   {
-    image_zscan_ = assembly::cv_imread(img_path.toStdString(), CV_LOAD_IMAGE_COLOR);
+    image_zscan_ = assembly::cv_imread(img_path.toStdString(), cv::IMREAD_COLOR);
 
     NQLog("AssemblyImageView", NQLog::Spam) << "update_image_zscan"
        << ": emitting signal \"image_zscan_updated\"";

--- a/assembly/assemblyCommon/AssemblyObjectAlignerView.cc
+++ b/assembly/assemblyCommon/AssemblyObjectAlignerView.cc
@@ -513,7 +513,7 @@ void AssemblyObjectAlignerView::updateImage(const int stage, const QString& file
 {
   NQLog("AssemblyObjectAlignerView", NQLog::Spam) << "updateImage(" << stage << ", file=" << filename << ")";
 
-  const cv::Mat img = assembly::cv_imread(filename, CV_LOAD_IMAGE_UNCHANGED);
+  const cv::Mat img = assembly::cv_imread(filename, cv::IMREAD_UNCHANGED);
 
   this->updateImage(stage, img);
 

--- a/assembly/assemblyCommon/AssemblyObjectFinderPatRec.cc
+++ b/assembly/assemblyCommon/AssemblyObjectFinderPatRec.cc
@@ -151,7 +151,7 @@ void AssemblyObjectFinderPatRec::launch_PatRec(const AssemblyObjectFinderPatRec:
   // ----------
 
   // update template image
-  const cv::Mat img_templa = assembly::cv_imread(conf.template_filepath_, CV_LOAD_IMAGE_COLOR);
+  const cv::Mat img_templa = assembly::cv_imread(conf.template_filepath_, cv::IMREAD_COLOR);
 
   if(assembly::MatIsBlackAndWhite(img_templa) == false)
   {
@@ -413,7 +413,7 @@ void AssemblyObjectFinderPatRec::template_matching(const AssemblyObjectFinderPat
   cv::Mat img_templa_PatRec_gs;
   if(img_templa_PatRec.channels() > 1)
   {
-    cv::cvtColor(img_templa_PatRec, img_templa_PatRec_gs, CV_BGR2GRAY);
+    cv::cvtColor(img_templa_PatRec, img_templa_PatRec_gs, cv::COLOR_GRAY2BGR);
   }
   else
   {
@@ -423,8 +423,8 @@ void AssemblyObjectFinderPatRec::template_matching(const AssemblyObjectFinderPat
   // Template-Matching method for matchTemplate() routine of OpenCV
   // For SQDIFF and SQDIFF_NORMED, the best match is the lowest value; for all the other methods, the best match is the highest value.
   // REF https://docs.opencv.org/2.4/modules/imgproc/doc/object_detection.html?highlight=matchtemplate#matchtemplate
-  const int match_method = CV_TM_SQDIFF_NORMED;
-  const bool use_minFOM = ((match_method  == CV_TM_SQDIFF) || (match_method == CV_TM_SQDIFF_NORMED));
+  const int match_method = cv::TM_SQDIFF_NORMED;
+  const bool use_minFOM = ((match_method  == cv::TM_SQDIFF) || (match_method == cv::TM_SQDIFF_NORMED));
 
   NQLog("AssemblyObjectFinderPatRec", NQLog::Spam) << "template_matching" << ": initiated matching routine with angular scan";
 
@@ -710,7 +710,7 @@ void AssemblyObjectFinderPatRec::PatRec(double& fom, cv::Point& match_loc, const
 
   minMaxLoc(result_mat, &minVal, &maxVal, &minLoc, &maxLoc, cv::Mat());
 
-  const bool use_minFOM = ((match_method  == CV_TM_SQDIFF) || (match_method == CV_TM_SQDIFF_NORMED));
+  const bool use_minFOM = ((match_method  == cv::TM_SQDIFF) || (match_method == cv::TM_SQDIFF_NORMED));
 
   if(use_minFOM){ match_loc = minLoc; fom = minVal; }
   else          { match_loc = maxLoc; fom = maxVal; }

--- a/assembly/assemblyCommon/AssemblyObjectFinderPatRec.cc
+++ b/assembly/assemblyCommon/AssemblyObjectFinderPatRec.cc
@@ -413,7 +413,7 @@ void AssemblyObjectFinderPatRec::template_matching(const AssemblyObjectFinderPat
   cv::Mat img_templa_PatRec_gs;
   if(img_templa_PatRec.channels() > 1)
   {
-    cv::cvtColor(img_templa_PatRec, img_templa_PatRec_gs, cv::COLOR_GRAY2BGR);
+    cv::cvtColor(img_templa_PatRec, img_templa_PatRec_gs, cv::COLOR_BGR2GRAY);
   }
   else
   {

--- a/assembly/assemblyCommon/AssemblyObjectFinderPatRecView.cc
+++ b/assembly/assemblyCommon/AssemblyObjectFinderPatRecView.cc
@@ -335,7 +335,7 @@ void AssemblyObjectFinderPatRecView::update_image(const int stage, const QString
 
   QMutexLocker ml(&mutex_);
 
-  const cv::Mat img = assembly::cv_imread(filename, CV_LOAD_IMAGE_UNCHANGED);
+  const cv::Mat img = assembly::cv_imread(filename, cv::IMREAD_UNCHANGED);
 
   ml.unlock();
 

--- a/assembly/assemblyCommon/AssemblyObjectFinderPatRecWidget.cc
+++ b/assembly/assemblyCommon/AssemblyObjectFinderPatRecWidget.cc
@@ -147,7 +147,7 @@ void AssemblyObjectFinderPatRecWidget::load_image_template_from_path(const QStri
 {
   if(filename.isNull() || filename.isEmpty()){ return; }
 
-  const cv::Mat img = assembly::cv_imread(filename, CV_LOAD_IMAGE_COLOR);
+  const cv::Mat img = assembly::cv_imread(filename, cv::IMREAD_COLOR);
 
   if(img.empty())
   {

--- a/assembly/assemblyCommon/AssemblyThresholder.cc
+++ b/assembly/assemblyCommon/AssemblyThresholder.cc
@@ -105,7 +105,7 @@ cv::Mat AssemblyThresholder::get_image_binary_threshold(const cv::Mat& img, cons
   if(img.channels() > 1)
   {
     // convert color to GS
-    cv::cvtColor(img, img_gs, CV_BGR2GRAY);
+    cv::cvtColor(img, img_gs, cv::COLOR_GRAY2BGR);
   }
   else
   {
@@ -170,7 +170,7 @@ cv::Mat AssemblyThresholder::get_image_binary_adaptiveThreshold(const cv::Mat& i
   if(img.channels() > 1)
   {
     // convert color to GS
-    cv::cvtColor(img, img_gs, CV_BGR2GRAY);
+    cv::cvtColor(img, img_gs, cv::COLOR_GRAY2BGR);
   }
   else
   {

--- a/assembly/assemblyCommon/AssemblyThresholder.cc
+++ b/assembly/assemblyCommon/AssemblyThresholder.cc
@@ -105,7 +105,7 @@ cv::Mat AssemblyThresholder::get_image_binary_threshold(const cv::Mat& img, cons
   if(img.channels() > 1)
   {
     // convert color to GS
-    cv::cvtColor(img, img_gs, cv::COLOR_GRAY2BGR);
+    cv::cvtColor(img, img_gs, cv::COLOR_BGR2GRAY);
   }
   else
   {
@@ -170,7 +170,7 @@ cv::Mat AssemblyThresholder::get_image_binary_adaptiveThreshold(const cv::Mat& i
   if(img.channels() > 1)
   {
     // convert color to GS
-    cv::cvtColor(img, img_gs, cv::COLOR_GRAY2BGR);
+    cv::cvtColor(img, img_gs, cv::COLOR_BGR2GRAY);
   }
   else
   {

--- a/assembly/assemblyCommon/AssemblyThresholderView.cc
+++ b/assembly/assemblyCommon/AssemblyThresholderView.cc
@@ -245,7 +245,7 @@ void AssemblyThresholderView::load_image_raw()
   const QString filename = QFileDialog::getOpenFileName(this, tr("Load Image"), QString::fromStdString(Config::CMSTkModLabBasePath+"/share/assembly"), tr("PNG Files (*.png);;All Files (*)"));
   if(filename.isNull() || filename.isEmpty()){ return; }
 
-  const cv::Mat img = assembly::cv_imread(filename, CV_LOAD_IMAGE_COLOR);
+  const cv::Mat img = assembly::cv_imread(filename, cv::IMREAD_COLOR);
 
   if(img.empty())
   {

--- a/assembly/assemblyCommon/AssemblyUEyeFakeCamera.cc
+++ b/assembly/assemblyCommon/AssemblyUEyeFakeCamera.cc
@@ -221,7 +221,7 @@ void AssemblyUEyeFakeCamera::acquireImage()
 {
     if(cameraState_ != State::READY){ return; }
 
-    image_ = cv::imread(imageFilenames_[imageIndex_++], CV_LOAD_IMAGE_GRAYSCALE);
+    image_ = cv::imread(imageFilenames_[imageIndex_++], cv::IMREAD_GRAYSCALE);
 
     NQLog("AssemblyUEyeFakeCamera", NQLog::Debug) << "acquireImage"
        << ": emitting signal \"imageAcquired\"";

--- a/assembly/assemblyCommon/AssemblyUEyeView.cc
+++ b/assembly/assemblyCommon/AssemblyUEyeView.cc
@@ -38,7 +38,7 @@ void AssemblyUEyeView::setImage(const cv::Mat& newImage)
     if(newImage.channels() == 1)
     {
         cv::Mat temp;
-        cvtColor(newImage, temp, CV_GRAY2RGB);
+        cvtColor(newImage, temp, cv::COLOR_GRAY2RGB);
 
         image_ = QImage((const uchar *) temp.data, temp.cols, temp.rows, temp.step, QImage::Format_RGB888);
         image_.bits();

--- a/assembly/assemblyCommon/AssemblyUtilities.cc
+++ b/assembly/assemblyCommon/AssemblyUtilities.cc
@@ -93,7 +93,7 @@ cv::Mat assembly::cv_imread(const QString& path_qstr, const int imread_flag)
 
   if(img_reader.format() == "png" && (img.channels() > 1))
   {
-    cv::cvtColor(img, img_1, CV_RGB2BGR);
+    cv::cvtColor(img, img_1, cv::COLOR_RGB2BGR);
   }
   else
   {
@@ -120,7 +120,7 @@ void assembly::cv_imwrite(const QString& path_qstr, const cv::Mat& img)
   else if(img.channels() > 1)
   {
     cv::Mat img_1;
-    cv::cvtColor(img, img_1, CV_BGR2RGB);
+    cv::cvtColor(img, img_1, cv::COLOR_BGR2RGB);
     cv::imwrite(path_qstr.toUtf8().constData(), img_1);
   }
   else

--- a/assembly/assemblyCommon/AssemblyZFocusFinder.cc
+++ b/assembly/assemblyCommon/AssemblyZFocusFinder.cc
@@ -513,7 +513,7 @@ double AssemblyZFocusFinder::image_focus_value(const cv::Mat& img)
 //
 //  // Convert the image to grayscale
 //  cv::Mat img_gray;
-//  cv::cvtColor(img_gaus, img_gray, cv::COLOR_GRAY2BGR);
+//  cv::cvtColor(img_gaus, img_gray, cv::COLOR_BGR2GRAY);
 
   // Apply laplacian function to GS image
   cv::Mat img_lap;

--- a/assembly/assemblyCommon/AssemblyZFocusFinder.cc
+++ b/assembly/assemblyCommon/AssemblyZFocusFinder.cc
@@ -513,7 +513,7 @@ double AssemblyZFocusFinder::image_focus_value(const cv::Mat& img)
 //
 //  // Convert the image to grayscale
 //  cv::Mat img_gray;
-//  cv::cvtColor(img_gaus, img_gray, CV_BGR2GRAY);
+//  cv::cvtColor(img_gaus, img_gray, cv::COLOR_GRAY2BGR);
 
   // Apply laplacian function to GS image
   cv::Mat img_lap;

--- a/devices/Canon/CMakeLists.txt
+++ b/devices/Canon/CMakeLists.txt
@@ -14,7 +14,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -std=c++11")
 set_target_properties(TkModLabCanon PROPERTIES VERSION ${PROJECT_VERSION})
 set_target_properties(TkModLabCanon PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/devices/lib)
 
-target_link_libraries(TkModLabCanon PkgConfig::LIBGPHOTO2 PkgConfig::OPENCV PkgConfig::EXIV2)
+target_link_libraries(TkModLabCanon PkgConfig::LIBGPHOTO2 PkgConfig::OPENCV4 PkgConfig::EXIV2)
 target_compile_features(TkModLabCanon PRIVATE cxx_std_11)
 
 #add_executable(TkModLabAgilent_test test.cc)

--- a/devices/Canon/EOS550DFake.cc
+++ b/devices/Canon/EOS550DFake.cc
@@ -189,7 +189,7 @@ string EOS550DFake::renderPicture(bool preview)
 
   // Font settings
 #ifndef USE_FAKEIO
-  int fontFace = CV_FONT_HERSHEY_SIMPLEX;
+  int fontFace = cv::FONT_HERSHEY_SIMPLEX;
 #else
   int fontFace = FONT_HERSHEY_SIMPLEX;
 #endif
@@ -284,7 +284,7 @@ string EOS550DFake::renderPicture(bool preview)
 
   vector<int> options;
 #ifndef USE_FAKEIO
-  options.push_back(CV_IMWRITE_JPEG_QUALITY);
+  options.push_back(cv::IMWRITE_JPEG_QUALITY);
 #else
   options.push_back(IMWRITE_JPEG_QUALITY);
 #endif

--- a/devices/Canon/Makefile.in
+++ b/devices/Canon/Makefile.in
@@ -20,7 +20,7 @@ MODULES       = CameraComHandler \
                 EOS550DFake
 
 CXXFLAGS     += `pkg-config --cflags libgphoto2`
-CXXFLAGS     += `pkg-config --cflags opencv`
+CXXFLAGS     += `pkg-config --cflags opencv4`
 CXXFLAGS     += `pkg-config --cflags exiv2`
 
 ALLDEPEND = $(addsuffix .d,$(MODULES))

--- a/devices/Canon/test/CMakeLists.txt
+++ b/devices/Canon/test/CMakeLists.txt
@@ -1,4 +1,4 @@
 add_executable(TkModLabCanon_test test2.cc)
-target_link_libraries(TkModLabCanon_test LINK_PUBLIC TkModLabCanon PkgConfig::LIBGPHOTO2 PkgConfig::OPENCV PkgConfig::EXIV2)
+target_link_libraries(TkModLabCanon_test LINK_PUBLIC TkModLabCanon PkgConfig::LIBGPHOTO2 PkgConfig::OPENCV4 PkgConfig::EXIV2)
 set_target_properties(TkModLabCanon_test PROPERTIES OUTPUT_NAME test)
 


### PR DESCRIPTION
On late Ubuntu versions (20.04 for me) opencv4 could not be found.

This fixes CMake and compilation on Ubuntu 20.04 for me, although admittedly with the flag 
`-DOPENCV4_INCLUDE_DIRS=/usr/include/opencv4` , as opencv4 comes with two file paths in its pkg-config file, of which one doesn't exist anymore :shrug: maybe we can solve this more elegantly, not sure...

 In addition, the naming convention changed a bit, which is where the changes `CV_SOME_MEMBER` -> `cv::SOME_MEMBER` come from.

Before merging, it would be worth checking whether this works on MacOS as well, as I don't have a chance to test this. If it doesn't, we'll have to reiterate.