### PR TITLE
Fix OpenCV issue for CMake configuration

### DIFF
--- a/assembly/assembly/CMakeLists.txt
+++ b/assembly/assembly/CMakeLists.txt
@@ -19,6 +19,8 @@ add_compile_definitions(__${CMAKE_HOST_SYSTEM_NAME}__)
 
 include_directories(${PROJECT_SOURCE_DIR})
 
+include_directories(${OPENCV4_INCLUDE_DIRS})
+
 include_directories(${Qt5Core_INCLUDE_DIRS})
 include_directories(${Qt5Widgts_INCLUDE_DIRS})
 include_directories(${Qt5Script_INCLUDE_DIRS})

--- a/assembly/assemblyCommon/CMakeLists.txt
+++ b/assembly/assemblyCommon/CMakeLists.txt
@@ -78,6 +78,8 @@ include_directories(${PROJECT_SOURCE_DIR})
 
 include_directories(${ROOT_INCLUDE_DIRS})
 
+include_directories(${OPENCV4_INCLUDE_DIRS})
+
 include_directories(${Qt5Core_INCLUDE_DIRS})
 include_directories(${Qt5Widgts_INCLUDE_DIRS})
 include_directories(${Qt5Script_INCLUDE_DIRS})

--- a/defo/defoCommon/CMakeLists.txt
+++ b/defo/defoCommon/CMakeLists.txt
@@ -49,6 +49,8 @@ set(CMAKE_AUTOMOC ON)
 
 include_directories(${PROJECT_SOURCE_DIR})
 
+include_directories(${OPENCV4_INCLUDE_DIRS})
+
 include_directories(${Qt5Core_INCLUDE_DIRS})
 include_directories(${Qt5Widgts_INCLUDE_DIRS})
 include_directories(${Qt5Script_INCLUDE_DIRS})

--- a/devices/Canon/CMakeLists.txt
+++ b/devices/Canon/CMakeLists.txt
@@ -14,7 +14,8 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -std=c++11")
 set_target_properties(TkModLabCanon PROPERTIES VERSION ${PROJECT_VERSION})
 set_target_properties(TkModLabCanon PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/devices/lib)
 
-target_link_libraries(TkModLabCanon PkgConfig::LIBGPHOTO2 PkgConfig::OPENCV4 PkgConfig::EXIV2)
+target_include_directories(TkModLabCanon PRIVATE ${OPENCV4_INCLUDE_DIRS})
+target_link_libraries(TkModLabCanon PkgConfig::LIBGPHOTO2 PkgConfig::EXIV2 ${OPENCV4_LIBRARIES})
 target_compile_features(TkModLabCanon PRIVATE cxx_std_11)
 
 #add_executable(TkModLabAgilent_test test.cc)

--- a/devices/Canon/CMakeLists.txt
+++ b/devices/Canon/CMakeLists.txt
@@ -14,7 +14,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -std=c++11")
 set_target_properties(TkModLabCanon PROPERTIES VERSION ${PROJECT_VERSION})
 set_target_properties(TkModLabCanon PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/devices/lib)
 
-target_include_directories(TkModLabCanon PRIVATE ${OPENCV4_INCLUDE_DIRS})
+target_include_directories(TkModLabCanon SYSTEM PRIVATE ${OPENCV4_INCLUDE_DIRS})
 target_link_libraries(TkModLabCanon PkgConfig::LIBGPHOTO2 PkgConfig::EXIV2 ${OPENCV4_LIBRARIES})
 target_compile_features(TkModLabCanon PRIVATE cxx_std_11)
 

--- a/devices/Canon/test/CMakeLists.txt
+++ b/devices/Canon/test/CMakeLists.txt
@@ -1,4 +1,4 @@
 add_executable(TkModLabCanon_test test2.cc)
-target_link_libraries(TkModLabCanon_test LINK_PUBLIC TkModLabCanon PkgConfig::LIBGPHOTO2 PkgConfig::OPENCV4 PkgConfig::EXIV2)
+target_link_libraries(TkModLabCanon_test LINK_PUBLIC TkModLabCanon PkgConfig::LIBGPHOTO2 PkgConfig::EXIV2 ${OPENCV4_LIBRARIES})
 set_target_properties(TkModLabCanon_test PROPERTIES OUTPUT_NAME test)
 


### PR DESCRIPTION
For me this solves the issue with CMake & OpenCV4

`PkgConfig::OPENCV4` seems to load opencv from scratch but with strict requirements on the paths. We can simply use the ones identified in the main `CMakeLists`.