### PR TITLE
Add Metrology

### DIFF
--- a/assembly/assembly/AssemblyMainWindow.cc
+++ b/assembly/assembly/AssemblyMainWindow.cc
@@ -881,7 +881,7 @@ void AssemblyMainWindow::start_metrology(const Metrology::Configuration& conf)
   connect(metrology_, SIGNAL(measured_angle(bool, double)), metrology_view_, SLOT(show_measured_angle(bool, double)));
 
   // show measured Results
-  connect(metrology_, SIGNAL(measured_results(double, double, double, double, double, double)), metrology_view_, SLOT(show_results(double, double, double, double, double, double)));
+  connect(metrology_, SIGNAL(measured_results(double, double, double, double, double, double, double)), metrology_view_, SLOT(show_results(double, double, double, double, double, double, double)));
 
   // once completed, disable connections between controllers used for alignment
   connect(metrology_, SIGNAL(execution_completed()), this, SLOT(disconnect_metrology()));

--- a/assembly/assembly/AssemblyMainWindow.cc
+++ b/assembly/assembly/AssemblyMainWindow.cc
@@ -303,6 +303,10 @@ AssemblyMainWindow::AssemblyMainWindow(const QString& outputdir_path, const QStr
 
     connect(metrology_view_, SIGNAL(configuration(Metrology::Configuration)), this, SLOT(start_metrology(Metrology::Configuration)));
 
+    connect(metrology_view_, SIGNAL(go_to_marker_signal()), metrology_, SLOT(move_to_start()));
+    connect(metrology_view_, SIGNAL(enable_vacuum_baseplate(int)), relayCardManager_, SLOT(enableVacuum(int)));
+    connect(relayCardManager_, SIGNAL(vacuumChannelState(int, bool)), metrology_view_, SLOT(updateVacuumChannelState(int, bool)));
+
     metrology_view_->PatRecOne_Image()->connectImageProducer(metrology_, SIGNAL(image_PatRecOne(cv::Mat)));
     metrology_view_->PatRecTwo_Image()->connectImageProducer(metrology_, SIGNAL(image_PatRecTwo(cv::Mat)));
     metrology_view_->PatRecThree_Image()->connectImageProducer(metrology_, SIGNAL(image_PatRecThree(cv::Mat)));

--- a/assembly/assembly/AssemblyMainWindow.cc
+++ b/assembly/assembly/AssemblyMainWindow.cc
@@ -881,7 +881,7 @@ void AssemblyMainWindow::start_metrology(const Metrology::Configuration& conf)
   connect(metrology_, SIGNAL(measured_angle(bool, double)), metrology_view_, SLOT(show_measured_angle(bool, double)));
 
   // show measured Results
-  connect(metrology_, SIGNAL(measured_results(double, double, double)), metrology_view_, SLOT(show_results(double, double, double)));
+  connect(metrology_, SIGNAL(measured_results(double, double, double, double, double, double)), metrology_view_, SLOT(show_results(double, double, double, double, double, double)));
 
   // once completed, disable connections between controllers used for alignment
   connect(metrology_, SIGNAL(execution_completed()), this, SLOT(disconnect_metrology()));

--- a/assembly/assembly/AssemblyMainWindow.cc
+++ b/assembly/assembly/AssemblyMainWindow.cc
@@ -311,6 +311,7 @@ AssemblyMainWindow::AssemblyMainWindow(const QString& outputdir_path, const QStr
     connect(metrology_view_->button_metrologyEmergencyStop(), SIGNAL(clicked()), this, SLOT(disconnect_Metrology()));
     connect(metrology_view_->button_metrologyEmergencyStop(), SIGNAL(clicked()), motion_manager_, SLOT(emergency_stop()));
     connect(metrology_view_->button_metrologyEmergencyStop(), SIGNAL(clicked()), zfocus_finder_ , SLOT(emergencyStop()));
+    connect(metrology_view_->button_metrologyClearResults(), SIGNAL(clicked()), metrology_, SLOT(clear_results()));
 
     NQLog("AssemblyMainWindow", NQLog::Message) << "added view " << tabname_Metrology;
     // ---------------------------------------------------------

--- a/assembly/assembly/AssemblyMainWindow.cc
+++ b/assembly/assembly/AssemblyMainWindow.cc
@@ -305,6 +305,8 @@ AssemblyMainWindow::AssemblyMainWindow(const QString& outputdir_path, const QStr
 
     metrology_view_->PatRecOne_Image()->connectImageProducer(metrology_, SIGNAL(image_PatRecOne(cv::Mat)));
     metrology_view_->PatRecTwo_Image()->connectImageProducer(metrology_, SIGNAL(image_PatRecTwo(cv::Mat)));
+    metrology_view_->PatRecThree_Image()->connectImageProducer(metrology_, SIGNAL(image_PatRecThree(cv::Mat)));
+    metrology_view_->PatRecFour_Image()->connectImageProducer(metrology_, SIGNAL(image_PatRecFour(cv::Mat)));
 
     connect(metrology_view_->button_metrologyEmergencyStop(), SIGNAL(clicked()), this, SLOT(disconnect_Metrology()));
     connect(metrology_view_->button_metrologyEmergencyStop(), SIGNAL(clicked()), motion_manager_, SLOT(emergency_stop()));

--- a/assembly/assembly/AssemblyMainWindow.cc
+++ b/assembly/assembly/AssemblyMainWindow.cc
@@ -939,7 +939,7 @@ void AssemblyMainWindow::disconnect_metrology()
   disconnect(metrology_, SIGNAL(measured_angle(bool, double)), metrology_view_, SLOT(show_measured_angle(bool, double)));
 
   // show measured Results
-  disconnect(metrology_, SIGNAL(measured_results(double, double, double)), metrology_view_, SLOT(show_results(double, double, double)));
+  disconnect(metrology_, SIGNAL(measured_results(double, double, double, double, double, double, double)), metrology_view_, SLOT(show_results(double, double, double, double, double, double, double)));
 
   // once completed, disable connections between controllers used for alignment
   disconnect(metrology_, SIGNAL(execution_completed(double, double, double)), this, SLOT(disconnect_metrology()));

--- a/assembly/assembly/AssemblyMainWindow.cc
+++ b/assembly/assembly/AssemblyMainWindow.cc
@@ -924,7 +924,7 @@ void AssemblyMainWindow::disconnect_metrology()
   disconnect(metrology_, SIGNAL(autofocused_image_request()), image_ctr_, SLOT(acquire_autofocused_image()));
 
   // master-image updated, go to next step (PatRec)
-  disconnect(finder_, SIGNAL(updated_image_master()), metrology_, SLOT(launch_next_alignment_step()));
+  disconnect(finder_, SIGNAL(updated_image_master()), metrology_, SLOT(launch_next_metrology_step()));
 
   // launch PatRec
   disconnect(metrology_, SIGNAL(PatRec_request(AssemblyObjectFinderPatRec::Configuration)), finder_, SLOT(launch_PatRec(AssemblyObjectFinderPatRec::Configuration)));
@@ -933,7 +933,7 @@ void AssemblyMainWindow::disconnect_metrology()
   disconnect(finder_, SIGNAL(PatRec_res_image_master_edited(cv::Mat)), metrology_, SLOT(redirect_image(cv::Mat)));
 
   // use PatRec results for next alignment step
-  disconnect(finder_, SIGNAL(PatRec_results(double, double, double)), metrology_, SLOT(run_alignment(double, double, double)));
+  disconnect(finder_, SIGNAL(PatRec_results(double, double, double)), metrology_, SLOT(run_metrology(double, double, double)));
 
   // show measured angle
   disconnect(metrology_, SIGNAL(measured_angle(bool, double)), metrology_view_, SLOT(show_measured_angle(bool, double)));
@@ -942,7 +942,7 @@ void AssemblyMainWindow::disconnect_metrology()
   disconnect(metrology_, SIGNAL(measured_results(double, double, double, double, double, double, double)), metrology_view_, SLOT(show_results(double, double, double, double, double, double, double)));
 
   // once completed, disable connections between controllers used for alignment
-  disconnect(metrology_, SIGNAL(execution_completed(double, double, double)), this, SLOT(disconnect_metrology()));
+  disconnect(metrology_, SIGNAL(execution_completed()), this, SLOT(disconnect_metrology()));
 
   // kick-start alignment
   disconnect(metrology_, SIGNAL(configuration_updated()), metrology_, SLOT(execute()));

--- a/assembly/assembly/AssemblyMainWindow.h
+++ b/assembly/assembly/AssemblyMainWindow.h
@@ -61,6 +61,9 @@ typedef AssemblyUEyeModel AssemblyUEyeModel_t;
 #include <AssemblyDBLoggerModel.h>
 #include <AssemblyDBLoggerController.h>
 #include <AssemblyDBLoggerView.h>
+#include <Metrology.h>
+#include <MetrologyView.h>
+
 
 #include <QMainWindow>
 #include <QString>
@@ -97,6 +100,9 @@ class AssemblyMainWindow : public QMainWindow
   void start_objectAligner(const AssemblyObjectAligner::Configuration&);
   void disconnect_objectAligner();
 
+  void start_metrology(const Metrology::Configuration&);
+  void disconnect_metrology();
+
   void start_multiPickupTest(const AssemblyMultiPickupTester::Configuration&);
   void disconnect_multiPickupTest();
 
@@ -129,6 +135,9 @@ class AssemblyMainWindow : public QMainWindow
 
   void objectAligner_connected();
   void objectAligner_disconnected();
+
+  void metrology_connected();
+  void metrology_disconnected();
 
   void multiPickupTest_disconnected();
 
@@ -169,6 +178,7 @@ class AssemblyMainWindow : public QMainWindow
   AssemblyZFocusFinder*       zfocus_finder_;
   AssemblyThresholder*        thresholder_;
   AssemblyObjectAligner*      aligner_;
+  Metrology*                  metrology_;
   AssemblyAssembly*           assembly_;
   AssemblyAssemblyV2*         assemblyV2_;
   AssemblyMultiPickupTester*  multipickup_tester_;
@@ -192,6 +202,7 @@ class AssemblyMainWindow : public QMainWindow
   AssemblyObjectFinderPatRecView* finder_view_;
   AssemblyObjectAlignerView* aligner_view_;
   AssemblyAssemblyView* assembly_view_;
+  MetrologyView* metrology_view_;
   AssemblyAssemblyV2View* assemblyV2_view_;
   AssemblyToolboxView* toolbox_view_;
   AssemblyParametersView* params_view_;
@@ -208,6 +219,7 @@ class AssemblyMainWindow : public QMainWindow
   // flags
   bool images_enabled_;
   bool aligner_connected_;
+  bool metrology_connected_;
 
   // timing
   double testTimerCount_;

--- a/assembly/assemblyCommon/AssemblyUEyeView.cc
+++ b/assembly/assemblyCommon/AssemblyUEyeView.cc
@@ -54,6 +54,14 @@ void AssemblyUEyeView::setImage(const cv::Mat& newImage)
     update();
 }
 
+void AssemblyUEyeView::resetImage()
+{
+    QMutexLocker lock(&mutex_);
+    image_ = QImage();
+    lock.unlock();
+    update();
+}
+
 void AssemblyUEyeView::paintEvent(QPaintEvent*)
 {
     if(image_.isNull() == false)

--- a/assembly/assemblyCommon/AssemblyUEyeView.h
+++ b/assembly/assemblyCommon/AssemblyUEyeView.h
@@ -47,6 +47,7 @@ class AssemblyUEyeView : public QLabel
  public slots:
 
   void setImage(const cv::Mat&);
+  void resetImage();
 };
 
 #endif // ASSEMBLYUEYEVIEW_H

--- a/assembly/assemblyCommon/CMakeLists.txt
+++ b/assembly/assemblyCommon/CMakeLists.txt
@@ -38,6 +38,8 @@ add_library(AssemblyCommon SHARED
         AssemblyHardwareControlView.cc
         AssemblyLogFileController.cc
         AssemblyLogFileView.cc
+        MetrologyView.cc
+        Metrology.cc
         RelayCardManager.cc
         LStepExpressModel.cc
         LStepExpressMotion.cc

--- a/assembly/assemblyCommon/Metrology.cc
+++ b/assembly/assemblyCommon/Metrology.cc
@@ -392,6 +392,7 @@ void Metrology::run_metrology(const double patrec_dX, const double patrec_dY, co
     dY += config_->getValue<double>("parameters", "FromPSPRefPointToPSSRefPoint_dY");
     const double dZ = config_->getValue<double>("parameters", "Thickness_GlueLayer") * 2.
                     + config_->getValue<double>("parameters", "Thickness_Spacer")
+                    + config_->getValue<double>("parameters", "Thickness_MPA")
                     + config_->getValue<double>("parameters", "Thickness_PSS");
 
 
@@ -554,8 +555,8 @@ void Metrology::run_metrology(const double patrec_dX, const double patrec_dY, co
 
     emit measured_angle(true, PSs_angle_deg_);
 
-    const double delta_x = (posi_PSs_x1_ - posi_PSs_x1_) - config_->getValue<double>("parameters", "FromPSPRefPointToPSSRefPoint_dX");
-    const double delta_y = (posi_PSs_y1_ - posi_PSs_y1_) - config_->getValue<double>("parameters", "FromPSPRefPointToPSSRefPoint_dY");
+    const double delta_x = (posi_PSs_x1_ - posi_PSp_x1_) - config_->getValue<double>("parameters", "FromPSPRefPointToPSSRefPoint_dX");
+    const double delta_y = (posi_PSs_y1_ - posi_PSp_y1_) - config_->getValue<double>("parameters", "FromPSPRefPointToPSSRefPoint_dY");
     const double delta_a = PSs_angle_deg_ - PSp_angle_deg_;
     emit measured_results(delta_x, delta_y, delta_a);
 

--- a/assembly/assemblyCommon/Metrology.cc
+++ b/assembly/assemblyCommon/Metrology.cc
@@ -576,7 +576,15 @@ void Metrology::run_metrology(const double patrec_dX, const double patrec_dY, co
     const double delta_z = (posi_PSs_z1_ + posi_PSs_z2_)/2. - (posi_PSp_z1_ + posi_PSp_z2_)/2.;
     const double delta_a_deg = PSs_angle_deg_ - PSp_angle_deg_;
     const double delta_a_urad = delta_a_deg * (M_PI/180.0);
+
     emit measured_results(delta_x, delta_x_corr, delta_y, delta_y_corr, delta_z, delta_a_deg, delta_a_urad);
+
+    NQLog("Metrology", NQLog::Message) << "run_metrology: Finished with results:";
+    NQLog("Metrology", NQLog::Message) << "run_metrology: Delta X (raw/corrected) [mm]:        \t" << delta_x << "\t" << delta_x_corr;
+    NQLog("Metrology", NQLog::Message) << "run_metrology: Delta Y (raw/corrected) [mm]:        \t" << delta_y << "\t" << delta_y_corr;
+    NQLog("Metrology", NQLog::Message, 4) << "run_metrology: Delta Z                 [mm]:        \t" << delta_z;
+    NQLog("Metrology", NQLog::Message, 3) << "run_metrology: Angle between PSp & PSs [deg / urad]:\t" << delta_a_deg << "\t" << delta_a_urad;
+
 
     if(this->configuration().complete_at_position1) //If box "Go back to marker-1 position before completion" is ticked, continue routine (go to marker1, take image, terminate)
     {

--- a/assembly/assemblyCommon/Metrology.cc
+++ b/assembly/assemblyCommon/Metrology.cc
@@ -1,0 +1,575 @@
+/////////////////////////////////////////////////////////////////////////////////
+//                                                                             //
+//               Copyright (C) 2011-2023 - The DESY CMS Group                  //
+//                           All rights reserved                               //
+//                                                                             //
+//      The CMStkModLab source code is licensed under the GNU GPL v3.0.        //
+//      You have the right to modify and/or redistribute this source code      //
+//      under the terms specified in the license, which may be found online    //
+//      at http://www.gnu.org/licenses or at License.txt.                      //
+//                                                                             //
+/////////////////////////////////////////////////////////////////////////////////
+
+#include <nqlogger.h>
+#include <ApplicationConfig.h>
+
+#include <Metrology.h>
+#include <AssemblyUtilities.h>
+
+#include <cmath>
+
+Metrology::Metrology(const LStepExpressMotionManager* const motion_manager, QObject* parent)
+ : QObject(parent)
+
+ , motion_manager_(motion_manager)
+ , motion_manager_enabled_(false)
+
+ , config_(nullptr)
+{
+  if(motion_manager_ == nullptr)
+  {
+    NQLog("Metrology", NQLog::Fatal) << "initialization error"
+       << ": null pointer to LStepExpressMotionManager object, exiting constructor";
+
+    assembly::kill_application(tr("[Metrology]"), tr("Null pointer to LStepExpressMotionManager. Aborting Application."));
+  }
+
+  //When launching metrology routine, most params get read by MetrologyView, and copied into this->configuration_.
+  //But other params are not related to the View (not editable in GUI), so must read their values manually here
+  config_ = ApplicationConfig::instance(); //Access config file
+  if(config_ == nullptr)
+  {
+    NQLog("Metrology", NQLog::Fatal)
+       << "ApplicationConfig::instance() not initialized (null pointer), stopped constructor";
+
+    assembly::kill_application(tr("[Metrology]"), tr("ApplicationConfig::instance() not initialized (null pointer), closing application"));
+  }
+
+  max_numOfRotations_ = config_->getDefaultValue<int>("main", "Metrology_maxNumberOfRotations", 10);
+
+  qRegisterMetaType<Metrology::Configuration>("Metrology::Configuration"); //"After a type has been registered, you can create and destroy objects of that type dynamically at run-time"
+
+  configuration_.reset();
+
+  this->reset();
+  this->reset_counter_numOfRotations();
+
+  connect(this, SIGNAL(nextMetrologyStep(double, double, double)), this, SLOT(run_metrology(double, double, double)));
+
+  connect(this, SIGNAL(motion_completed()), this, SLOT(launch_next_metrology_step()));
+
+  NQLog("Metrology", NQLog::Debug) << "constructed";
+}
+
+
+void Metrology::Configuration::reset()
+{
+  complete_at_position1 = true;
+  use_autofocusing = true;
+
+  PatRec_PSP1_configuration.reset();
+  PatRec_PSP2_configuration.reset();
+  PatRec_PSS1_configuration.reset();
+  PatRec_PSS2_configuration.reset();
+
+}
+
+bool Metrology::Configuration::is_valid() const
+{
+
+  if(PatRec_PSP1_configuration.is_valid() == false){ return false; }
+  if(PatRec_PSP2_configuration.is_valid() == false){ return false; }
+  if(PatRec_PSS1_configuration.is_valid() == false){ return false; }
+  if(PatRec_PSS2_configuration.is_valid() == false){ return false; }
+
+  return true;
+}
+
+void Metrology::reset()
+{
+  metrology_step_ = 0;
+
+  posi_PSp_x1_ = 0.;
+  posi_PSp_y1_ = 0.;
+  posi_PSp_x2_ = 0.;
+  posi_PSp_y2_ = 0.;
+  posi_PSs_x1_ = 0.;
+  posi_PSs_y1_ = 0.;
+  posi_PSs_x2_ = 0.;
+  posi_PSs_y2_ = 0.;
+
+  PSp_angle_deg_ = 0.;
+  PSs_angle_deg_ = 0.;
+
+  return;
+}
+
+void Metrology::reset_counter_numOfRotations()
+{
+  counter_numOfRotations_ = 0;
+}
+
+void Metrology::update_configuration(const Metrology::Configuration& conf)
+{
+  if(conf.is_valid() == false)
+  {
+    NQLog("Metrology", NQLog::Critical) << "update_configuration"
+       << ": invalid input Metrology::Configuration object, no action taken";
+
+    return;
+  }
+
+  configuration_ = conf;
+
+  NQLog("Metrology", NQLog::Spam) << "update_configuration"
+     << ": emitting signal \"configuration_updated\"";
+
+  emit configuration_updated();
+}
+
+// FIXME
+void Metrology::redirect_image(const cv::Mat& img)
+{
+  if(metrology_step_ == 2)
+  {
+    NQLog("Metrology", NQLog::Spam) << "redirect_image"
+       << ": emitting signal \"image_PatRecOne\"";
+
+    emit image_PatRecOne(img);
+  }
+  else if(metrology_step_ == 5)
+  {
+    NQLog("Metrology", NQLog::Spam) << "redirect_image"
+       << ": emitting signal \"image_PatRecTwo\"";
+
+    emit image_PatRecTwo(img);
+  }
+
+  return;
+}
+
+void Metrology::enable_motion_manager(const bool arg)
+{
+  if(arg == motion_manager_enabled_)
+  {
+    NQLog("Metrology", NQLog::Debug) << "enable_motion_manager(" << arg << ")"
+       << ": motion-manager for Metrology already " << (arg ? "enabled" : "disabled") << ", no action taken";
+
+    return;
+  }
+
+  if(arg)
+  {
+    connect(this, SIGNAL(move_relative_request(double, double, double, double)), motion_manager_, SLOT(moveRelative(double, double, double, double)));
+    connect(motion_manager_, SIGNAL(motion_finished()), this, SLOT(complete_motion()));
+
+    motion_manager_enabled_ = true;
+
+    NQLog("Metrology", NQLog::Spam) << "enable_motion_manager(" << arg << ")"
+       << ": motion-manager for Metrology enabled";
+  }
+  else
+  {
+    disconnect(this, SIGNAL(move_relative_request(double, double, double, double)), motion_manager_, SLOT(moveRelative(double, double, double, double)));
+    disconnect(motion_manager_, SIGNAL(motion_finished()), this, SLOT(complete_motion()));
+
+    motion_manager_enabled_ = false;
+
+    NQLog("Metrology", NQLog::Spam) << "enable_motion_manager(" << arg << ")"
+       << ": motion-manager for Metrology disabled";
+  }
+
+  return;
+}
+
+void Metrology::move_relative(const double x, const double y, const double z, const double a)
+{
+  this->connect_motion_manager();
+
+  emit move_relative_request(x, y, z, a);
+}
+
+void Metrology::complete_motion()
+{
+  this->disconnect_motion_manager();
+
+  NQLog("Metrology", NQLog::Spam) << "complete_motion"
+     << ": emitting signal \"motion_completed\"";
+
+  emit motion_completed();
+}
+
+void Metrology::launch_next_metrology_step()
+{
+  NQLog("Metrology", NQLog::Spam) << "launch_next_metrology_step"
+     << ": emitting signal \"nextMetrologyStep(0, 0, 0)\"";
+
+  emit nextMetrologyStep(0.0, 0.0, 0.0);
+}
+
+void Metrology::execute()
+{
+  this->reset();
+  this->reset_counter_numOfRotations();
+
+  this->run_metrology(0., 0., 0.);
+}
+
+void Metrology::run_metrology(const double patrec_dX, const double patrec_dY, const double patrec_angle)
+{
+  // Step #0:
+  if(metrology_step_ == 0)
+  {
+      NQLog("Metrology", NQLog::Message) << "\e[1;32m=== Starting metrology\e[0m";
+
+      emit DBLogMessage("=== Starting metrology" );
+
+      NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]";
+
+      if(this->configuration().use_autofocusing)
+      {
+        NQLog("Metrology", NQLog::Spam) << "run_metrology: step [" << metrology_step_ << "]"
+           << ": emitting signal \"autofocused_image_request\"";
+
+        ++metrology_step_;
+
+        emit autofocused_image_request();
+      }
+      else
+      {
+        NQLog("Metrology", NQLog::Spam) << "run_metrology: step [" << metrology_step_ << "]"
+           << ": emitting signal \"image_request\"";
+
+        ++metrology_step_;
+
+        emit image_request();
+      }
+  }
+  // Step #1: PatRec on marker-1 (PSP)
+  else if(metrology_step_ == 1)
+  {
+    NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]";
+
+    NQLog("Metrology", NQLog::Spam) << "run_metrology: step [" << metrology_step_ << "]"
+       << ": emitting signal \"PatRec_request\"";
+
+    ++metrology_step_;
+
+    emit PatRec_request(this->configuration().PatRec_PSP1_configuration);
+  }
+  // Step #2: move to marker-2 (PSP)
+  else if(metrology_step_ == 2)
+  {
+    NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]"
+       << ": determining best-match position of PatRec #1";
+
+    // marker-1: position of PatRec best-match
+    posi_PSp_x1_ = motion_manager_->get_position_X() + patrec_dX;
+    posi_PSp_y1_ = motion_manager_->get_position_Y() + patrec_dY;
+
+    NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]";
+    NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]: motion-stage X = " << motion_manager_->get_position_X();
+    NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]: motion-stage Y = " << motion_manager_->get_position_Y();
+    NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]";
+    NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]: PatRec dX = " << patrec_dX;
+    NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]: PatRec dY = " << patrec_dY;
+    NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]";
+    NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]: x1-position = " << posi_PSp_x1_;
+    NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]: y1-position = " << posi_PSp_y1_;
+    NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]";
+
+    // relative movement to reach the opposite marker
+    const double obj_deltaX = config_->getValue<double>("main", "AssemblyObjectAlignerView_PSP_deltaX");
+    const double obj_deltaY = config_->getValue<double>("main", "AssemblyObjectAlignerView_PSP_deltaY");
+
+    // angle from marker's outer edge to best-match position in the camera ref-frame
+    //   - the 90.0 deg offset corresponds to the angle spanned by the marker (L-shape)
+    const double patrec_angle_full = (patrec_angle + 90.0);
+
+    const double camera_offset_dA = config_->getValue<double>("parameters", "AngleOfCameraFrameInRefFrame_dA");
+
+    double dX_1to2, dY_1to2;
+    assembly::rotation2D_deg(dX_1to2, dY_1to2, (patrec_angle_full + camera_offset_dA), obj_deltaX, obj_deltaY);
+
+    // combined relative movement
+    const double dX = patrec_dX + dX_1to2;
+    const double dY = patrec_dY + dY_1to2;
+
+    NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]"
+       << ": moving to position for PatRec #2";
+
+    NQLog("Metrology", NQLog::Spam) << "run_metrology: step [" << metrology_step_ << "]"
+       << ": emitting signal \"move_relative(" << dX << ", " << dY << ", 0, 0)\"";
+
+    ++metrology_step_;
+
+    this->move_relative(dX, dY, 0.0, 0.0);
+  }
+  // Step #3: request image on marker-2 (PSP)
+  else if(metrology_step_ == 3)
+  {
+    NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]"
+       << ": acquiring image for PatRec #2";
+
+    if(this->configuration().use_autofocusing)
+    {
+      NQLog("Metrology", NQLog::Spam) << "run_metrology: step [" << metrology_step_ << "]"
+         << ": emitting signal \"autofocused_image_request\"";
+
+      ++metrology_step_;
+
+      emit autofocused_image_request();
+    }
+    else
+    {
+      NQLog("Metrology", NQLog::Spam) << "run_metrology: step [" << metrology_step_ << "]"
+         << ": emitting signal \"image_request\"";
+
+      ++metrology_step_;
+
+      emit image_request();
+    }
+  }
+  // Step #4: PatRec on marker-2 (PSP)
+  else if(metrology_step_ == 4)
+  {
+    NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]";
+
+    NQLog("Metrology", NQLog::Spam) << "run_metrology: step [" << metrology_step_ << "]"
+       << ": emitting signal \"PatRec_request\"";
+
+    ++metrology_step_;
+
+    emit PatRec_request(this->configuration().PatRec_PSP2_configuration);
+  }
+  // Step #5: calculate angle and move to marker-1 (PSS)
+  else if(metrology_step_ == 5)
+  {
+    posi_PSp_x2_ = motion_manager_->get_position_X() + patrec_dX;
+    posi_PSp_y2_ = motion_manager_->get_position_Y() + patrec_dY;
+
+    NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]";
+    NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]: position(X1) = " << posi_PSp_x1_;
+    NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]: position(Y1) = " << posi_PSp_y1_;
+    NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]";
+    NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]: position(X2) = " << posi_PSp_x2_;
+    NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]: position(Y2) = " << posi_PSp_y2_;
+
+    // measurement of object orientation
+    if(posi_PSp_x2_ == posi_PSp_x1_)
+    {
+      PSp_angle_deg_ = (posi_PSp_y2_ == posi_PSp_y1_) ? 0. : ((posi_PSp_y2_ > posi_PSp_y1_) ? 90. : -90.);
+    }
+    else
+    {
+      const double obj_slope = ((posi_PSp_y2_ - posi_PSp_y1_)/(posi_PSp_x2_ - posi_PSp_x1_));
+
+      PSp_angle_deg_ = atan(obj_slope) * (180.0/M_PI);
+    }
+
+    emit measured_angle(false, PSp_angle_deg_);
+
+    // relative (X,Y) movement to reach the opposite PSp marker (marker-1) ...
+    double dX = (posi_PSp_x1_ - motion_manager_->get_position_X());
+    double dY = (posi_PSp_y1_ - motion_manager_->get_position_Y());
+
+    // ... and then from PSP to PSS
+    dX += config_->getValue<double>("parameters", "FromPSPRefPointToPSSRefPoint_dX");
+    dY += config_->getValue<double>("parameters", "FromPSPRefPointToPSSRefPoint_dY");
+    const double dZ = config_->getValue<double>("parameters", "Thickness_GlueLayer") * 2.
+                    + config_->getValue<double>("parameters", "Thickness_Spacer")
+                    + config_->getValue<double>("parameters", "Thickness_PSS");
+
+
+    NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]"
+       << ": moving to position for PatRec #3";
+
+    NQLog("Metrology", NQLog::Spam) << "run_metrology: step [" << metrology_step_ << "]"
+       << ": emitting signal \"move_relative(" << dX << ", " << dY << ", 0, 0)\"";
+
+    ++metrology_step_;
+
+    this->move_relative(dX, dY, dZ, 0.0);
+  }
+  // Step #6: request image
+  else if(metrology_step_ == 6)
+  {
+    NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]"
+       << ": acquiring image for PatRec #3";
+
+    if(this->configuration().use_autofocusing)
+    {
+      NQLog("Metrology", NQLog::Spam) << "run_metrology: step [" << metrology_step_ << "]"
+         << ": emitting signal \"autofocused_image_request\"";
+
+      ++metrology_step_;
+
+      emit autofocused_image_request();
+    }
+    else
+    {
+      NQLog("Metrology", NQLog::Spam) << "run_metrology: step [" << metrology_step_ << "]"
+         << ": emitting signal \"image_request\"";
+
+      ++metrology_step_;
+
+      emit image_request();
+    }
+  }
+  // Step #7: PatRec on marker-1 (PSS)
+  else if(metrology_step_ == 7)
+  {
+    NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]";
+
+    NQLog("Metrology", NQLog::Spam) << "run_metrology: step [" << metrology_step_ << "]"
+       << ": emitting signal \"PatRec_request\"";
+
+    ++metrology_step_;
+
+    emit PatRec_request(this->configuration().PatRec_PSS1_configuration);
+  }
+  // Step #8: move to marker-2 (PSS)
+  else if(metrology_step_ == 8)
+  {
+    NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]"
+       << ": determining best-match position of PatRec #4";
+
+    // marker-1: position of PatRec best-match
+    posi_PSs_x1_ = motion_manager_->get_position_X() + patrec_dX;
+    posi_PSs_y1_ = motion_manager_->get_position_Y() + patrec_dY;
+
+    NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]";
+    NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]: motion-stage X = " << motion_manager_->get_position_X();
+    NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]: motion-stage Y = " << motion_manager_->get_position_Y();
+    NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]";
+    NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]: PatRec dX = " << patrec_dX;
+    NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]: PatRec dY = " << patrec_dY;
+    NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]";
+    NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]: x1-position = " << posi_PSs_x1_;
+    NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]: y1-position = " << posi_PSs_y1_;
+    NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]";
+
+    // relative movement to reach the opposite marker
+    const double obj_deltaX = config_->getValue<double>("main", "AssemblyObjectAlignerView_PSS_deltaX");
+    const double obj_deltaY = config_->getValue<double>("main", "AssemblyObjectAlignerView_PSS_deltaY");
+
+    // angle from marker's outer edge to best-match position in the camera ref-frame
+    //   - the 90.0 deg offset corresponds to the angle spanned by the marker (L-shape)
+    const double patrec_angle_full = (patrec_angle + 90.0);
+
+    const double camera_offset_dA = config_->getValue<double>("parameters", "AngleOfCameraFrameInRefFrame_dA");
+
+    double dX_1to2, dY_1to2;
+    assembly::rotation2D_deg(dX_1to2, dY_1to2, (patrec_angle_full + camera_offset_dA), obj_deltaX, obj_deltaY);
+
+    // combined relative movement
+    const double dX = patrec_dX + dX_1to2;
+    const double dY = patrec_dY + dY_1to2;
+
+    NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]"
+       << ": moving to position for PatRec #4";
+
+    NQLog("Metrology", NQLog::Spam) << "run_metrology: step [" << metrology_step_ << "]"
+       << ": emitting signal \"move_relative(" << dX << ", " << dY << ", 0, 0)\"";
+
+    ++metrology_step_;
+
+    this->move_relative(dX, dY, 0.0, 0.0);
+  }
+  // Step #9: request image on marker-2 (PSS)
+  else if(metrology_step_ == 9)
+  {
+    NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]"
+       << ": acquiring image for PatRec #4";
+
+    if(this->configuration().use_autofocusing)
+    {
+      NQLog("Metrology", NQLog::Spam) << "run_metrology: step [" << metrology_step_ << "]"
+         << ": emitting signal \"autofocused_image_request\"";
+
+      ++metrology_step_;
+
+      emit autofocused_image_request();
+    }
+    else
+    {
+      NQLog("Metrology", NQLog::Spam) << "run_metrology: step [" << metrology_step_ << "]"
+         << ": emitting signal \"image_request\"";
+
+      ++metrology_step_;
+
+      emit image_request();
+    }
+  }
+  // Step #10: PatRec on marker-2 (PSS)
+  else if(metrology_step_ == 10)
+  {
+    NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]";
+
+    NQLog("Metrology", NQLog::Spam) << "run_metrology: step [" << metrology_step_ << "]"
+       << ": emitting signal \"PatRec_request\"";
+
+    ++metrology_step_;
+
+    emit PatRec_request(this->configuration().PatRec_PSS2_configuration);
+  }
+  // Step #11: calculate angle and move to marker-1 (PSS)
+  else if(metrology_step_ == 11)
+  {
+    posi_PSs_x2_ = motion_manager_->get_position_X() + patrec_dX;
+    posi_PSs_y2_ = motion_manager_->get_position_Y() + patrec_dY;
+
+    NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]";
+    NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]: position(X1) = " << posi_PSs_x1_;
+    NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]: position(Y1) = " << posi_PSs_y1_;
+    NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]";
+    NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]: position(X2) = " << posi_PSs_x2_;
+    NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]: position(Y2) = " << posi_PSs_y2_;
+
+    // measurement of object orientation
+    if(posi_PSs_x2_ == posi_PSs_x1_)
+    {
+      PSs_angle_deg_ = (posi_PSs_y2_ == posi_PSs_y1_) ? 0. : ((posi_PSs_y2_ > posi_PSs_y1_) ? 90. : -90.);
+    }
+    else
+    {
+      const double obj_slope = ((posi_PSs_y2_ - posi_PSs_y1_)/(posi_PSs_x2_ - posi_PSs_x1_));
+
+      PSs_angle_deg_ = atan(obj_slope) * (180.0/M_PI);
+    }
+
+    emit measured_angle(true, PSs_angle_deg_);
+
+    const double delta_x = (posi_PSs_x1_ - posi_PSs_x1_) - config_->getValue<double>("parameters", "FromPSPRefPointToPSSRefPoint_dX");
+    const double delta_y = (posi_PSs_y1_ - posi_PSs_y1_) - config_->getValue<double>("parameters", "FromPSPRefPointToPSSRefPoint_dY");
+    const double delta_a = PSs_angle_deg_ - PSp_angle_deg_;
+    emit measured_results(delta_x, delta_y, delta_a);
+
+    if(this->configuration().complete_at_position1) //If box "Go back to marker-1 position before completion" is ticked, continue routine (go to marker1, take image, terminate)
+    {
+      NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]: metrology completed, moving back to best-match position of PatRec #1";
+      NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]";
+
+      ++metrology_step_;
+
+      const double dX = (posi_PSp_x1_ - motion_manager_->get_position_X());
+      const double dY = (posi_PSp_y1_ - motion_manager_->get_position_Y());
+      const double dZ = (config_->getValue<double>("parameters", "RefPointSensor_Z") - motion_manager_->get_position_Z());
+
+      NQLog("Metrology", NQLog::Spam) << "run_metrology: step [" << metrology_step_ << "]"
+      << ": emitting signal \"move_relative(" << dX << ", " << dY << ", 0, 0)\"";
+
+      this->move_relative(dX, dY, dZ, 0.0);
+    }
+    this->reset();
+
+    QMessageBox* msgBox = new QMessageBox;
+    msgBox->setInformativeText("Metrology routine completed successfully!\nSee the results in the Metrology tab.");
+
+    msgBox->setStandardButtons(QMessageBox::Ok);
+
+    int ret = msgBox->exec();
+
+    emit execution_completed();
+  }
+}

