### PR TITLE
Smart Move upwards

### DIFF
--- a/assembly/assemblyCommon/AssemblyAssemblyV2.cc
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2.cc
@@ -728,8 +728,13 @@ void AssemblyAssemblyV2::PickupMaPSA_start()
     return;
   }
 
-  connect(this, SIGNAL(move_relative_request(double, double, double, double)), motion_, SLOT(moveRelative(double, double, double, double)));
-  connect(motion_, SIGNAL(motion_finished()), this, SLOT(PickupMaPSA_finish()));
+  if(use_smartMove_) {
+      connect(this, SIGNAL(move_relative_request(double, double, double, double)), smart_motion_, SLOT(move_relative(double, double, double, double)));
+      connect(smart_motion_, SIGNAL(motion_completed()), this, SLOT(PickupMaPSA_finish()));
+  } else {
+      connect(this, SIGNAL(move_relative_request(double, double, double, double)), motion_, SLOT(moveRelative(double, double, double, double)));
+      connect(motion_, SIGNAL(motion_finished()), this, SLOT(PickupMaPSA_finish()));
+  }
 
   in_action_ = true;
 
@@ -741,8 +746,13 @@ void AssemblyAssemblyV2::PickupMaPSA_start()
 
 void AssemblyAssemblyV2::PickupMaPSA_finish()
 {
-  disconnect(this, SIGNAL(move_relative_request(double, double, double, double)), motion_, SLOT(moveRelative(double, double, double, double)));
-  disconnect(motion_, SIGNAL(motion_finished()), this, SLOT(PickupMaPSA_finish()));
+  if(use_smartMove_) {
+      disconnect(this, SIGNAL(move_relative_request(double, double, double, double)), smart_motion_, SLOT(move_relative(double, double, double, double)));
+      disconnect(smart_motion_, SIGNAL(motion_completed()), this, SLOT(PickupMaPSA_finish()));
+  } else {
+      disconnect(this, SIGNAL(move_relative_request(double, double, double, double)), motion_, SLOT(moveRelative(double, double, double, double)));
+      disconnect(motion_, SIGNAL(motion_finished()), this, SLOT(PickupMaPSA_finish()));
+  }
 
   if(in_action_){ in_action_ = false; }
 
@@ -787,8 +797,13 @@ void AssemblyAssemblyV2::PickupPSS_start()
     return;
   }
 
-  connect(this, SIGNAL(move_relative_request(double, double, double, double)), motion_, SLOT(moveRelative(double, double, double, double)));
-  connect(motion_, SIGNAL(motion_finished()), this, SLOT(PickupPSS_finish()));
+  if(use_smartMove_) {
+      connect(this, SIGNAL(move_relative_request(double, double, double, double)), smart_motion_, SLOT(move_relative(double, double, double, double)));
+      connect(smart_motion_, SIGNAL(motion_completed()), this, SLOT(PickupPSS_finish()));
+  } else {
+      connect(this, SIGNAL(move_relative_request(double, double, double, double)), motion_, SLOT(moveRelative(double, double, double, double)));
+      connect(motion_, SIGNAL(motion_finished()), this, SLOT(PickupPSS_finish()));
+  }
 
   in_action_ = true;
 
@@ -800,8 +815,13 @@ void AssemblyAssemblyV2::PickupPSS_start()
 
 void AssemblyAssemblyV2::PickupPSS_finish()
 {
-  disconnect(this, SIGNAL(move_relative_request(double, double, double, double)), motion_, SLOT(moveRelative(double, double, double, double)));
-  disconnect(motion_, SIGNAL(motion_finished()), this, SLOT(PickupPSS_finish()));
+  if(use_smartMove_) {
+      disconnect(this, SIGNAL(move_relative_request(double, double, double, double)), smart_motion_, SLOT(move_relative(double, double, double, double)));
+      disconnect(smart_motion_, SIGNAL(motion_completed()), this, SLOT(PickupPSS_finish()));
+  } else {
+      disconnect(this, SIGNAL(move_relative_request(double, double, double, double)), motion_, SLOT(moveRelative(double, double, double, double)));
+      disconnect(motion_, SIGNAL(motion_finished()), this, SLOT(PickupPSS_finish()));
+  }
 
   if(in_action_){ in_action_ = false; }
 
@@ -1676,8 +1696,13 @@ void AssemblyAssemblyV2::PickupPSSPlusSpacers_start()
     return;
   }
 