--- a/assembly/assemblyCommon/Metrology.cc
+++ b/assembly/assemblyCommon/Metrology.cc
@@ -89,21 +89,7 @@ void Metrology::reset()
 {
   metrology_step_ = 0;
 
-  posi_PSp_x1_ = 0.;
-  posi_PSp_y1_ = 0.;
-  posi_PSp_z1_ = 0.;
-  posi_PSp_x2_ = 0.;
-  posi_PSp_y2_ = 0.;
-  posi_PSp_z2_ = 0.;
-  posi_PSs_x1_ = 0.;
-  posi_PSs_y1_ = 0.;
-  posi_PSs_z1_ = 0.;
-  posi_PSs_x2_ = 0.;
-  posi_PSs_y2_ = 0.;
-  posi_PSs_z2_ = 0.;
-
-  PSp_angle_deg_ = 0.;
-  PSs_angle_deg_ = 0.;
+  clear_results();
 
   return;
 }
@@ -613,4 +599,23 @@ void Metrology::run_metrology(const double patrec_dX, const double patrec_dY, co
 
     emit execution_completed();
   }
+}
+
+void Metrology::clear_results()
+{
+    posi_PSp_x1_ = 0.;
+    posi_PSp_y1_ = 0.;
+    posi_PSp_z1_ = 0.;
+    posi_PSp_x2_ = 0.;
+    posi_PSp_y2_ = 0.;
+    posi_PSp_z2_ = 0.;
+    posi_PSs_x1_ = 0.;
+    posi_PSs_y1_ = 0.;
+    posi_PSs_z1_ = 0.;
+    posi_PSs_x2_ = 0.;
+    posi_PSs_y2_ = 0.;
+    posi_PSs_z2_ = 0.;
+
+    PSp_angle_deg_ = 0.;
+    PSs_angle_deg_ = 0.;
 }