-  connect(this, SIGNAL(move_relative_request(double, double, double, double)), motion_, SLOT(moveRelative(double, double, double, double)));
-  connect(motion_, SIGNAL(motion_finished()), this, SLOT(PickupPSSPlusSpacers_finish()));
+  if(use_smartMove_){
+      connect(this, SIGNAL(move_relative_request(double, double, double, double)), smart_motion_, SLOT(move_relative(double, double, double, double)));
+      connect(smart_motion_, SIGNAL(motion_completed()), this, SLOT(PickupPSSPlusSpacers_finish()));
+  } else {
+      connect(this, SIGNAL(move_relative_request(double, double, double, double)), motion_, SLOT(moveRelative(double, double, double, double)));
+      connect(motion_, SIGNAL(motion_finished()), this, SLOT(PickupPSSPlusSpacers_finish()));
+  }
 
   in_action_ = true;
 
@@ -1689,8 +1714,13 @@ void AssemblyAssemblyV2::PickupPSSPlusSpacers_start()
 
 void AssemblyAssemblyV2::PickupPSSPlusSpacers_finish()
 {
-  disconnect(this, SIGNAL(move_relative_request(double, double, double, double)), motion_, SLOT(moveRelative(double, double, double, double)));
-  disconnect(motion_, SIGNAL(motion_finished()), this, SLOT(PickupPSSPlusSpacers_finish()));
+  if(use_smartMove_){
+      disconnect(this, SIGNAL(move_relative_request(double, double, double, double)), smart_motion_, SLOT(move_relative(double, double, double, double)));
+      disconnect(smart_motion_, SIGNAL(motion_completed()), this, SLOT(PickupPSSPlusSpacers_finish()));
+  } else {
+      disconnect(this, SIGNAL(move_relative_request(double, double, double, double)), motion_, SLOT(moveRelative(double, double, double, double)));
+      disconnect(motion_, SIGNAL(motion_finished()), this, SLOT(PickupPSSPlusSpacers_finish()));
+  }
 
   if(in_action_){ in_action_ = false; }
 

--- a/assembly/assemblyCommon/AssemblySmartMotionManager.cc
+++ b/assembly/assemblyCommon/AssemblySmartMotionManager.cc
@@ -253,7 +253,10 @@ QQueue<LStepExpressMotion> AssemblySmartMotionManager::smartMotions_relative(con
     motions.enqueue(LStepExpressMotion(0, 0, initial_dZ, 0, false));
     motions.enqueue(LStepExpressMotion(0, 0, dz-initial_dZ, 0, false));
 
-    if(move_xya){ motions.enqueue(LStepExpressMotion(dx, dy, 0, da, false)); }
+    if(move_xya){
+      smart_motions_N = 2;
+      motions.enqueue(LStepExpressMotion(dx, dy, 0, da, false));
+    }
   }
   else
   {

--- a/assembly/assemblyCommon/AssemblySmartMotionManager.cc
+++ b/assembly/assemblyCommon/AssemblySmartMotionManager.cc
@@ -28,6 +28,8 @@ AssemblySmartMotionManager::AssemblySmartMotionManager(const LStepExpressMotionM
  , motion_manager_enabled_(false)
  , motion_index_(-1)
 
+ , smartMove_initial_step_up_dZ_(0.)
+
  , smartMotions_N_(0)
 {
   if(motion_manager_ == nullptr)
@@ -81,6 +83,9 @@ AssemblySmartMotionManager::AssemblySmartMotionManager(const LStepExpressMotionM
 
   NQLog("AssemblySmartMotionManager", NQLog::Message)
      << "loaded " << smartMove_steps_dZ_.size() << " smartMove steps (\"" << smartMove_steps_dZ_str << "\")";
+
+  smartMove_initial_step_up_dZ_ = config->getDefaultValue<double>("main", "AssemblySmartMotionManager_initial_step_up_dZ", 1.0);
+
   // -----------------------
 
   NQLog("AssemblySmartMotionManager", NQLog::Debug) << "constructed";
@@ -156,7 +161,7 @@ void AssemblySmartMotionManager::move_relative(const double dx0, const double dy
     return;
   }
 
-  motions_ = this->smartMotions_relative(dx0, dy0, dz0, da0, smartMove_steps_dZ_, smartMotions_N_);
+  motions_ = this->smartMotions_relative(dx0, dy0, dz0, da0, smartMove_steps_dZ_, smartMotions_N_, smartMove_initial_step_up_dZ_);
 
   this->connect_motion_manager();
 
@@ -234,7 +239,7 @@ void AssemblySmartMotionManager::smartMove_window(const LStepExpressMotion& moti
   }
 }
 
-QQueue<LStepExpressMotion> AssemblySmartMotionManager::smartMotions_relative(const double dx, const double dy, const double dz, const double da, const std::vector<double>& dz_steps, int& smart_motions_N)
+QQueue<LStepExpressMotion> AssemblySmartMotionManager::smartMotions_relative(const double dx, const double dy, const double dz, const double da, const std::vector<double>& dz_steps, int& smart_motions_N, const double initial_dZ)
 {
   QQueue<LStepExpressMotion> motions;
 
@@ -244,7 +249,9 @@ QQueue<LStepExpressMotion> AssemblySmartMotionManager::smartMotions_relative(con
 
   if(dz > 0.)
   {
-    motions.enqueue(LStepExpressMotion(0, 0, dz, 0, false));
+    smart_motions_N = 1;
+    motions.enqueue(LStepExpressMotion(0, 0, initial_dZ, 0, false));
+    motions.enqueue(LStepExpressMotion(0, 0, dz-initial_dZ, 0, false));
 
     if(move_xya){ motions.enqueue(LStepExpressMotion(dx, dy, 0, da, false)); }
   }

--- a/assembly/assemblyCommon/AssemblySmartMotionManager.h
+++ b/assembly/assemblyCommon/AssemblySmartMotionManager.h
@@ -29,7 +29,7 @@ class AssemblySmartMotionManager : public QObject
   explicit AssemblySmartMotionManager(const LStepExpressMotionManager* const, QObject* parent=nullptr);
   virtual ~AssemblySmartMotionManager() {}
 
-  static QQueue<LStepExpressMotion> smartMotions_relative(const double, const double, const double, const double, const std::vector<double>&, int&);
+  static QQueue<LStepExpressMotion> smartMotions_relative(const double, const double, const double, const double, const std::vector<double>&, int&, const double);
 
  protected:
 
@@ -42,6 +42,8 @@ class AssemblySmartMotionManager : public QObject
   int smartMotions_N_;
 
   std::vector<double> smartMove_steps_dZ_;
+
+  double smartMove_initial_step_up_dZ_;
 
   QQueue<LStepExpressMotion> motions_;
 

--- a/assembly/assembly_SiDummyPS.cfg
+++ b/assembly/assembly_SiDummyPS.cfg
@@ -90,6 +90,7 @@ AssemblyObjectAlignerView_PatRec_PSS2_template_fpath    share/assembly/SiDummyPS
 
 # AssemblySmartMotionManager
 AssemblySmartMotionManager_steps_dZ   0.5,0.5,0.2,0.2,0.2,0.2,0.1,0.05,0.05
+AssemblySmartMotionManager_initial_step_up_dZ   1.0
 
 # AssemblyAssembly
 AssemblyAssembly_pickup1_Z                         130.0

--- a/assembly/assembly_glass.cfg
+++ b/assembly/assembly_glass.cfg
@@ -91,6 +91,7 @@ AssemblyObjectAlignerView_PatRec_PSS2_template_fpath    share/assembly/markedgla
 
 # AssemblySmartMotionManager
 AssemblySmartMotionManager_steps_dZ   0.5,0.5,0.2,0.2,0.2,0.2,0.1,0.05,0.05
+AssemblySmartMotionManager_initial_step_up_dZ   1.0
 
 # AssemblyAssembly
 AssemblyAssembly_pickup1_Z                         130.0


### PR DESCRIPTION
Current status: `Smart Move` contains two protection mechanisms:
-  When lowering objects onto other objects or the glue bath, the last configurable bit (default: 1 mm) of the motion is separated into incremental steps, and a visual inspection is possible before confirming the next step
- When moving in XYA **and** Z, the Z-motion is done before or after the XYA motion, depending on wheter the motion is directed up- or downwards. This prevents crashing into objects that are in the direct path of the pickup tool

New: When we pick up things from the assembly platform, a first step of a configurable distance is performed upwards, then the user is asked on whether to proceed with the rest of the step. This is only the case at the following steps of the assembly: pick up MaPSA, pick up PSS, pick up PSS+spacers, raise spacers from glue bath.

The configuration parameter is called `AssemblySmartMotionManager_initial_step_up_dZ` , belongs to the main configuration file (not the parameter file) and defaults to 1 mm.