--- a/assembly/assemblyCommon/Metrology.cc
+++ b/assembly/assemblyCommon/Metrology.cc
@@ -144,6 +144,20 @@ void Metrology::redirect_image(const cv::Mat& img)
 
     emit image_PatRecTwo(img);
   }
+  else if(metrology_step_ == 8)
+  {
+    NQLog("Metrology", NQLog::Spam) << "redirect_image"
+       << ": emitting signal \"image_PatRecThree\"";
+
+    emit image_PatRecThree(img);
+  }
+  else if(metrology_step_ == 11)
+  {
+    NQLog("Metrology", NQLog::Spam) << "redirect_image"
+       << ": emitting signal \"image_PatRecFour\"";
+
+    emit image_PatRecFour(img);
+  }
 
   return;
 }

--- a/assembly/assemblyCommon/Metrology.cc
+++ b/assembly/assemblyCommon/Metrology.cc
@@ -555,10 +555,13 @@ void Metrology::run_metrology(const double patrec_dX, const double patrec_dY, co
 
     emit measured_angle(true, PSs_angle_deg_);
 
-    const double delta_x = (posi_PSs_x1_ - posi_PSp_x1_) - config_->getValue<double>("parameters", "FromPSPRefPointToPSSRefPoint_dX");
-    const double delta_y = (posi_PSs_y1_ - posi_PSp_y1_) - config_->getValue<double>("parameters", "FromPSPRefPointToPSSRefPoint_dY");
-    const double delta_a = PSs_angle_deg_ - PSp_angle_deg_;
-    emit measured_results(delta_x, delta_y, delta_a);
+    const double delta_x = (posi_PSs_x1_ - posi_PSp_x1_);
+    const double delta_x_corr = delta_x - config_->getValue<double>("parameters", "FromPSPRefPointToPSSRefPoint_dX");
+    const double delta_y = (posi_PSs_y1_ - posi_PSp_y1_);
+    const double delta_y_corr = delta_y - config_->getValue<double>("parameters", "FromPSPRefPointToPSSRefPoint_dY");
+    const double delta_a_deg = PSs_angle_deg_ - PSp_angle_deg_;
+    const double delta_a_urad = delta_a_deg * (M_PI/180.0);
+    emit measured_results(delta_x, delta_x_corr, delta_y, delta_y_corr, delta_a_deg, delta_a_urad);
 
     if(this->configuration().complete_at_position1) //If box "Go back to marker-1 position before completion" is ticked, continue routine (go to marker1, take image, terminate)
     {

--- a/assembly/assemblyCommon/Metrology.cc
+++ b/assembly/assemblyCommon/Metrology.cc
@@ -91,12 +91,16 @@ void Metrology::reset()
 
   posi_PSp_x1_ = 0.;
   posi_PSp_y1_ = 0.;
+  posi_PSp_z1_ = 0.;
   posi_PSp_x2_ = 0.;
   posi_PSp_y2_ = 0.;
+  posi_PSp_z2_ = 0.;
   posi_PSs_x1_ = 0.;
   posi_PSs_y1_ = 0.;
+  posi_PSs_z1_ = 0.;
   posi_PSs_x2_ = 0.;
   posi_PSs_y2_ = 0.;
+  posi_PSs_z2_ = 0.;
 
   PSp_angle_deg_ = 0.;
   PSs_angle_deg_ = 0.;
@@ -280,6 +284,7 @@ void Metrology::run_metrology(const double patrec_dX, const double patrec_dY, co
     // marker-1: position of PatRec best-match
     posi_PSp_x1_ = motion_manager_->get_position_X() + patrec_dX;
     posi_PSp_y1_ = motion_manager_->get_position_Y() + patrec_dY;
+    posi_PSp_z1_ = motion_manager_->get_position_Z();
 
     NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]";
     NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]: motion-stage X = " << motion_manager_->get_position_X();
@@ -290,6 +295,7 @@ void Metrology::run_metrology(const double patrec_dX, const double patrec_dY, co
     NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]";
     NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]: x1-position = " << posi_PSp_x1_;
     NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]: y1-position = " << posi_PSp_y1_;
+    NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]: z1-position = " << posi_PSp_z1_;
     NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]";
 
     // relative movement to reach the opposite marker
@@ -361,13 +367,16 @@ void Metrology::run_metrology(const double patrec_dX, const double patrec_dY, co
   {
     posi_PSp_x2_ = motion_manager_->get_position_X() + patrec_dX;
     posi_PSp_y2_ = motion_manager_->get_position_Y() + patrec_dY;
+    posi_PSp_z2_ = motion_manager_->get_position_Z();
 
     NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]";
     NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]: position(X1) = " << posi_PSp_x1_;
     NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]: position(Y1) = " << posi_PSp_y1_;
+    NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]: position(Z1) = " << posi_PSp_z1_;
     NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]";
     NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]: position(X2) = " << posi_PSp_x2_;
     NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]: position(Y2) = " << posi_PSp_y2_;
+    NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]: position(Z2) = " << posi_PSp_z2_;
 
     // measurement of object orientation
     if(posi_PSp_x2_ == posi_PSp_x1_)
@@ -452,6 +461,7 @@ void Metrology::run_metrology(const double patrec_dX, const double patrec_dY, co
     // marker-1: position of PatRec best-match
     posi_PSs_x1_ = motion_manager_->get_position_X() + patrec_dX;
     posi_PSs_y1_ = motion_manager_->get_position_Y() + patrec_dY;
+    posi_PSs_z1_ = motion_manager_->get_position_Z();
 
     NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]";
     NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]: motion-stage X = " << motion_manager_->get_position_X();
@@ -462,6 +472,7 @@ void Metrology::run_metrology(const double patrec_dX, const double patrec_dY, co
     NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]";
     NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]: x1-position = " << posi_PSs_x1_;
     NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]: y1-position = " << posi_PSs_y1_;
+    NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]: z1-position = " << posi_PSs_z1_;
     NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]";
 
     // relative movement to reach the opposite marker
@@ -533,13 +544,16 @@ void Metrology::run_metrology(const double patrec_dX, const double patrec_dY, co
   {
     posi_PSs_x2_ = motion_manager_->get_position_X() + patrec_dX;
     posi_PSs_y2_ = motion_manager_->get_position_Y() + patrec_dY;
+    posi_PSs_z2_ = motion_manager_->get_position_Z();
 
     NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]";
     NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]: position(X1) = " << posi_PSs_x1_;
     NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]: position(Y1) = " << posi_PSs_y1_;
+    NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]: position(Z1) = " << posi_PSs_z1_;
     NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]";
     NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]: position(X2) = " << posi_PSs_x2_;
     NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]: position(Y2) = " << posi_PSs_y2_;
+    NQLog("Metrology", NQLog::Message) << "run_metrology: step [" << metrology_step_ << "]: position(Z2) = " << posi_PSs_z2_;
 
     // measurement of object orientation
     if(posi_PSs_x2_ == posi_PSs_x1_)
@@ -559,9 +573,10 @@ void Metrology::run_metrology(const double patrec_dX, const double patrec_dY, co
     const double delta_x_corr = delta_x - config_->getValue<double>("parameters", "FromPSPRefPointToPSSRefPoint_dX");
     const double delta_y = (posi_PSs_y1_ - posi_PSp_y1_);
     const double delta_y_corr = delta_y - config_->getValue<double>("parameters", "FromPSPRefPointToPSSRefPoint_dY");
+    const double delta_z = (posi_PSs_z1_ + posi_PSs_z2_)/2. - (posi_PSp_z1_ + posi_PSp_z2_)/2.;
     const double delta_a_deg = PSs_angle_deg_ - PSp_angle_deg_;
     const double delta_a_urad = delta_a_deg * (M_PI/180.0);
-    emit measured_results(delta_x, delta_x_corr, delta_y, delta_y_corr, delta_a_deg, delta_a_urad);
+    emit measured_results(delta_x, delta_x_corr, delta_y, delta_y_corr, delta_z, delta_a_deg, delta_a_urad);
 
     if(this->configuration().complete_at_position1) //If box "Go back to marker-1 position before completion" is ticked, continue routine (go to marker1, take image, terminate)
     {

--- a/assembly/assemblyCommon/Metrology.cc
+++ b/assembly/assemblyCommon/Metrology.cc
@@ -45,14 +45,11 @@ Metrology::Metrology(const LStepExpressMotionManager* const motion_manager, QObj
     assembly::kill_application(tr("[Metrology]"), tr("ApplicationConfig::instance() not initialized (null pointer), closing application"));
   }
 
-  max_numOfRotations_ = config_->getDefaultValue<int>("main", "Metrology_maxNumberOfRotations", 10);
-
   qRegisterMetaType<Metrology::Configuration>("Metrology::Configuration"); //"After a type has been registered, you can create and destroy objects of that type dynamically at run-time"
 
   configuration_.reset();
 
   this->reset();
-  this->reset_counter_numOfRotations();
 
   connect(this, SIGNAL(nextMetrologyStep(double, double, double)), this, SLOT(run_metrology(double, double, double)));
 
@@ -92,11 +89,6 @@ void Metrology::reset()
   clear_results();
 
   return;
-}
-
-void Metrology::reset_counter_numOfRotations()
-{
-  counter_numOfRotations_ = 0;
 }
 
 void Metrology::update_configuration(const Metrology::Configuration& conf)
@@ -214,8 +206,6 @@ void Metrology::launch_next_metrology_step()
 void Metrology::execute()
 {
   this->reset();
-  this->reset_counter_numOfRotations();
-
   this->run_metrology(0., 0., 0.);
 }
 

--- a/assembly/assemblyCommon/Metrology.cc
+++ b/assembly/assemblyCommon/Metrology.cc
@@ -575,7 +575,7 @@ void Metrology::run_metrology(const double patrec_dX, const double patrec_dY, co
     const double delta_y_corr = delta_y - config_->getValue<double>("parameters", "FromPSPRefPointToPSSRefPoint_dY");
     const double delta_z = (posi_PSs_z1_ + posi_PSs_z2_)/2. - (posi_PSp_z1_ + posi_PSp_z2_)/2.;
     const double delta_a_deg = PSs_angle_deg_ - PSp_angle_deg_;
-    const double delta_a_urad = delta_a_deg * (M_PI/180.0);
+    const double delta_a_urad = delta_a_deg * 1e6 * (M_PI/180.0);
 
     emit measured_results(delta_x, delta_x_corr, delta_y, delta_y_corr, delta_z, delta_a_deg, delta_a_urad);
 

--- a/assembly/assemblyCommon/Metrology.h
+++ b/assembly/assemblyCommon/Metrology.h
@@ -62,12 +62,8 @@ class Metrology : public QObject
     void connect_motion_manager() { this->enable_motion_manager(true) ; }
     void disconnect_motion_manager() { this->enable_motion_manager(false); }
 
-    // maximum number of allowed iterations in a single alignment execution
-    int max_numOfRotations_;
-
     // transient data (values to be updated during alignment)
     int metrology_step_;
-    int counter_numOfRotations_; //Count the number of rotations executed during the alignment routine
 
     double posi_PSp_x1_, posi_PSp_y1_, posi_PSp_z1_;
     double posi_PSp_x2_, posi_PSp_y2_, posi_PSp_z2_;
@@ -78,7 +74,6 @@ class Metrology : public QObject
     double PSs_angle_deg_;
 
     void reset();
-    void reset_counter_numOfRotations();
 
   public slots:
 

--- a/assembly/assemblyCommon/Metrology.h
+++ b/assembly/assemblyCommon/Metrology.h
@@ -96,6 +96,8 @@ class Metrology : public QObject
 
     void complete_motion();
 
+    void clear_results();
+
   signals:
 
     void configuration_updated();

--- a/assembly/assemblyCommon/Metrology.h
+++ b/assembly/assemblyCommon/Metrology.h
@@ -118,7 +118,7 @@ class Metrology : public QObject
 
     void measured_angle(const bool, const double);
 
-    void measured_results(const double, const double, const double);
+    void measured_results(const double, const double, const double, const double, const double, const double);
 
     void execution_completed();
 

--- a/assembly/assemblyCommon/Metrology.h
+++ b/assembly/assemblyCommon/Metrology.h
@@ -73,6 +73,8 @@ class Metrology : public QObject
     double PSp_angle_deg_;
     double PSs_angle_deg_;
 
+    bool moving_to_start_;
+
     void reset();
 
   public slots:
@@ -90,6 +92,8 @@ class Metrology : public QObject
     void move_relative(const double, const double, const double, const double);
 
     void complete_motion();
+
+    void move_to_start();
 
     void clear_results();
 

--- a/assembly/assemblyCommon/Metrology.h
+++ b/assembly/assemblyCommon/Metrology.h
@@ -104,6 +104,8 @@ class Metrology : public QObject
 
     void image_PatRecOne(const cv::Mat&);
     void image_PatRecTwo(const cv::Mat&);
+    void image_PatRecThree(const cv::Mat&);
+    void image_PatRecFour(const cv::Mat&);
 
     void image_request();
     void autofocused_image_request();

--- a/assembly/assemblyCommon/Metrology.h
+++ b/assembly/assemblyCommon/Metrology.h
@@ -69,10 +69,10 @@ class Metrology : public QObject
     int metrology_step_;
     int counter_numOfRotations_; //Count the number of rotations executed during the alignment routine
 
-    double posi_PSp_x1_, posi_PSp_y1_;
-    double posi_PSp_x2_, posi_PSp_y2_;
-    double posi_PSs_x1_, posi_PSs_y1_;
-    double posi_PSs_x2_, posi_PSs_y2_;
+    double posi_PSp_x1_, posi_PSp_y1_, posi_PSp_z1_;
+    double posi_PSp_x2_, posi_PSp_y2_, posi_PSp_z2_;
+    double posi_PSs_x1_, posi_PSs_y1_, posi_PSs_z1_;
+    double posi_PSs_x2_, posi_PSs_y2_, posi_PSs_z2_;
 
     double PSp_angle_deg_;
     double PSs_angle_deg_;
@@ -118,7 +118,7 @@ class Metrology : public QObject
 
     void measured_angle(const bool, const double);
 
-    void measured_results(const double, const double, const double, const double, const double, const double);
+    void measured_results(const double, const double, const double, const double, const double, const double, const double);
 
     void execution_completed();
 

--- a/assembly/assemblyCommon/Metrology.h
+++ b/assembly/assemblyCommon/Metrology.h
@@ -1,0 +1,126 @@
+////////////////////////////////////////////////////////////////////////////////
+//                                                                             //
+//               Copyright (C) 2011-2017 - The DESY CMS Group                  //
+//                           All rights reserved                               //
+//                                                                             //
+//      The CMStkModLab source code is licensed under the GNU GPL v3.0.        //
+//      You have the right to modify and/or redistribute this source code      //
+//      under the terms specified in the license, which may be found online    //
+//      at http://www.gnu.org/licenses or at License.txt.                      //
+//                                                                             //
+/////////////////////////////////////////////////////////////////////////////////
+
+#ifndef Metrology_h
+#define Metrology_h
+
+#include <LStepExpressMotionManager.h>
+#include <AssemblyObjectFinderPatRec.h>
+
+#include <QObject>
+
+class Metrology : public QObject
+{
+ Q_OBJECT
+
+ public:
+  explicit Metrology(const LStepExpressMotionManager* const, QObject* parent=nullptr);
+  virtual ~Metrology() {}
+
+  class Configuration {
+
+   public:
+    explicit Configuration() { this->reset(); }
+    virtual ~Configuration() {}
+
+    void reset();
+
+    bool is_valid() const;
+
+    bool complete_at_position1;
+    bool use_autofocusing;
+
+    //Cfg instances which must be transmitted when running PatRec on markers 1 and 2
+    AssemblyObjectFinderPatRec::Configuration PatRec_PSP1_configuration;
+    AssemblyObjectFinderPatRec::Configuration PatRec_PSP2_configuration;
+    AssemblyObjectFinderPatRec::Configuration PatRec_PSS1_configuration;
+    AssemblyObjectFinderPatRec::Configuration PatRec_PSS2_configuration;
+  };
+
+  const Configuration& configuration() const { return configuration_; }
+
+  protected:
+
+    const LStepExpressMotionManager* const motion_manager_;
+
+    Configuration configuration_;
+    const ApplicationConfig* config_;
+
+    bool motion_manager_enabled_;
+
+    void enable_motion_manager(const bool);
+
+    void connect_motion_manager() { this->enable_motion_manager(true) ; }
+    void disconnect_motion_manager() { this->enable_motion_manager(false); }
+
+    // maximum number of allowed iterations in a single alignment execution
+    int max_numOfRotations_;
+
+    // transient data (values to be updated during alignment)
+    int metrology_step_;
+    int counter_numOfRotations_; //Count the number of rotations executed during the alignment routine
+
+    double posi_PSp_x1_, posi_PSp_y1_;
+    double posi_PSp_x2_, posi_PSp_y2_;
+    double posi_PSs_x1_, posi_PSs_y1_;
+    double posi_PSs_x2_, posi_PSs_y2_;
+
+    double PSp_angle_deg_;
+    double PSs_angle_deg_;
+
+    void reset();
+    void reset_counter_numOfRotations();
+
+  public slots:
+
+    void update_configuration(const Configuration&);
+
+    void redirect_image(const cv::Mat&);
+
+    void execute();
+
+    void run_metrology(const double, const double, const double);
+
+    void launch_next_metrology_step();
+
+    void move_relative(const double, const double, const double, const double);
+
+    void complete_motion();
+
+  signals:
+
+    void configuration_updated();
+
+    void nextMetrologyStep(const double, const double, const double);
+
+    void image_PatRecOne(const cv::Mat&);
+    void image_PatRecTwo(const cv::Mat&);
+
+    void image_request();
+    void autofocused_image_request();
+
+    void PatRec_request(const AssemblyObjectFinderPatRec::Configuration&);
+
+    void move_relative_request(const double, const double, const double, const double);
+
+    void motion_completed();
+
+    void measured_angle(const bool, const double);
+
+    void measured_results(const double, const double, const double);
+
+    void execution_completed();
+
+    void DBLogMessage(const QString);
+};
+
+#endif // Metrology_h

--- a/assembly/assemblyCommon/MetrologyView.cc
+++ b/assembly/assemblyCommon/MetrologyView.cc
@@ -41,6 +41,8 @@ MetrologyView::MetrologyView(QWidget* parent)
  , metro_useAutoFocusing_checkbox_(nullptr)
 
  , metro_exemetro_pusbu_(nullptr)
+ , metro_goToMarker_pusbu_(nullptr)
+ , metro_enableVacuum_pusbu_(nullptr)
 
  , alignm_angmax_dontIter_linee_(nullptr)
  , alignm_angmax_complete_linee_(nullptr)
@@ -128,14 +130,33 @@ MetrologyView::MetrologyView(QWidget* parent)
 
   metro_exemod_lay->addSpacing(20);
 
+  // Add layout with a few buttons
+  QVBoxLayout* metro_button_lay = new QVBoxLayout;
+  metro_exemod_lay->addLayout(metro_button_lay);
+
+  QHBoxLayout* metro_prep_lay = new QHBoxLayout;
+  metro_button_lay->addLayout(metro_prep_lay);
+
+  QLabel* metro_prep_label = new QLabel("Preparations: ");
+  metro_goToMarker_pusbu_ = new QPushButton(tr("Go to PSp TL marker"));
+  metro_enableVacuum_pusbu_ = new QPushButton(tr("Enable baseplate vacuum"));
+
+  metro_prep_lay->addWidget(metro_prep_label);
+  metro_prep_lay->addWidget(metro_goToMarker_pusbu_);
+  metro_prep_lay->addWidget(metro_enableVacuum_pusbu_);
+
+  connect(metro_enableVacuum_pusbu_, SIGNAL(clicked()), this, SLOT(enable_vacuum_on_baseplate()));
+  connect(metro_goToMarker_pusbu_, SIGNAL(clicked()), this, SLOT(go_to_marker()));
+
   // mode: align object
   QHBoxLayout* metro_exemetro_lay = new QHBoxLayout;
-  metro_exemod_lay->addLayout(metro_exemetro_lay);
+  metro_button_lay->addLayout(metro_exemetro_lay);
 
   metro_exemetro_pusbu_ = new QPushButton(tr("Perform Metrology"));
 
   connect(metro_exemetro_pusbu_, SIGNAL(clicked()), this, SLOT(transmit_configuration()));
   metro_exemetro_lay->addWidget(metro_exemetro_pusbu_);
+
   // ----------
 
   metro_cfg_lay->addSpacing(50);
@@ -524,6 +545,36 @@ void MetrologyView::switch_to_config()
 
     toolbox_->setCurrentIndex(idx_cfg_wid_);
     return;
+}
+
+void MetrologyView::updateVacuumChannelState(int channel, bool state)
+{
+    const int vacuum_channel_baseplate = config_->getValue<int>("main", "Vacuum_Baseplate");
+    if (channel == vacuum_channel_baseplate) {
+        if(state) {
+            metro_enableVacuum_pusbu_->setEnabled(false);
+        } else {
+            metro_enableVacuum_pusbu_->setEnabled(true);
+        }
+    }
+}
+
+void MetrologyView::enable_vacuum_on_baseplate()
+{
+    const int vacuum_channel_baseplate = config_->getValue<int>("main", "Vacuum_Baseplate");
+
+    NQLog("MetrologyView", NQLog::Spam) << "enable_vacuum_on_baseplate"
+       << ": emitting signal \"enable_vacuum_baseplate(" << vacuum_channel_baseplate << ")\"";
+
+    emit enable_vacuum_baseplate(vacuum_channel_baseplate);
+}
+
+void MetrologyView::go_to_marker()
+{
+    NQLog("MetrologyView", NQLog::Spam) << "go_to_marker"
+       << ": emitting signal \"go_to_marker_signal()\"";
+
+    emit go_to_marker_signal();
 }
 
 void MetrologyView::transmit_configuration()

--- a/assembly/assemblyCommon/MetrologyView.cc
+++ b/assembly/assemblyCommon/MetrologyView.cc
@@ -53,9 +53,10 @@ MetrologyView::MetrologyView(QWidget* parent)
  , metro_mesang_PSp_linee_(nullptr)
  , metro_mesang_PSs_linee_(nullptr)
  , metro_dx_linee_(nullptr)
- , metro_dy_linee_(nullptr)
  , metro_dx_corr_linee_(nullptr)
+ , metro_dy_linee_(nullptr)
  , metro_dy_corr_linee_(nullptr)
+ , metro_dz_linee_(nullptr)
  , metro_da_deg_linee_(nullptr)
  , metro_da_urad_linee_(nullptr)
 
@@ -336,6 +337,27 @@ MetrologyView::MetrologyView(QWidget* parent)
   metro_dy_lay->setStretch(3,  44);
   metro_dy_lay->setStretch(4,  55);
   metro_dy_lay->setStretch(5, 101);
+
+  QHBoxLayout* metro_dz_lay = new QHBoxLayout;
+  metro_diff_lay->addLayout(metro_dz_lay);
+
+  QLabel* metro_dz_label = new QLabel("Measured dz [mm]");
+  metro_dz_linee_ = new QLineEdit("");
+  metro_dz_linee_->setReadOnly(true);
+
+  metro_dz_lay->addWidget(metro_dz_label);
+  metro_dz_lay->addWidget(metro_dz_linee_);
+  metro_dz_lay->addWidget(new QLabel);
+  metro_dz_lay->addWidget(new QLabel);
+  metro_dz_lay->addWidget(new QLabel);
+  metro_dz_lay->addWidget(new QLabel);
+
+  metro_dz_lay->setStretch(0,  44);
+  metro_dz_lay->setStretch(1,  55);
+  metro_dz_lay->setStretch(2, 101);
+  metro_dz_lay->setStretch(3,  44);
+  metro_dz_lay->setStretch(4,  55);
+  metro_dz_lay->setStretch(5, 101);
 
   QHBoxLayout* metro_da_lay = new QHBoxLayout;
   metro_diff_lay->addLayout(metro_da_lay);
@@ -627,7 +649,7 @@ void MetrologyView::show_measured_angle(const bool sensor_PSs, const double val)
   return;
 }
 
-void MetrologyView::show_results(const double dx, const double dx_corr, const double dy, const double dy_corr, const double da_deg, const double da_urad)
+void MetrologyView::show_results(const double dx, const double dx_corr, const double dy, const double dy_corr, const double dz, const double da_deg, const double da_urad)
 {
   std::stringstream posi_strs_dx;
   posi_strs_dx << dx;
@@ -644,6 +666,10 @@ void MetrologyView::show_results(const double dx, const double dx_corr, const do
   std::stringstream posi_strs_dy_corr;
   posi_strs_dy_corr << dy_corr;
   metro_dy_corr_linee_->setText(QString::fromStdString(posi_strs_dy_corr.str()));
+
+  std::stringstream posi_strs_dz;
+  posi_strs_dz << dz;
+  metro_dz_linee_->setText(QString::fromStdString(posi_strs_dz.str()));
 
   std::stringstream posi_strs_da_deg;
   posi_strs_da_deg << da_deg;

--- a/assembly/assemblyCommon/MetrologyView.cc
+++ b/assembly/assemblyCommon/MetrologyView.cc
@@ -530,7 +530,7 @@ void MetrologyView::transmit_configuration()
 {
   QMessageBox* msgBox = new QMessageBox;
   msgBox->setStyleSheet("QLabel{min-width: 300px;}");
-  msgBox->setInformativeText("Are you sure you selected the correct template images and defined the relevant B/W thresholds?");
+  msgBox->setInformativeText("Are you sure the camera is positioned at the TL fiducial of the PSp sensor, the correct template images are selected and the relevant B/W thresholds are defined?");
   msgBox->setStandardButtons(QMessageBox::Yes | QMessageBox::No);
   msgBox->setDefaultButton(QMessageBox::Yes);
   int ret = msgBox->exec();

--- a/assembly/assemblyCommon/MetrologyView.cc
+++ b/assembly/assemblyCommon/MetrologyView.cc
@@ -24,7 +24,6 @@
 #include <QHBoxLayout>
 #include <QGridLayout>
 #include <QGroupBox>
-#include <QToolBox>
 #include <QLabel>
 #include <QScriptEngine>
 #include <qnumeric.h>
@@ -32,6 +31,8 @@
 
 MetrologyView::MetrologyView(QWidget* parent)
  : QWidget(parent)
+
+ , toolbox_(nullptr)
 
  , metro_cfg_wid_(nullptr)
  , metro_res_wid_(nullptr)
@@ -71,20 +72,24 @@ MetrologyView::MetrologyView(QWidget* parent)
 
  , finder_connected_(false)
 
+ , idx_cfg_wid_(0)
+ , idx_results_wid_(0)
+
  , config_(nullptr)
 {
   QVBoxLayout* layout = new QVBoxLayout;
   this->setLayout(layout);
 
-  QToolBox* toolbox = new QToolBox;
-  layout->addWidget(toolbox);
+  toolbox_ = new QToolBox;
+  layout->addWidget(toolbox_);
 
   config_ = ApplicationConfig::instance();
 
   // Configuration + Execution
 
   metro_cfg_wid_ = new QWidget;
-  toolbox->addItem(metro_cfg_wid_, tr("Metrology Configuration"));
+  toolbox_->addItem(metro_cfg_wid_, tr("Metrology Configuration"));
+  idx_cfg_wid_ = toolbox_->indexOf(metro_cfg_wid_);
 
   QVBoxLayout* metro_cfg_lay = new QVBoxLayout;
   metro_cfg_wid_->setLayout(metro_cfg_lay);
@@ -241,7 +246,8 @@ MetrologyView::MetrologyView(QWidget* parent)
 
   // Results -------------
   metro_res_wid_ = new QWidget;
-  toolbox->addItem(metro_res_wid_, "Metrology Results");
+  toolbox_->addItem(metro_res_wid_, "Metrology Results");
+  idx_results_wid_ = toolbox_->indexOf(metro_res_wid_);
 
   QVBoxLayout* metro_res_lay = new QVBoxLayout;
   metro_res_wid_->setLayout(metro_res_lay);
@@ -444,6 +450,15 @@ void MetrologyView::update_templates(const bool checked)
   return;
 }
 
+void MetrologyView::switch_to_results()
+{
+    NQLog("MetrologyView", NQLog::Critical) << "switch_to_results"
+    << ": Switching to results widget";
+
+    toolbox_->setCurrentIndex(idx_results_wid_);
+    return;
+}
+
 void MetrologyView::transmit_configuration()
 {
   QMessageBox* msgBox = new QMessageBox;
@@ -479,6 +494,8 @@ void MetrologyView::transmit_configuration()
      << ": emitting signal \"configuration(Metrology::Configuration)\"";
 
   emit configuration(conf);
+
+  switch_to_results();
 }
 
 

--- a/assembly/assemblyCommon/MetrologyView.cc
+++ b/assembly/assemblyCommon/MetrologyView.cc
@@ -705,7 +705,7 @@ void MetrologyView::display_infoTab()
 {
     QMessageBox::information(this, tr("Information - Metrology"),
             tr("<p>Click 'Perform Metrology' to run the module metrology.</p>"
-            "<p>Make sure to move to the first marker of the PSp beforehand and to set template images for PatRec and B/W thresholds.</p>"
+            "<p>Make sure to move to the first marker of the PSp beforehand and to set template images for PatRec and B/W thresholds. It is recommended to enable vacuum on the baseplate</p>"
     ));
 
     return;

--- a/assembly/assemblyCommon/MetrologyView.cc
+++ b/assembly/assemblyCommon/MetrologyView.cc
@@ -114,10 +114,12 @@ MetrologyView::MetrologyView(QWidget* parent)
 
   metro_completeAtPosOne_checkbox_ = new QCheckBox("Go back to marker-1 position before completion");
   metro_exeopt_lay->addWidget(metro_completeAtPosOne_checkbox_);
+  metro_completeAtPosOne_checkbox_->setChecked(true);
 
   // option: go-back to start before stopping
   metro_useAutoFocusing_checkbox_ = new QCheckBox("Use Auto-Focusing");
   metro_exeopt_lay->addWidget(metro_useAutoFocusing_checkbox_);
+  metro_useAutoFocusing_checkbox_->setChecked(true);
 
   metro_exemod_lay->addSpacing(20);
 

--- a/assembly/assemblyCommon/MetrologyView.cc
+++ b/assembly/assemblyCommon/MetrologyView.cc
@@ -400,6 +400,7 @@ MetrologyView::MetrologyView(QWidget* parent)
   patrecOne_image_->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
   patrecOne_image_->setScaledContents(true);
   patrecOne_image_->setAlignment(Qt::AlignCenter);
+  patrecOne_image_->setZoomFactor(0.2);
 
   QApplication::processEvents();
 
@@ -420,6 +421,7 @@ MetrologyView::MetrologyView(QWidget* parent)
   patrecTwo_image_->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
   patrecTwo_image_->setScaledContents(true);
   patrecTwo_image_->setAlignment(Qt::AlignCenter);
+  patrecTwo_image_->setZoomFactor(0.2);
 
   patrecTwo_scroll_ = new QScrollArea(this);
   patrecTwo_scroll_->setMinimumSize(200, 200);
@@ -438,6 +440,7 @@ MetrologyView::MetrologyView(QWidget* parent)
   patrecThree_image_->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
   patrecThree_image_->setScaledContents(true);
   patrecThree_image_->setAlignment(Qt::AlignCenter);
+  patrecThree_image_->setZoomFactor(0.2);
 
   patrecThree_scroll_ = new QScrollArea(this);
   patrecThree_scroll_->setMinimumSize(200, 200);
@@ -456,6 +459,7 @@ MetrologyView::MetrologyView(QWidget* parent)
   patrecFour_image_->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
   patrecFour_image_->setScaledContents(true);
   patrecFour_image_->setAlignment(Qt::AlignCenter);
+  patrecFour_image_->setZoomFactor(0.2);
 
   patrecFour_scroll_ = new QScrollArea(this);
   patrecFour_scroll_->setMinimumSize(200, 200);

--- a/assembly/assemblyCommon/MetrologyView.cc
+++ b/assembly/assemblyCommon/MetrologyView.cc
@@ -72,6 +72,7 @@ MetrologyView::MetrologyView(QWidget* parent)
  , patrecFour_image_ (nullptr)
  , patrecFour_scroll_(nullptr)
 
+ , button_metrologyClearResults_(nullptr)
  , button_metrologyEmergencyStop_(nullptr)
 
  , finder_connected_(false)
@@ -469,13 +470,17 @@ MetrologyView::MetrologyView(QWidget* parent)
 
   QHBoxLayout* buttons_lay = new QHBoxLayout;
 
+  button_metrologyClearResults_ = new QPushButton(tr("Clear Results"));
   button_metrologyEmergencyStop_ = new QPushButton(tr("Emergency Stop"));
 
-  buttons_lay->addWidget(new QLabel, 33);
+  buttons_lay->addWidget(button_metrologyClearResults_, 33);
   buttons_lay->addWidget(new QLabel, 33);
   buttons_lay->addWidget(button_metrologyEmergencyStop_, 33);
 
   layout->addLayout(buttons_lay);
+
+  button_metrologyClearResults_->setEnabled(false);
+  connect(button_metrologyClearResults_, SIGNAL(clicked()), this, SLOT(clearResults()));
 }
 
 
@@ -687,6 +692,8 @@ void MetrologyView::show_results(const double dx, const double dx_corr, const do
   posi_strs_da_urad << da_urad;
   metro_da_urad_linee_->setText(QString::fromStdString(posi_strs_da_urad.str()));
 
+  button_metrologyClearResults_->setEnabled(true);
+
   return;
 }
 
@@ -718,23 +725,43 @@ void MetrologyView::updateImage(const int stage, const cv::Mat& img)
   if(stage == 1)
   {
     patrecOne_image_->setImage(img);
-//    patrecOne_image_->setZoomFactor(0.3);
   }
   else if(stage == 2)
   {
     patrecTwo_image_->setImage(img);
-//    patrecTwo_image_->setZoomFactor(0.5);
   }
   else if(stage == 3)
   {
     patrecThree_image_->setImage(img);
-//    patrecTwo_image_->setZoomFactor(0.5);
   }
   else if(stage == 4)
   {
     patrecFour_image_->setImage(img);
-//    patrecTwo_image_->setZoomFactor(0.5);
   }
 
   return;
+}
+
+void MetrologyView::clearResults()
+{
+  NQLog("MetrologyView", NQLog::Spam) << "clearResults()";
+
+  patrecOne_image_->resetImage();
+  patrecTwo_image_->resetImage();
+  patrecThree_image_->resetImage();
+  patrecFour_image_->resetImage();
+
+  metro_mesang_PSp_linee_->setText("");
+  metro_mesang_PSs_linee_->setText("");
+  metro_dx_linee_->setText("");
+  metro_dx_corr_linee_->setText("");
+  metro_dy_linee_->setText("");
+  metro_dy_corr_linee_->setText("");
+  metro_dz_linee_->setText("");
+  metro_da_deg_linee_->setText("");
+  metro_da_urad_linee_->setText("");
+
+  button_metrologyClearResults_->setEnabled(false);
+
+  switch_to_config();
 }

--- a/assembly/assemblyCommon/MetrologyView.cc
+++ b/assembly/assemblyCommon/MetrologyView.cc
@@ -508,6 +508,14 @@ void MetrologyView::switch_to_results()
     toolbox_->setCurrentIndex(idx_results_wid_);
     return;
 }
+void MetrologyView::switch_to_config()
+{
+    NQLog("MetrologyView", NQLog::Critical) << "switch_to_config"
+    << ": Switching to config widget";
+
+    toolbox_->setCurrentIndex(idx_cfg_wid_);
+    return;
+}
 
 void MetrologyView::transmit_configuration()
 {

--- a/assembly/assemblyCommon/MetrologyView.cc
+++ b/assembly/assemblyCommon/MetrologyView.cc
@@ -54,7 +54,10 @@ MetrologyView::MetrologyView(QWidget* parent)
  , metro_mesang_PSs_linee_(nullptr)
  , metro_dx_linee_(nullptr)
  , metro_dy_linee_(nullptr)
- , metro_da_linee_(nullptr)
+ , metro_dx_corr_linee_(nullptr)
+ , metro_dy_corr_linee_(nullptr)
+ , metro_da_deg_linee_(nullptr)
+ , metro_da_urad_linee_(nullptr)
 
  , patrecOne_image_ (nullptr)
  , patrecOne_scroll_(nullptr)
@@ -258,35 +261,28 @@ MetrologyView::MetrologyView(QWidget* parent)
   metro_res_lay->addLayout(metro_mesangs_lay);
 
   // Numerical Results
-  QHBoxLayout* metro_mesang_PSp_lay = new QHBoxLayout;
-  metro_mesangs_lay->addLayout(metro_mesang_PSp_lay);
-
   QLabel* metro_mesang_PSp_label = new QLabel("Measured Angle PSp [deg]");
   metro_mesang_PSp_linee_ = new QLineEdit("");
   metro_mesang_PSp_linee_->setReadOnly(true);
 
-  metro_mesang_PSp_lay->addWidget(metro_mesang_PSp_label);
-  metro_mesang_PSp_lay->addWidget(metro_mesang_PSp_linee_);
-  metro_mesang_PSp_lay->addWidget(new QLabel);
-
-  metro_mesang_PSp_lay->setStretch(0,  34);
-  metro_mesang_PSp_lay->setStretch(1,  65);
-  metro_mesang_PSp_lay->setStretch(2, 101);
-
-  QHBoxLayout* metro_mesang_PSs_lay = new QHBoxLayout;
-  metro_mesangs_lay->addLayout(metro_mesang_PSs_lay);
+  metro_mesangs_lay->addWidget(metro_mesang_PSp_label);
+  metro_mesangs_lay->addWidget(metro_mesang_PSp_linee_);
+  metro_mesangs_lay->addWidget(new QLabel);
 
   QLabel* metro_mesang_PSs_label = new QLabel("Measured Angle PSs [deg]");
   metro_mesang_PSs_linee_ = new QLineEdit("");
   metro_mesang_PSs_linee_->setReadOnly(true);
 
-  metro_mesang_PSs_lay->addWidget(metro_mesang_PSs_label);
-  metro_mesang_PSs_lay->addWidget(metro_mesang_PSs_linee_);
-  metro_mesang_PSs_lay->addWidget(new QLabel);
+  metro_mesangs_lay->addWidget(metro_mesang_PSs_label);
+  metro_mesangs_lay->addWidget(metro_mesang_PSs_linee_);
+  metro_mesangs_lay->addWidget(new QLabel);
 
-  metro_mesang_PSs_lay->setStretch(0,  34);
-  metro_mesang_PSs_lay->setStretch(1,  65);
-  metro_mesang_PSs_lay->setStretch(2, 101);
+  metro_mesangs_lay->setStretch(0,  44);
+  metro_mesangs_lay->setStretch(1,  55);
+  metro_mesangs_lay->setStretch(2, 101);
+  metro_mesangs_lay->setStretch(3,  44);
+  metro_mesangs_lay->setStretch(4,  55);
+  metro_mesangs_lay->setStretch(5, 101);
 
   QVBoxLayout* metro_diff_lay = new QVBoxLayout;
   metro_res_lay->addLayout(metro_diff_lay);
@@ -298,13 +294,23 @@ MetrologyView::MetrologyView(QWidget* parent)
   metro_dx_linee_ = new QLineEdit("");
   metro_dx_linee_->setReadOnly(true);
 
+  QLabel* metro_dx_corr_label = new QLabel("Corrected dx [mm]");
+  metro_dx_corr_linee_ = new QLineEdit("");
+  metro_dx_corr_linee_->setReadOnly(true);
+
   metro_dx_lay->addWidget(metro_dx_label);
   metro_dx_lay->addWidget(metro_dx_linee_);
   metro_dx_lay->addWidget(new QLabel);
+  metro_dx_lay->addWidget(metro_dx_corr_label);
+  metro_dx_lay->addWidget(metro_dx_corr_linee_);
+  metro_dx_lay->addWidget(new QLabel);
 
-  metro_dx_lay->setStretch(0,  34);
-  metro_dx_lay->setStretch(1,  65);
+  metro_dx_lay->setStretch(0,  44);
+  metro_dx_lay->setStretch(1,  55);
   metro_dx_lay->setStretch(2, 101);
+  metro_dx_lay->setStretch(3,  44);
+  metro_dx_lay->setStretch(4,  55);
+  metro_dx_lay->setStretch(5, 101);
 
   QHBoxLayout* metro_dy_lay = new QHBoxLayout;
   metro_diff_lay->addLayout(metro_dy_lay);
@@ -313,28 +319,48 @@ MetrologyView::MetrologyView(QWidget* parent)
   metro_dy_linee_ = new QLineEdit("");
   metro_dy_linee_->setReadOnly(true);
 
+  QLabel* metro_dy_corr_label = new QLabel("Corrected dy [mm]");
+  metro_dy_corr_linee_ = new QLineEdit("");
+  metro_dy_corr_linee_->setReadOnly(true);
+
   metro_dy_lay->addWidget(metro_dy_label);
   metro_dy_lay->addWidget(metro_dy_linee_);
   metro_dy_lay->addWidget(new QLabel);
+  metro_dy_lay->addWidget(metro_dy_corr_label);
+  metro_dy_lay->addWidget(metro_dy_corr_linee_);
+  metro_dy_lay->addWidget(new QLabel);
 
-  metro_dy_lay->setStretch(0,  34);
-  metro_dy_lay->setStretch(1,  65);
+  metro_dy_lay->setStretch(0,  44);
+  metro_dy_lay->setStretch(1,  55);
   metro_dy_lay->setStretch(2, 101);
+  metro_dy_lay->setStretch(3,  44);
+  metro_dy_lay->setStretch(4,  55);
+  metro_dy_lay->setStretch(5, 101);
 
   QHBoxLayout* metro_da_lay = new QHBoxLayout;
   metro_diff_lay->addLayout(metro_da_lay);
 
-  QLabel* metro_da_label = new QLabel("Measured angle difference [deg]");
-  metro_da_linee_ = new QLineEdit("");
-  metro_da_linee_->setReadOnly(true);
+  QLabel* metro_da_deg_label = new QLabel("Measured angle difference [deg]");
+  metro_da_deg_linee_ = new QLineEdit("");
+  metro_da_deg_linee_->setReadOnly(true);
 
-  metro_da_lay->addWidget(metro_da_label);
-  metro_da_lay->addWidget(metro_da_linee_);
+  QLabel* metro_da_urad_label = new QLabel("Measured angle difference [urad]");
+  metro_da_urad_linee_ = new QLineEdit("");
+  metro_da_urad_linee_->setReadOnly(true);
+
+  metro_da_lay->addWidget(metro_da_deg_label);
+  metro_da_lay->addWidget(metro_da_deg_linee_);
+  metro_da_lay->addWidget(new QLabel);
+  metro_da_lay->addWidget(metro_da_urad_label);
+  metro_da_lay->addWidget(metro_da_urad_linee_);
   metro_da_lay->addWidget(new QLabel);
 
-  metro_da_lay->setStretch(0,  34);
-  metro_da_lay->setStretch(1,  65);
+  metro_da_lay->setStretch(0,  44);
+  metro_da_lay->setStretch(1,  55);
   metro_da_lay->setStretch(2, 101);
+  metro_da_lay->setStretch(3,  44);
+  metro_da_lay->setStretch(4,  55);
+  metro_da_lay->setStretch(5, 101);
 
 
   // Graphical Results (PatRec Images)
@@ -601,19 +627,31 @@ void MetrologyView::show_measured_angle(const bool sensor_PSs, const double val)
   return;
 }
 
-void MetrologyView::show_results(const double dx, const double dy, const double da)
+void MetrologyView::show_results(const double dx, const double dx_corr, const double dy, const double dy_corr, const double da_deg, const double da_urad)
 {
   std::stringstream posi_strs_dx;
   posi_strs_dx << dx;
   metro_dx_linee_->setText(QString::fromStdString(posi_strs_dx.str()));
 
+  std::stringstream posi_strs_dx_corr;
+  posi_strs_dx_corr << dx_corr;
+  metro_dx_corr_linee_->setText(QString::fromStdString(posi_strs_dx_corr.str()));
+
   std::stringstream posi_strs_dy;
   posi_strs_dy << dy;
   metro_dy_linee_->setText(QString::fromStdString(posi_strs_dy.str()));
 
-  std::stringstream posi_strs_da;
-  posi_strs_da << da;
-  metro_da_linee_->setText(QString::fromStdString(posi_strs_da.str()));
+  std::stringstream posi_strs_dy_corr;
+  posi_strs_dy_corr << dy_corr;
+  metro_dy_corr_linee_->setText(QString::fromStdString(posi_strs_dy_corr.str()));
+
+  std::stringstream posi_strs_da_deg;
+  posi_strs_da_deg << da_deg;
+  metro_da_deg_linee_->setText(QString::fromStdString(posi_strs_da_deg.str()));
+
+  std::stringstream posi_strs_da_urad;
+  posi_strs_da_urad << da_urad;
+  metro_da_urad_linee_->setText(QString::fromStdString(posi_strs_da_urad.str()));
 
   return;
 }

--- a/assembly/assemblyCommon/MetrologyView.cc
+++ b/assembly/assemblyCommon/MetrologyView.cc
@@ -538,6 +538,7 @@ void MetrologyView::switch_to_results()
     toolbox_->setCurrentIndex(idx_results_wid_);
     return;
 }
+
 void MetrologyView::switch_to_config()
 {
     NQLog("MetrologyView", NQLog::Critical) << "switch_to_config"

--- a/assembly/assemblyCommon/MetrologyView.cc
+++ b/assembly/assemblyCommon/MetrologyView.cc
@@ -1,0 +1,649 @@
+/////////////////////////////////////////////////////////////////////////////////
+//                                                                             //
+//               Copyright (C) 2011-2022 - The DESY CMS Group                  //
+//                           All rights reserved                               //
+//                                                                             //
+//      The CMStkModLab source code is licensed under the GNU GPL v3.0.        //
+//      You have the right to modify and/or redistribute this source code      //
+//      under the terms specified in the license, which may be found online    //
+//      at http://www.gnu.org/licenses or at License.txt.                      //
+//                                                                             //
+/////////////////////////////////////////////////////////////////////////////////
+
+#include <nqlogger.h>
+
+#include <MetrologyView.h>
+#include <AssemblyUtilities.h>
+
+#include <sstream>
+#include <iomanip>
+#include <cmath>
+
+#include <QApplication>
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QGridLayout>
+#include <QGroupBox>
+#include <QToolBox>
+#include <QLabel>
+#include <QScriptEngine>
+#include <qnumeric.h>
+
+
+MetrologyView::MetrologyView(QWidget* parent)
+ : QWidget(parent)
+
+ , metro_cfg_wid_(nullptr)
+ , metro_res_wid_(nullptr)
+
+ , metro_completeAtPosOne_checkbox_(nullptr)
+ , metro_useAutoFocusing_checkbox_(nullptr)
+
+ , metro_exemetro_pusbu_(nullptr)
+
+ , alignm_angmax_dontIter_linee_(nullptr)
+ , alignm_angmax_complete_linee_(nullptr)
+
+ , patrecOne_wid_(nullptr)
+ , patrecTwo_wid_(nullptr)
+ , patrecThree_wid_(nullptr)
+ , patrecFour_wid_(nullptr)
+
+ , metro_mesang_PSp_linee_(nullptr)
+ , metro_mesang_PSs_linee_(nullptr)
+ , metro_dx_linee_(nullptr)
+ , metro_dy_linee_(nullptr)
+ , metro_da_linee_(nullptr)
+
+ , patrecOne_image_ (nullptr)
+ , patrecOne_scroll_(nullptr)
+
+ , patrecTwo_image_ (nullptr)
+ , patrecTwo_scroll_(nullptr)
+
+ , patrecThree_image_ (nullptr)
+ , patrecThree_scroll_(nullptr)
+
+ , patrecFour_image_ (nullptr)
+ , patrecFour_scroll_(nullptr)
+
+ , button_metrologyEmergencyStop_(nullptr)
+
+ , finder_connected_(false)
+
+ , config_(nullptr)
+{
+  QVBoxLayout* layout = new QVBoxLayout;
+  this->setLayout(layout);
+
+  QToolBox* toolbox = new QToolBox;
+  layout->addWidget(toolbox);
+
+  config_ = ApplicationConfig::instance();
+
+  // Configuration + Execution
+
+  metro_cfg_wid_ = new QWidget;
+  toolbox->addItem(metro_cfg_wid_, tr("Metrology Configuration"));
+
+  QVBoxLayout* metro_cfg_lay = new QVBoxLayout;
+  metro_cfg_wid_->setLayout(metro_cfg_lay);
+
+  // Object Configuration + Execution Modes
+  QHBoxLayout* metro_cfgexe_lay = new QHBoxLayout;
+  metro_cfg_lay->addLayout(metro_cfgexe_lay);
+
+  // execution modes
+  QVBoxLayout* metro_exe_lay = new QVBoxLayout;
+  metro_cfgexe_lay->addLayout(metro_exe_lay);
+
+  QGroupBox* metro_exemod_box = new QGroupBox;
+  metro_exe_lay->addWidget(metro_exemod_box);
+
+  QHBoxLayout* metro_exemod_lay = new QHBoxLayout;
+  metro_exemod_box->setLayout(metro_exemod_lay);
+
+  // option: go-back to start before stopping
+  QVBoxLayout* metro_exeopt_lay = new QVBoxLayout;
+  metro_exemod_lay->addLayout(metro_exeopt_lay);
+
+  metro_completeAtPosOne_checkbox_ = new QCheckBox("Go back to marker-1 position before completion");
+  metro_exeopt_lay->addWidget(metro_completeAtPosOne_checkbox_);
+
+  // option: go-back to start before stopping
+  metro_useAutoFocusing_checkbox_ = new QCheckBox("Use Auto-Focusing");
+  metro_exeopt_lay->addWidget(metro_useAutoFocusing_checkbox_);
+
+  metro_exemod_lay->addSpacing(20);
+
+  // mode: align object
+  QHBoxLayout* metro_exemetro_lay = new QHBoxLayout;
+  metro_exemod_lay->addLayout(metro_exemetro_lay);
+
+  metro_exemetro_pusbu_ = new QPushButton(tr("Perform Metrology"));
+
+  connect(metro_exemetro_pusbu_, SIGNAL(clicked()), this, SLOT(transmit_configuration()));
+  metro_exemetro_lay->addWidget(metro_exemetro_pusbu_);
+  // ----------
+
+  metro_cfg_lay->addSpacing(50);
+
+  // PatRec Configuration
+  QHBoxLayout* alignm_PR_PSP_cfg_lay = new QHBoxLayout;
+  metro_cfg_lay->addLayout(alignm_PR_PSP_cfg_lay);
+  QHBoxLayout* alignm_PR_PSS_cfg_lay = new QHBoxLayout;
+  metro_cfg_lay->addLayout(alignm_PR_PSS_cfg_lay);
+
+  // PatRecWidget #1
+  QGroupBox* patrecOne_cfg_box = new QGroupBox(tr("PatRec Marker PSp #1 [Bottom-Left Marker]"));
+  patrecOne_cfg_box->setObjectName("patrecOne_cfg_box");
+  patrecOne_cfg_box->setStyleSheet("QWidget#patrecOne_cfg_box { font-weight : bold; color : blue; }");
+
+  patrecOne_wid_ = new AssemblyObjectFinderPatRecWidget;
+  patrecOne_wid_->setToolTip("Pattern Recognition Configuration PSp #1 [Bottom-Left Marker]");
+
+  if(config_ != nullptr)
+  {
+    const std::string fpath = config_->getDefaultValue<std::string>("main", "AssemblyObjectAlignerView_PatRec_PSP1_template_fpath", "");
+    if(fpath != ""){ patrecOne_wid_->load_image_template_from_path(QString::fromStdString(Config::CMSTkModLabBasePath+"/"+fpath)); }
+
+    assembly::QLineEdit_setText(patrecOne_wid_->threshold_lineEdit()        , config_->getDefaultValue<int>("main", "AssemblyObjectAlignerView_PatRec_threshold"        , 100));
+    assembly::QLineEdit_setText(patrecOne_wid_->adaptiveThreshold_lineEdit(), config_->getDefaultValue<int>("main", "AssemblyObjectAlignerView_PatRec_adaptiveThreshold", 587));
+
+    assembly::QLineEdit_setText(patrecOne_wid_->angles_prescan_lineEdit()   , config_->getDefaultValue<double>("main", "AssemblyObjectAlignerView_PatRec_angles_prescan" , 0));
+    assembly::QLineEdit_setText(patrecOne_wid_->angles_finemax_lineEdit()   , config_->getDefaultValue<double>("main", "AssemblyObjectAlignerView_PatRec_angles_finemax" , 2));
+    assembly::QLineEdit_setText(patrecOne_wid_->angles_finestep_lineEdit()  , config_->getDefaultValue<double>("main", "AssemblyObjectAlignerView_PatRec_angles_finestep", 0.2));
+  }
+
+  patrecOne_cfg_box->setLayout(patrecOne_wid_->layout());
+  // -----
+
+  // PatRecWidget #2
+  QGroupBox* patrecTwo_cfg_box = new QGroupBox(tr("PatRec Marker PSp #2 [Top-Right Marker]"));
+  patrecTwo_cfg_box->setObjectName("patrecTwo_cfg_box");
+  patrecTwo_cfg_box->setStyleSheet("QWidget#patrecTwo_cfg_box { font-weight : bold; color : blue; }");
+
+  patrecTwo_wid_ = new AssemblyObjectFinderPatRecWidget;
+  patrecTwo_wid_->setToolTip("Pattern Recognition Configuration PSp #2 [Top-Right Marker]");
+
+  if(config_ != nullptr)
+  {
+    const std::string fpath = config_->getDefaultValue<std::string>("main", "AssemblyObjectAlignerView_PatRec_PSP2_template_fpath", "");
+    if(fpath != ""){ patrecTwo_wid_->load_image_template_from_path(QString::fromStdString(Config::CMSTkModLabBasePath+"/"+fpath)); }
+
+    assembly::QLineEdit_setText(patrecTwo_wid_->threshold_lineEdit()        , config_->getDefaultValue<int>("main", "AssemblyObjectAlignerView_PatRec_threshold"        , 100));
+    assembly::QLineEdit_setText(patrecTwo_wid_->adaptiveThreshold_lineEdit(), config_->getDefaultValue<int>("main", "AssemblyObjectAlignerView_PatRec_adaptiveThreshold", 587));
+
+    assembly::QLineEdit_setText(patrecTwo_wid_->angles_prescan_lineEdit()   , config_->getDefaultValue<double>("main", "AssemblyObjectAlignerView_PatRec_angles_prescan" , 0));
+    assembly::QLineEdit_setText(patrecTwo_wid_->angles_finemax_lineEdit()   , config_->getDefaultValue<double>("main", "AssemblyObjectAlignerView_PatRec_angles_finemax" , 2));
+    assembly::QLineEdit_setText(patrecTwo_wid_->angles_finestep_lineEdit()  , config_->getDefaultValue<double>("main", "AssemblyObjectAlignerView_PatRec_angles_finestep", 0.2));
+  }
+
+  patrecTwo_cfg_box->setLayout(patrecTwo_wid_->layout());
+  // -----
+  // PatRecWidget #3
+  QGroupBox* patrecThree_cfg_box = new QGroupBox(tr("PatRec Marker PSs #1 [Bottom-Left Marker]"));
+  patrecThree_cfg_box->setObjectName("patrecThree_cfg_box");
+  patrecThree_cfg_box->setStyleSheet("QWidget#patrecThree_cfg_box { font-weight : bold; color : blue; }");
+
+  patrecThree_wid_ = new AssemblyObjectFinderPatRecWidget;
+  patrecThree_wid_->setToolTip("Pattern Recognition Configuration PSs #1 [Bottom-Left Marker]");
+
+  if(config_ != nullptr)
+  {
+    const std::string fpath = config_->getDefaultValue<std::string>("main", "AssemblyObjectAlignerView_PatRec_PSS1_template_fpath", "");
+    if(fpath != ""){ patrecThree_wid_->load_image_template_from_path(QString::fromStdString(Config::CMSTkModLabBasePath+"/"+fpath)); }
+
+    assembly::QLineEdit_setText(patrecThree_wid_->threshold_lineEdit()        , config_->getDefaultValue<int>("main", "AssemblyObjectAlignerView_PatRec_threshold"        , 100));
+    assembly::QLineEdit_setText(patrecThree_wid_->adaptiveThreshold_lineEdit(), config_->getDefaultValue<int>("main", "AssemblyObjectAlignerView_PatRec_adaptiveThreshold", 587));
+
+    assembly::QLineEdit_setText(patrecThree_wid_->angles_prescan_lineEdit()   , config_->getDefaultValue<double>("main", "AssemblyObjectAlignerView_PatRec_angles_prescan" , 0));
+    assembly::QLineEdit_setText(patrecThree_wid_->angles_finemax_lineEdit()   , config_->getDefaultValue<double>("main", "AssemblyObjectAlignerView_PatRec_angles_finemax" , 2));
+    assembly::QLineEdit_setText(patrecThree_wid_->angles_finestep_lineEdit()  , config_->getDefaultValue<double>("main", "AssemblyObjectAlignerView_PatRec_angles_finestep", 0.2));
+  }
+
+  patrecThree_cfg_box->setLayout(patrecThree_wid_->layout());
+  // -----
+
+  // PatRecWidget #4
+  QGroupBox* patrecFour_cfg_box = new QGroupBox(tr("PatRec Marker PSs #2 [Top-Right Marker]"));
+  patrecFour_cfg_box->setObjectName("patrecFour_cfg_box");
+  patrecFour_cfg_box->setStyleSheet("QWidget#patrecFour_cfg_box { font-weight : bold; color : blue; }");
+
+  patrecFour_wid_ = new AssemblyObjectFinderPatRecWidget;
+  patrecFour_wid_->setToolTip("Pattern Recognition Configuration PSs #2 [Top-Right Marker]");
+
+  if(config_ != nullptr)
+  {
+    const std::string fpath = config_->getDefaultValue<std::string>("main", "AssemblyObjectAlignerView_PatRec_PSS2_template_fpath", "");
+    if(fpath != ""){ patrecFour_wid_->load_image_template_from_path(QString::fromStdString(Config::CMSTkModLabBasePath+"/"+fpath)); }
+
+    assembly::QLineEdit_setText(patrecFour_wid_->threshold_lineEdit()        , config_->getDefaultValue<int>("main", "AssemblyObjectAlignerView_PatRec_threshold"        , 100));
+    assembly::QLineEdit_setText(patrecFour_wid_->adaptiveThreshold_lineEdit(), config_->getDefaultValue<int>("main", "AssemblyObjectAlignerView_PatRec_adaptiveThreshold", 587));
+
+    assembly::QLineEdit_setText(patrecFour_wid_->angles_prescan_lineEdit()   , config_->getDefaultValue<double>("main", "AssemblyObjectAlignerView_PatRec_angles_prescan" , 0));
+    assembly::QLineEdit_setText(patrecFour_wid_->angles_finemax_lineEdit()   , config_->getDefaultValue<double>("main", "AssemblyObjectAlignerView_PatRec_angles_finemax" , 2));
+    assembly::QLineEdit_setText(patrecFour_wid_->angles_finestep_lineEdit()  , config_->getDefaultValue<double>("main", "AssemblyObjectAlignerView_PatRec_angles_finestep", 0.2));
+  }
+
+  patrecFour_cfg_box->setLayout(patrecFour_wid_->layout());
+  // -----
+
+  alignm_PR_PSP_cfg_lay->addWidget(patrecOne_cfg_box, 50);
+  alignm_PR_PSP_cfg_lay->addWidget(patrecTwo_cfg_box, 50);
+  alignm_PR_PSS_cfg_lay->addWidget(patrecThree_cfg_box, 50);
+  alignm_PR_PSS_cfg_lay->addWidget(patrecFour_cfg_box, 50);
+
+  metro_cfg_lay->addStretch(1);
+  // ----------
+
+  // ---------------------
+
+  // Results -------------
+  metro_res_wid_ = new QWidget;
+  toolbox->addItem(metro_res_wid_, "Metrology Results");
+
+  QVBoxLayout* metro_res_lay = new QVBoxLayout;
+  metro_res_wid_->setLayout(metro_res_lay);
+
+  QHBoxLayout* metro_mesangs_lay = new QHBoxLayout;
+  metro_res_lay->addLayout(metro_mesangs_lay);
+
+  // Numerical Results
+  QHBoxLayout* metro_mesang_PSp_lay = new QHBoxLayout;
+  metro_mesangs_lay->addLayout(metro_mesang_PSp_lay);
+
+  QLabel* metro_mesang_PSp_label = new QLabel("Measured Angle PSp [deg]");
+  metro_mesang_PSp_linee_ = new QLineEdit("");
+  metro_mesang_PSp_linee_->setReadOnly(true);
+
+  metro_mesang_PSp_lay->addWidget(metro_mesang_PSp_label);
+  metro_mesang_PSp_lay->addWidget(metro_mesang_PSp_linee_);
+  metro_mesang_PSp_lay->addWidget(new QLabel);
+
+  metro_mesang_PSp_lay->setStretch(0,  34);
+  metro_mesang_PSp_lay->setStretch(1,  65);
+  metro_mesang_PSp_lay->setStretch(2, 101);
+
+  QHBoxLayout* metro_mesang_PSs_lay = new QHBoxLayout;
+  metro_mesangs_lay->addLayout(metro_mesang_PSs_lay);
+
+  QLabel* metro_mesang_PSs_label = new QLabel("Measured Angle PSs [deg]");
+  metro_mesang_PSs_linee_ = new QLineEdit("");
+  metro_mesang_PSs_linee_->setReadOnly(true);
+
+  metro_mesang_PSs_lay->addWidget(metro_mesang_PSs_label);
+  metro_mesang_PSs_lay->addWidget(metro_mesang_PSs_linee_);
+  metro_mesang_PSs_lay->addWidget(new QLabel);
+
+  metro_mesang_PSs_lay->setStretch(0,  34);
+  metro_mesang_PSs_lay->setStretch(1,  65);
+  metro_mesang_PSs_lay->setStretch(2, 101);
+
+  QVBoxLayout* metro_diff_lay = new QVBoxLayout;
+  metro_res_lay->addLayout(metro_diff_lay);
+
+  QHBoxLayout* metro_dx_lay = new QHBoxLayout;
+  metro_diff_lay->addLayout(metro_dx_lay);
+
+  QLabel* metro_dx_label = new QLabel("Measured dx [mm]");
+  metro_dx_linee_ = new QLineEdit("");
+  metro_dx_linee_->setReadOnly(true);
+
+  metro_dx_lay->addWidget(metro_dx_label);
+  metro_dx_lay->addWidget(metro_dx_linee_);
+  metro_dx_lay->addWidget(new QLabel);
+
+  metro_dx_lay->setStretch(0,  34);
+  metro_dx_lay->setStretch(1,  65);
+  metro_dx_lay->setStretch(2, 101);
+
+  QHBoxLayout* metro_dy_lay = new QHBoxLayout;
+  metro_diff_lay->addLayout(metro_dy_lay);
+
+  QLabel* metro_dy_label = new QLabel("Measured dy [mm]");
+  metro_dy_linee_ = new QLineEdit("");
+  metro_dy_linee_->setReadOnly(true);
+
+  metro_dy_lay->addWidget(metro_dy_label);
+  metro_dy_lay->addWidget(metro_dy_linee_);
+  metro_dy_lay->addWidget(new QLabel);
+
+  metro_dy_lay->setStretch(0,  34);
+  metro_dy_lay->setStretch(1,  65);
+  metro_dy_lay->setStretch(2, 101);
+
+  QHBoxLayout* metro_da_lay = new QHBoxLayout;
+  metro_diff_lay->addLayout(metro_da_lay);
+
+  QLabel* metro_da_label = new QLabel("Measured angle difference [deg]");
+  metro_da_linee_ = new QLineEdit("");
+  metro_da_linee_->setReadOnly(true);
+
+  metro_da_lay->addWidget(metro_da_label);
+  metro_da_lay->addWidget(metro_da_linee_);
+  metro_da_lay->addWidget(new QLabel);
+
+  metro_da_lay->setStretch(0,  34);
+  metro_da_lay->setStretch(1,  65);
+  metro_da_lay->setStretch(2, 101);
+
+
+  // Graphical Results (PatRec Images)
+  QGridLayout* metro_img_lay = new QGridLayout;
+  metro_res_lay->addLayout(metro_img_lay);
+
+  QPalette palette;
+  palette.setColor(QPalette::Window, QColor(220, 220, 220));
+
+  patrecOne_image_ = new AssemblyUEyeView(this);
+  patrecOne_image_->setMinimumSize(200, 200);
+  patrecOne_image_->setPalette(palette);
+  patrecOne_image_->setBackgroundRole(QPalette::Window);
+  patrecOne_image_->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+  patrecOne_image_->setScaledContents(true);
+  patrecOne_image_->setAlignment(Qt::AlignCenter);
+
+  QApplication::processEvents();
+
+  patrecOne_scroll_ = new QScrollArea(this);
+  patrecOne_scroll_->setMinimumSize(200, 200);
+  patrecOne_scroll_->setPalette(palette);
+  patrecOne_scroll_->setBackgroundRole(QPalette::Window);
+  patrecOne_scroll_->setAlignment(Qt::AlignCenter);
+  patrecOne_scroll_->setWidget(patrecOne_image_);
+  patrecOne_scroll_->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+
+  metro_img_lay->addWidget(patrecOne_scroll_, 0, 0);
+
+  patrecTwo_image_ = new AssemblyUEyeView(this);
+  patrecTwo_image_->setMinimumSize(200, 200);
+  patrecTwo_image_->setPalette(palette);
+  patrecTwo_image_->setBackgroundRole(QPalette::Window);
+  patrecTwo_image_->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+  patrecTwo_image_->setScaledContents(true);
+  patrecTwo_image_->setAlignment(Qt::AlignCenter);
+
+  patrecTwo_scroll_ = new QScrollArea(this);
+  patrecTwo_scroll_->setMinimumSize(200, 200);
+  patrecTwo_scroll_->setPalette(palette);
+  patrecTwo_scroll_->setBackgroundRole(QPalette::Window);
+  patrecTwo_scroll_->setAlignment(Qt::AlignCenter);
+  patrecTwo_scroll_->setWidget(patrecTwo_image_);
+  patrecTwo_scroll_->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+
+  metro_img_lay->addWidget(patrecTwo_scroll_, 0, 1);
+
+  patrecThree_image_ = new AssemblyUEyeView(this);
+  patrecThree_image_->setMinimumSize(200, 200);
+  patrecThree_image_->setPalette(palette);
+  patrecThree_image_->setBackgroundRole(QPalette::Window);
+  patrecThree_image_->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+  patrecThree_image_->setScaledContents(true);
+  patrecThree_image_->setAlignment(Qt::AlignCenter);
+
+  patrecThree_scroll_ = new QScrollArea(this);
+  patrecThree_scroll_->setMinimumSize(200, 200);
+  patrecThree_scroll_->setPalette(palette);
+  patrecThree_scroll_->setBackgroundRole(QPalette::Window);
+  patrecThree_scroll_->setAlignment(Qt::AlignCenter);
+  patrecThree_scroll_->setWidget(patrecThree_image_);
+  patrecThree_scroll_->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+
+  metro_img_lay->addWidget(patrecThree_scroll_, 1, 0);
+
+  patrecFour_image_ = new AssemblyUEyeView(this);
+  patrecFour_image_->setMinimumSize(200, 200);
+  patrecFour_image_->setPalette(palette);
+  patrecFour_image_->setBackgroundRole(QPalette::Window);
+  patrecFour_image_->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+  patrecFour_image_->setScaledContents(true);
+  patrecFour_image_->setAlignment(Qt::AlignCenter);
+
+  patrecFour_scroll_ = new QScrollArea(this);
+  patrecFour_scroll_->setMinimumSize(200, 200);
+  patrecFour_scroll_->setPalette(palette);
+  patrecFour_scroll_->setBackgroundRole(QPalette::Window);
+  patrecFour_scroll_->setAlignment(Qt::AlignCenter);
+  patrecFour_scroll_->setWidget(patrecFour_image_);
+  patrecFour_scroll_->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+
+  metro_img_lay->addWidget(patrecFour_scroll_, 1, 1);
+  // ---------------------
+
+  QHBoxLayout* buttons_lay = new QHBoxLayout;
+
+  button_metrologyEmergencyStop_ = new QPushButton(tr("Emergency Stop"));
+
+  buttons_lay->addWidget(new QLabel, 33);
+  buttons_lay->addWidget(new QLabel, 33);
+  buttons_lay->addWidget(button_metrologyEmergencyStop_, 33);
+
+  layout->addLayout(buttons_lay);
+}
+
+
+void MetrologyView::update_templates(const bool checked)
+{
+  QRadioButton* ptr_qedit = qobject_cast<QRadioButton*>(sender());
+  std::string f_path_1;
+  std::string f_path_2;
+  std::string f_path_3;
+  std::string f_path_4;
+
+  f_path_1 = config_->getDefaultValue<std::string>("main", "AssemblyObjectAlignerView_PatRec_PSS1_template_fpath", "");
+  f_path_2 = config_->getDefaultValue<std::string>("main", "AssemblyObjectAlignerView_PatRec_PSS2_template_fpath", "");
+  f_path_3 = config_->getDefaultValue<std::string>("main", "AssemblyObjectAlignerView_PatRec_PSP1_template_fpath", "");
+  f_path_4 = config_->getDefaultValue<std::string>("main", "AssemblyObjectAlignerView_PatRec_PSP2_template_fpath", "");
+
+  patrecOne_wid_->load_image_template_from_path(QString::fromStdString(Config::CMSTkModLabBasePath+"/"+f_path_1));
+  patrecTwo_wid_->load_image_template_from_path(QString::fromStdString(Config::CMSTkModLabBasePath+"/"+f_path_2));
+  patrecThree_wid_->load_image_template_from_path(QString::fromStdString(Config::CMSTkModLabBasePath+"/"+f_path_3));
+  patrecFour_wid_->load_image_template_from_path(QString::fromStdString(Config::CMSTkModLabBasePath+"/"+f_path_4));
+
+  return;
+}
+
+void MetrologyView::transmit_configuration()
+{
+  QMessageBox* msgBox = new QMessageBox;
+  msgBox->setStyleSheet("QLabel{min-width: 300px;}");
+  msgBox->setInformativeText("Are you sure you selected the correct template images and defined the relevant B/W thresholds?");
+  msgBox->setStandardButtons(QMessageBox::Yes | QMessageBox::No);
+  msgBox->setDefaultButton(QMessageBox::Yes);
+  int ret = msgBox->exec();
+  switch(ret)
+  {
+    case QMessageBox::Yes:
+      break;
+    case QMessageBox::No:
+      NQLog("MetrologyView", NQLog::Critical) << "transmit_configuration"
+      << ": abort start of alignment procedure";
+      return;
+    default: return;
+  }
+
+  bool valid_conf(false);
+
+  const auto& conf = this->get_configuration(valid_conf);
+
+  if(valid_conf == false)
+  {
+    NQLog("MetrologyView", NQLog::Critical) << "transmit_configuration"
+       << ": invalid MetrologyView::Configuration object, no action taken";
+
+    return;
+  }
+
+  NQLog("MetrologyView", NQLog::Spam) << "transmit_configuration"
+     << ": emitting signal \"configuration(Metrology::Configuration)\"";
+
+  emit configuration(conf);
+}
+
+
+Metrology::Configuration MetrologyView::get_configuration(bool& valid_conf) const
+{
+  Metrology::Configuration conf;
+
+  // execution option(s)
+  conf.complete_at_position1 = metro_completeAtPosOne_checkbox_->isChecked();
+  conf.use_autofocusing      = metro_useAutoFocusing_checkbox_ ->isChecked();
+
+  /// PatRec #1 --------------------
+  bool valid_PatRecOne_conf(false);
+
+  conf.PatRec_PSP1_configuration = patrecOne_wid_->get_configuration(valid_PatRecOne_conf);
+
+  if(valid_PatRecOne_conf == false)
+  {
+    NQLog("AssemblyObjectAlignerView", NQLog::Critical) << "transmit_configuration"
+       << ": invalid AssemblyObjectFinderPatRec::Configuration object from PatRec Widget #1, no action taken";
+
+    valid_conf = false;
+
+    conf.reset();
+
+    return conf;
+  }
+  /// ------------------------------
+
+  /// PatRec #2 --------------------
+  bool valid_PatRecTwo_conf(false);
+
+  conf.PatRec_PSP2_configuration = patrecTwo_wid_->get_configuration(valid_PatRecTwo_conf);
+
+  if(valid_PatRecTwo_conf == false)
+  {
+    NQLog("AssemblyObjectAlignerView", NQLog::Critical) << "transmit_configuration"
+       << ": invalid AssemblyObjectFinderPatRec::Configuration object from PatRec Widget #2, no action taken";
+
+    valid_conf = false;
+
+    conf.reset();
+
+    return conf;
+  }
+  /// ------------------------------
+
+
+  /// PatRec #3 --------------------
+  bool valid_PatRecThree_conf(false);
+
+  conf.PatRec_PSS1_configuration = patrecThree_wid_->get_configuration(valid_PatRecThree_conf);
+
+  if(valid_PatRecThree_conf == false)
+  {
+      NQLog("AssemblyObjectAlignerView", NQLog::Critical) << "transmit_configuration"
+      << ": invalid AssemblyObjectFinderPatRec::Configuration object from PatRec Widget #1, no action taken";
+
+      valid_conf = false;
+
+      conf.reset();
+
+      return conf;
+  }
+  /// ------------------------------
+
+  /// PatRec #4 --------------------
+  bool valid_PatRecFour_conf(false);
+
+  conf.PatRec_PSS2_configuration = patrecFour_wid_->get_configuration(valid_PatRecFour_conf);
+
+  if(valid_PatRecFour_conf == false)
+  {
+      NQLog("AssemblyObjectAlignerView", NQLog::Critical) << "transmit_configuration"
+         << ": invalid AssemblyObjectFinderPatRec::Configuration object from PatRec Widget #2, no action taken";
+
+      valid_conf = false;
+
+      conf.reset();
+
+      return conf;
+  }
+  /// ------------------------------
+
+  valid_conf = true;
+
+  return conf;
+}
+
+void MetrologyView::show_measured_angle(const bool sensor_PSs, const double val)
+{
+  std::stringstream posi_strs;
+  posi_strs << val;
+
+  if(!sensor_PSs){
+      metro_mesang_PSp_linee_->setText(QString::fromStdString(posi_strs.str()));
+  }else{
+      metro_mesang_PSs_linee_->setText(QString::fromStdString(posi_strs.str()));
+  }
+
+  return;
+}
+
+void MetrologyView::show_results(const double dx, const double dy, const double da)
+{
+  std::stringstream posi_strs_dx;
+  posi_strs_dx << dx;
+  metro_dx_linee_->setText(QString::fromStdString(posi_strs_dx.str()));
+
+  std::stringstream posi_strs_dy;
+  posi_strs_dy << dy;
+  metro_dy_linee_->setText(QString::fromStdString(posi_strs_dy.str()));
+
+  std::stringstream posi_strs_da;
+  posi_strs_da << da;
+  metro_da_linee_->setText(QString::fromStdString(posi_strs_da.str()));
+
+  return;
+}
+
+void MetrologyView::display_infoTab()
+{
+    QMessageBox::information(this, tr("Information - Metrology"),
+            tr("<p>Click 'Perform Metrology' to run the module metrology.</p>"
+            "<p>Make sure to move to the first marker of the PSp beforehand and to set template images for PatRec and B/W thresholds.</p>"
+    ));
+
+    return;
+}
+
+void MetrologyView::updateImage(const int stage, const QString& filename)
+{
+  NQLog("MetrologyView", NQLog::Spam) << "updateImage(" << stage << ", file=" << filename << ")";
+
+  const cv::Mat img = assembly::cv_imread(filename, cv::IMREAD_UNCHANGED);
+
+  this->updateImage(stage, img);
+
+  return;
+}
+
+void MetrologyView::updateImage(const int stage, const cv::Mat& img)
+{
+  NQLog("MetrologyView", NQLog::Spam) << "updateImage(" << stage << ", image)";
+
+  if(stage == 1)
+  {
+    patrecOne_image_->setImage(img);
+//    patrecOne_image_->setZoomFactor(0.3);
+  }
+  else if(stage == 2)
+  {
+    patrecTwo_image_->setImage(img);
+//    patrecTwo_image_->setZoomFactor(0.5);
+  }
+  else if(stage == 3)
+  {
+    patrecThree_image_->setImage(img);
+//    patrecTwo_image_->setZoomFactor(0.5);
+  }
+  else if(stage == 4)
+  {
+    patrecFour_image_->setImage(img);
+//    patrecTwo_image_->setZoomFactor(0.5);
+  }
+
+  return;
+}

--- a/assembly/assemblyCommon/MetrologyView.h
+++ b/assembly/assemblyCommon/MetrologyView.h
@@ -46,6 +46,8 @@ class MetrologyView : public QWidget
 
   AssemblyUEyeView* PatRecOne_Image() const { return patrecOne_image_; }
   AssemblyUEyeView* PatRecTwo_Image() const { return patrecTwo_image_; }
+  AssemblyUEyeView* PatRecThree_Image() const { return patrecThree_image_; }
+  AssemblyUEyeView* PatRecFour_Image() const { return patrecFour_image_; }
 
   QPushButton* button_metrologyEmergencyStop() const { return button_metrologyEmergencyStop_; }
 

--- a/assembly/assemblyCommon/MetrologyView.h
+++ b/assembly/assemblyCommon/MetrologyView.h
@@ -65,7 +65,9 @@ class MetrologyView : public QWidget
   QCheckBox* metro_completeAtPosOne_checkbox_;
   QCheckBox* metro_useAutoFocusing_checkbox_;
 
-  QPushButton*  metro_exemetro_pusbu_;
+  QPushButton* metro_exemetro_pusbu_;
+  QPushButton* metro_goToMarker_pusbu_;
+  QPushButton* metro_enableVacuum_pusbu_;
 
   QLineEdit* alignm_angmax_dontIter_linee_;
   QLineEdit* alignm_angmax_complete_linee_;
@@ -124,11 +126,20 @@ class MetrologyView : public QWidget
 
   void update_templates(const bool);
 
+  void enable_vacuum_on_baseplate();
+
+  void go_to_marker();
+
   void clearResults();
+
+  void updateVacuumChannelState(int, bool);
 
  signals:
 
   void configuration(Metrology::Configuration);
+
+  void enable_vacuum_baseplate(int);
+  void go_to_marker_signal();
 
  };
 

--- a/assembly/assemblyCommon/MetrologyView.h
+++ b/assembly/assemblyCommon/MetrologyView.h
@@ -109,6 +109,7 @@ class MetrologyView : public QWidget
   void transmit_configuration();
 
   void switch_to_results();
+  void switch_to_config();
 
   void show_measured_angle(const bool, const double);
 

--- a/assembly/assemblyCommon/MetrologyView.h
+++ b/assembly/assemblyCommon/MetrologyView.h
@@ -96,6 +96,7 @@ class MetrologyView : public QWidget
   AssemblyUEyeView* patrecFour_image_;
   QScrollArea*      patrecFour_scroll_;
 
+  QPushButton*  button_metrologyClearResults_;
   QPushButton* button_metrologyEmergencyStop_;
 
   bool finder_connected_;
@@ -121,6 +122,8 @@ class MetrologyView : public QWidget
   void updateImage(const int, const cv::Mat&);
 
   void update_templates(const bool);
+
+  void clearResults();
 
  signals:
 

--- a/assembly/assemblyCommon/MetrologyView.h
+++ b/assembly/assemblyCommon/MetrologyView.h
@@ -80,6 +80,7 @@ class MetrologyView : public QWidget
   QLineEdit* metro_dx_corr_linee_;
   QLineEdit* metro_dy_linee_;
   QLineEdit* metro_dy_corr_linee_;
+  QLineEdit* metro_dz_linee_;
   QLineEdit* metro_da_deg_linee_;
   QLineEdit* metro_da_urad_linee_;
 
@@ -111,7 +112,7 @@ class MetrologyView : public QWidget
 
   void show_measured_angle(const bool, const double);
 
-  void show_results(const double, const double, const double, const double, const double, const double);
+  void show_results(const double, const double, const double, const double, const double, const double, const double);
 
   void display_infoTab();
 

--- a/assembly/assemblyCommon/MetrologyView.h
+++ b/assembly/assemblyCommon/MetrologyView.h
@@ -1,0 +1,117 @@
+/////////////////////////////////////////////////////////////////////////////////
+//                                                                             //
+//               Copyright (C) 2011-2023 - The DESY CMS Group                  //
+//                           All rights reserved                               //
+//                                                                             //
+//      The CMStkModLab source code is licensed under the GNU GPL v3.0.        //
+//      You have the right to modify and/or redistribute this source code      //
+//      under the terms specified in the license, which may be found online    //
+//      at http://www.gnu.org/licenses or at License.txt.                      //
+//                                                                             //
+/////////////////////////////////////////////////////////////////////////////////
+
+#ifndef METROLOGYVIEW_H
+#define METROLOGYVIEW_H
+
+#include <AssemblyUEyeView.h>
+#include <AssemblyObjectFinderPatRecWidget.h>
+#include <ApplicationConfig.h>
+#include <Metrology.h>
+
+#include <QWidget>
+#include <QString>
+#include <QScrollArea>
+#include <QKeyEvent>
+#include <QCheckBox>
+#include <QRadioButton>
+#include <QPushButton>
+#include <QLineEdit>
+
+#include <opencv2/opencv.hpp>
+
+class MetrologyView : public QWidget
+{
+ Q_OBJECT
+
+ public:
+
+  explicit MetrologyView(QWidget* parent=nullptr);
+  virtual ~MetrologyView() {}
+
+  QWidget* Configuration_Widget() const { return metro_cfg_wid_; }
+  QWidget* Results_Widget()       const { return metro_res_wid_; }
+
+  AssemblyObjectFinderPatRecWidget* PatRecOne_Widget() const { return patrecOne_wid_; }
+  AssemblyObjectFinderPatRecWidget* PatRecTwo_Widget() const { return patrecTwo_wid_; }
+
+  AssemblyUEyeView* PatRecOne_Image() const { return patrecOne_image_; }
+  AssemblyUEyeView* PatRecTwo_Image() const { return patrecTwo_image_; }
+
+  QPushButton* button_metrologyEmergencyStop() const { return button_metrologyEmergencyStop_; }
+
+  Metrology::Configuration get_configuration(bool&) const;
+
+ protected:
+
+  QWidget* metro_cfg_wid_;
+  QWidget* metro_res_wid_;
+
+  QCheckBox* metro_completeAtPosOne_checkbox_;
+  QCheckBox* metro_useAutoFocusing_checkbox_;
+
+  QPushButton*  metro_exemetro_pusbu_;
+
+  QLineEdit* alignm_angmax_dontIter_linee_;
+  QLineEdit* alignm_angmax_complete_linee_;
+
+  AssemblyObjectFinderPatRecWidget* patrecOne_wid_;
+  AssemblyObjectFinderPatRecWidget* patrecTwo_wid_;
+  AssemblyObjectFinderPatRecWidget* patrecThree_wid_;
+  AssemblyObjectFinderPatRecWidget* patrecFour_wid_;
+
+  QLineEdit* metro_mesang_PSp_linee_;
+  QLineEdit* metro_mesang_PSs_linee_;
+  QLineEdit* metro_dx_linee_;
+  QLineEdit* metro_dy_linee_;
+  QLineEdit* metro_da_linee_;
+
+  AssemblyUEyeView* patrecOne_image_;
+  QScrollArea*      patrecOne_scroll_;
+
+  AssemblyUEyeView* patrecTwo_image_;
+  QScrollArea*      patrecTwo_scroll_;
+
+  AssemblyUEyeView* patrecThree_image_;
+  QScrollArea*      patrecThree_scroll_;
+
+  AssemblyUEyeView* patrecFour_image_;
+  QScrollArea*      patrecFour_scroll_;
+
+  QPushButton* button_metrologyEmergencyStop_;
+
+  bool finder_connected_;
+
+  ApplicationConfig* config_;
+
+ public slots:
+
+  void transmit_configuration();
+
+  void show_measured_angle(const bool, const double);
+
+  void show_results(const double, const double, const double);
+
+  void display_infoTab();
+
+  void updateImage(const int, const QString&);
+  void updateImage(const int, const cv::Mat&);
+
+  void update_templates(const bool);
+
+ signals:
+
+  void configuration(Metrology::Configuration);
+
+ };
+
+#endif // METROLOGYVIEW_H

--- a/assembly/assemblyCommon/MetrologyView.h
+++ b/assembly/assemblyCommon/MetrologyView.h
@@ -77,8 +77,11 @@ class MetrologyView : public QWidget
   QLineEdit* metro_mesang_PSp_linee_;
   QLineEdit* metro_mesang_PSs_linee_;
   QLineEdit* metro_dx_linee_;
+  QLineEdit* metro_dx_corr_linee_;
   QLineEdit* metro_dy_linee_;
-  QLineEdit* metro_da_linee_;
+  QLineEdit* metro_dy_corr_linee_;
+  QLineEdit* metro_da_deg_linee_;
+  QLineEdit* metro_da_urad_linee_;
 
   AssemblyUEyeView* patrecOne_image_;
   QScrollArea*      patrecOne_scroll_;
@@ -108,7 +111,7 @@ class MetrologyView : public QWidget
 
   void show_measured_angle(const bool, const double);
 
-  void show_results(const double, const double, const double);
+  void show_results(const double, const double, const double, const double, const double, const double);
 
   void display_infoTab();
 

--- a/assembly/assemblyCommon/MetrologyView.h
+++ b/assembly/assemblyCommon/MetrologyView.h
@@ -50,6 +50,7 @@ class MetrologyView : public QWidget
   AssemblyUEyeView* PatRecThree_Image() const { return patrecThree_image_; }
   AssemblyUEyeView* PatRecFour_Image() const { return patrecFour_image_; }
 
+  QPushButton* button_metrologyClearResults() const { return button_metrologyClearResults_; }
   QPushButton* button_metrologyEmergencyStop() const { return button_metrologyEmergencyStop_; }
 
   Metrology::Configuration get_configuration(bool&) const;

--- a/assembly/assemblyCommon/MetrologyView.h
+++ b/assembly/assemblyCommon/MetrologyView.h
@@ -18,6 +18,7 @@
 #include <ApplicationConfig.h>
 #include <Metrology.h>
 
+#include <QToolBox>
 #include <QWidget>
 #include <QString>
 #include <QScrollArea>
@@ -54,6 +55,8 @@ class MetrologyView : public QWidget
   Metrology::Configuration get_configuration(bool&) const;
 
  protected:
+
+  QToolBox* toolbox_;
 
   QWidget* metro_cfg_wid_;
   QWidget* metro_res_wid_;
@@ -93,11 +96,15 @@ class MetrologyView : public QWidget
 
   bool finder_connected_;
 
+  int idx_cfg_wid_, idx_results_wid_;
+
   ApplicationConfig* config_;
 
  public slots:
 
   void transmit_configuration();
+
+  void switch_to_results();
 
   void show_measured_angle(const bool, const double);
 

--- a/common/nqlogger.cc
+++ b/common/nqlogger.cc
@@ -25,12 +25,12 @@
 
 #include "nqlogger.h"
 
-NQLog::NQLog(const QString& module, LogLevel level)
+NQLog::NQLog(const QString& module, LogLevel level, int precision)
 : module_(module),
   level_(level),
   stream_(&buffer_)
 {
-
+  stream_.setRealNumberPrecision(precision);
 }
 
 NQLog::~NQLog()

--- a/common/nqlogger.h
+++ b/common/nqlogger.h
@@ -47,7 +47,7 @@ public:
         Fatal       = 5
     };
 
-    NQLog(const QString& module, LogLevel level = Message);
+    NQLog(const QString& module, LogLevel level = Message, int precision = 6);
     ~NQLog();
 
     inline NQLog &operator<<(QChar t) { stream_ << '\'' << t << '\''; return *this;}


### PR DESCRIPTION
This adds a light-weight metrology for fully assembled modules.

There's a new tab in the main window called "Metrology". The usual settings are available there, similar to the alignment routine. The metrology needs to be started at the position of the top-left PSp fiducial marker, which should be located around the "RefMarker" position. I suggest to furthermore enable the vacuum on the baseplate. Hence, I added two buttons to a) move to the initial position and b) to enable the vacuum on the baseplate.

Then the SW performs pattern recognitions on the four top markers and calculates the following quantities:

- dx/dy: (position_PSs_top_left_marker - position_PSp_top_left_marker) in both x and y
- dx/dy corrected: the upper value, corrected for the target (configuration parameter) offset between the two markers
- PSp/PSs angle: angle of PSp and PSs in the stage coordinate system
- Angle between PSp and PSs: the difference between the above

One could consider using all four markers for better statistics, but this would require to also create and load templates for the bottom markers. For a first check of the alignment, the part implemented here should be ok.