### PR TITLE
Pick up PSS+Spacers subassembly

### DIFF
--- a/assembly/assembly/AssemblyMainWindow.cc
+++ b/assembly/assembly/AssemblyMainWindow.cc
@@ -434,7 +434,10 @@ AssemblyMainWindow::AssemblyMainWindow(const QString& outputdir_path, const QStr
     // TOOLBOX VIEW --------------------------------------------
     const QString tabname_Toolbox("Toolbox");
 
-    toolbox_view_ = new AssemblyToolboxView(motion_manager_, controls_tab);
+    subassembly_pickup_ = new AssemblySubassemblyPickup(motion_manager_, relayCardManager_, smart_motion_);
+
+
+    toolbox_view_ = new AssemblyToolboxView(motion_manager_, subassembly_pickup_, controls_tab);
     controls_tab->addTab(toolbox_view_, tabname_Toolbox);
 
     // multi-pickup tester

--- a/assembly/assembly/AssemblyMainWindow.cc
+++ b/assembly/assembly/AssemblyMainWindow.cc
@@ -436,6 +436,7 @@ AssemblyMainWindow::AssemblyMainWindow(const QString& outputdir_path, const QStr
 
     subassembly_pickup_ = new AssemblySubassemblyPickup(motion_manager_, relayCardManager_, smart_motion_);
 
+    connect(subassembly_pickup_, SIGNAL(switchToAlignmentTab_PSS_request()), this, SLOT(update_alignment_tab_pss()));
 
     toolbox_view_ = new AssemblyToolboxView(motion_manager_, subassembly_pickup_, controls_tab);
     controls_tab->addTab(toolbox_view_, tabname_Toolbox);
@@ -616,8 +617,8 @@ AssemblyMainWindow::AssemblyMainWindow(const QString& outputdir_path, const QStr
 
     main_tab->setTabPosition(QTabWidget::North);
 
-    main_tab->addTab(assembly_tab, tr("Module Assembly"));
-    main_tab->addTab(controls_tab, tr("Manual Controls and Parameters"));
+    idx_module_tab = main_tab->addTab(assembly_tab, tr("Module Assembly"));
+    idx_manual_tab = main_tab->addTab(controls_tab, tr("Manual Controls and Parameters"));
 
     assembly_tab->setStyleSheet(assembly_tab->styleSheet()+" QTabBar::tab {width: 300px; }");
     controls_tab->setStyleSheet(controls_tab->styleSheet()+" QTabBar::tab {width: 375px; }");
@@ -1147,6 +1148,7 @@ void AssemblyMainWindow::disconnect_otherSlots()
     disconnect(motion_manager_, SIGNAL(restartMotionStage_request()), this, SLOT(messageBox_restartMotionStage()));
     disconnect(assemblyV2_, SIGNAL(switchToAlignmentTab_PSP_request()), this, SLOT(update_alignment_tab_psp()));
     disconnect(assemblyV2_, SIGNAL(switchToAlignmentTab_PSS_request()), this, SLOT(update_alignment_tab_pss()));
+    disconnect(subassembly_pickup_, SIGNAL(switchToAlignmentTab_PSS_request()), this, SLOT(update_alignment_tab_pss()));
     disconnect(this, SIGNAL(set_alignmentMode_PSP_request()), aligner_view_, SLOT(set_alignmentMode_PSP()));
     disconnect(this, SIGNAL(set_alignmentMode_PSS_request()), aligner_view_, SLOT(set_alignmentMode_PSS()));
 
@@ -1251,6 +1253,8 @@ void AssemblyMainWindow::switchAndUpdate_alignment_tab(bool psp_mode)
 {
     // std::cout<<"There are "<<main_tab->count()<<" main tabs"<<std::endl; //Count main tabs
     // QTabWidget* assemblyTab = main_tab->findChild<QTabWidget*>("Module Assembly");
+    main_tab->setCurrentIndex(idx_module_tab);
+
     QList<QTabWidget*> widgets = main_tab->findChildren<QTabWidget*>(); //Get main tabs
     QTabWidget* assemblyTab = widgets[1]; //Get 'Module Assembly' main tab
     // std::cout<<"There are "<<assemblyTab->count()<<" sub-tabs"<<std::endl; //Count sub-tabs

--- a/assembly/assembly/AssemblyMainWindow.h
+++ b/assembly/assembly/AssemblyMainWindow.h
@@ -244,6 +244,8 @@ class AssemblyMainWindow : public QMainWindow
   QTimer* liveTimer_;
 
   int idx_alignment_tab;
+  int idx_module_tab;
+  int idx_manual_tab;
 };
 
 #endif // ASSEMBLYMAINWINDOW_H

--- a/assembly/assembly/AssemblyMainWindow.h
+++ b/assembly/assembly/AssemblyMainWindow.h
@@ -199,6 +199,7 @@ class AssemblyMainWindow : public QMainWindow
   AssemblyAssembly*           assembly_;
   AssemblyAssemblyV2*         assemblyV2_;
   AssemblyMultiPickupTester*  multipickup_tester_;
+  AssemblySubassemblyPickup*  subassembly_pickup_;
 
   AssemblyObjectFinderPatRec*       finder_;
   AssemblyObjectFinderPatRecThread* finder_thread_;

--- a/assembly/assemblyCommon/AssemblySubassemblyPickup.cc
+++ b/assembly/assemblyCommon/AssemblySubassemblyPickup.cc
@@ -12,32 +12,48 @@
 
 #include <nqlogger.h>
 #include <ApplicationConfig.h>
+#include <AssemblyUtilities.h>
 
 #include <AssemblySubassemblyPickup.h>
 
-AssemblySubassemblyPickup::AssemblySubassemblyPickup(const LStepExpressMotionManager* motion_manager, QObject* parent)
+AssemblySubassemblyPickup::AssemblySubassemblyPickup(const LStepExpressMotionManager* const motion, const RelayCardManager* const vacuum, const AssemblySmartMotionManager* const smart_motion, QObject* parent)
  : QObject(parent)
 
- , motion_manager_(motion_manager)
- , motion_manager_enabled_(false)
+  , motion_(motion)
+  , vacuum_(vacuum)
+  , smart_motion_(smart_motion)
+  , config_(nullptr)
+
+  , vacuum_pickup_(0)
+  , vacuum_spacer_(0)
+  , vacuum_basepl_(0)
+
+  , use_smartMove_(false)
+  , in_action_(false)
 {
-  if(motion_manager_ == nullptr)
-  {
-    NQLog("AssemblySubassemblyPickup", NQLog::Critical) << "input error"
-       << ": null pointer to LStepExpressMotionManager object, initialization stopped";
+    // validate pointers to controllers
+    this->motion();
+    this->vacuum();
 
-    return;
-  }
+    // indices of vacuum lines
+    config_ = ApplicationConfig::instance();
+    if(config_ == nullptr)
+    {
+      NQLog("AssemblySubassemblyPickup", NQLog::Fatal)
+         << "ApplicationConfig::instance() not initialized (null pointer), stopped constructor";
 
-  ApplicationConfig* config = ApplicationConfig::instance();
-  if(config == nullptr)
-  {
-    NQLog("AssemblySubassemblyPickup", NQLog::Fatal)
-       << "ApplicationConfig::instance() not initialized (null pointer), stopped constructor";
+      assembly::kill_application(tr("[AssemblySubassemblyPickup]"), tr("ApplicationConfig::instance() not initialized (null pointer), closing application"));
+    }
 
-    return;
-  }
+    vacuum_pickup_ = config_->getValue<int>("main", "Vacuum_PickupTool");
+    vacuum_spacer_ = config_->getValue<int>("main", "Vacuum_Spacers");
+    vacuum_basepl_ = config_->getValue<int>("main", "Vacuum_Baseplate");
 
+    alreadyClicked_LowerPickupToolOntoSubassembly = false;
+
+    // absolute Z-position of motion stage for pickup of object after gluing
+    // (1: PSs to Spacers)
+    pickup1_Z_ = config_->getValue<double>("main", "AssemblyAssembly_pickup1_Z");
 
   this->reset();
 
@@ -48,42 +64,500 @@ AssemblySubassemblyPickup::~AssemblySubassemblyPickup()
 {
 }
 
-void AssemblySubassemblyPickup::enable_motion_manager(const bool arg)
+const LStepExpressMotionManager* AssemblySubassemblyPickup::motion() const
 {
-  if(arg == motion_manager_enabled_)
+  if(motion_ == nullptr)
   {
-    NQLog("AssemblySubassemblyPickup", NQLog::Debug) << "enable_motion_manager(" << arg << ")"
-       << ": motion-manager for multi-pickup test already " << (arg ? "enabled" : "disabled") << ", no action taken";
+    NQLog("AssemblySubassemblyPickup", NQLog::Fatal) << "motion"
+       << ": pointer to LStepExpressMotionManager is NULL, exiting constructor";
 
-    return;
+    assembly::kill_application(tr("[AssemblySubassemblyPickup]"), tr("pointer to LStepExpressMotionManager is NULL, aborting"));
   }
 
-  if(arg)
+  return motion_;
+}
+
+const RelayCardManager* AssemblySubassemblyPickup::vacuum() const
+{
+  if(motion_ == nullptr)
   {
-    connect(this, SIGNAL(move_relative(double, double, double, double)), motion_manager_, SLOT(moveRelative(double, double, double, double)));
-    connect(motion_manager_, SIGNAL(motion_finished()), this, SLOT(setup_next_step()));
+    NQLog("AssemblySubassemblyPickup", NQLog::Fatal) << "vacuum"
+       << ": pointer to RelayCardManager is NULL, exiting constructor";
 
-    motion_manager_enabled_ = true;
+    assembly::kill_application(tr("[AssemblySubassemblyPickup]"), tr("pointer to RelayCardManager is NULL, aborting"));
+  }
 
-    NQLog("AssemblySubassemblyPickup", NQLog::Spam) << "enable_motion_manager(" << arg << ")"
-       << ": motion-manager for multi-pickup test enabled";
+  return vacuum_;
+}
+
+void AssemblySubassemblyPickup::use_smartMove(const int state)
+{
+  if(state == 2)
+  {
+    if(smart_motion_ == nullptr)
+    {
+      NQLog("AssemblySubassemblyPickup", NQLog::Warning) << "use_smartMove(" << state << ")"
+         << ": attempting to enable \"smartMove\" mode, but pointer to AssemblySmartMotionManager is invalid (NULL), \"smartMove\" mode will stay disabled";
+
+      use_smartMove_ = false;
+    }
+    else
+    {
+      NQLog("AssemblySubassemblyPickup", NQLog::Message) << "use_smartMove(" << state << ")"
+         << ": \"smartMove\" mode switched ON";
+
+      use_smartMove_ = true;
+    }
+  }
+  else if(state == 0)
+  {
+    NQLog("AssemblySubassemblyPickup", NQLog::Message) << "use_smartMove(" << state << ")"
+       << ": \"smartMove\" mode switched OFF";
+
+    use_smartMove_ = false;
   }
   else
   {
-    disconnect(this, SIGNAL(move_relative(double, double, double, double)), motion_manager_, SLOT(moveRelative(double, double, double, double)));
-    disconnect(motion_manager_, SIGNAL(motion_finished()), this, SLOT(setup_next_step()));
-
-    motion_manager_enabled_ = false;
-
-    NQLog("AssemblySubassemblyPickup", NQLog::Spam) << "enable_motion_manager(" << arg << ")"
-       << ": motion-manager for multi-pickup test disabled";
+    NQLog("AssemblySubassemblyPickup", NQLog::Warning) << "use_smartMove(" << state << ")"
+       << ": invalid argument (state=" << state << "), no action taken (smartMove=" << use_smartMove_ << ")";
   }
 
   return;
 }
+// ----------------------------------------------------------------------------------------------------
 
 void AssemblySubassemblyPickup::reset()
 {
 
-  this->disconnect_motion_manager();
 }
+
+// ----------------------------------------------------------------------------------------------------
+// GoToSensorMarkerPreAlignment -----------------------------------------------------------------------
+// ----------------------------------------------------------------------------------------------------
+void AssemblySubassemblyPickup::GoToSensorMarkerPreAlignment_start()
+{
+  if(in_action_){
+
+    NQLog("AssemblySubassemblyPickup", NQLog::Warning) << "GoToSensorMarkerPreAlignment_start"
+       << ": logic error, an assembly step is still in progress, will not take further action";
+
+    return;
+  }
+
+  const double x0 =
+     config_->getValue<double>("parameters", "RefPointPlatform_X")
+   + config_->getValue<double>("parameters", "FromRefPointPlatformToSpacerEdge_dX")
+   + config_->getValue<double>("parameters", "FromSpacerEdgeToPSSRefPoint_dX");
+
+  const double y0 =
+     config_->getValue<double>("parameters", "RefPointPlatform_Y")
+   + config_->getValue<double>("parameters", "FromRefPointPlatformToSpacerEdge_dY")
+   + config_->getValue<double>("parameters", "FromSpacerEdgeToPSSRefPoint_dY");
+
+  const double z0 =
+     config_->getValue<double>("parameters", "CameraFocusOnAssemblyStage_Z")
+   - config_->getValue<double>("parameters", "Depth_SpacerSlots")
+   + config_->getValue<double>("parameters", "Thickness_Spacer")
+   + config_->getValue<double>("parameters", "Thickness_GlueLayer")
+   + config_->getValue<double>("parameters", "Thickness_PSS");
+
+  const double a0 = config_->getValue<double>("parameters", "RefPointPlatform_A");
+
+  connect(this, SIGNAL(move_absolute_request(double, double, double, double)), motion_, SLOT(moveAbsolute(double, double, double, double)));
+  connect(motion_, SIGNAL(motion_finished()), this, SLOT(GoToSensorMarkerPreAlignment_finish()));
+
+  in_action_ = true;
+
+  NQLog("AssemblySubassemblyPickup", NQLog::Spam) << "GoToSensorMarkerPreAlignment_start"
+     << ": emitting signal \"move_absolute_request(" << x0 << ", " << y0 << ", " << z0 << ", " << a0 << ")\"";
+
+  emit move_absolute_request(x0, y0, z0, a0);
+}
+
+void AssemblySubassemblyPickup::GoToSensorMarkerPreAlignment_finish()
+{
+  disconnect(this, SIGNAL(move_absolute_request(double, double, double, double)), motion_, SLOT(moveAbsolute(double, double, double, double)));
+  disconnect(motion_, SIGNAL(motion_finished()), this, SLOT(GoToSensorMarkerPreAlignment_finish()));
+
+  if(in_action_){ in_action_ = false; }
+
+  NQLog("AssemblySubassemblyPickup", NQLog::Spam) << "GoToSensorMarkerPreAlignment_finish"
+     << ": emitting signal \"GoToSensorMarkerPreAlignment_finished\"";
+
+  emit GoToSensorMarkerPreAlignment_finished();
+
+  NQLog("AssemblySubassemblyPickup", NQLog::Message) << "GoToSensorMarkerPreAlignment_finish"
+     << ": assembly-step completed";
+
+  emit DBLogMessage("== Assembly step completed : [Move to sensor's reference marker (pre-alignment)]");
+}
+// ----------------------------------------------------------------------------------------------------
+
+// ----------------------------------------------------------------------------------------------------
+// EnableVacuumSpacers --------------------------------------------------------------------------------
+// ----------------------------------------------------------------------------------------------------
+void AssemblySubassemblyPickup::EnableVacuumSpacers_start()
+{
+  if(in_action_){
+
+    NQLog("AssemblySubassemblyPickup", NQLog::Warning) << "EnableVacuumSpacers_start"
+       << ": logic error, an assembly step is still in progress, will not take further action";
+
+    return;
+  }
+
+  connect(this, SIGNAL(vacuum_ON_request(int)), this->vacuum(), SLOT(enableVacuum(int)));
+
+  connect(this->vacuum(), SIGNAL(vacuum_enabled()), this, SLOT(EnableVacuumSpacers_finish()));
+  connect(this->vacuum(), SIGNAL(vacuum_toggled()), this, SLOT(EnableVacuumSpacers_finish()));
+  connect(this->vacuum(), SIGNAL(vacuum_error  ()), this, SLOT(EnableVacuumSpacers_finish()));
+
+  in_action_ = true;
+
+  NQLog("AssemblySubassemblyPickup", NQLog::Spam) << "EnableVacuumSpacers_start"
+     << ": emitting signal \"vacuum_ON_request(" << vacuum_spacer_ << ")\"";
+
+  emit vacuum_ON_request(vacuum_spacer_);
+}
+
+void AssemblySubassemblyPickup::EnableVacuumSpacers_finish()
+{
+  disconnect(this, SIGNAL(vacuum_ON_request(int)), this->vacuum(), SLOT(enableVacuum(int)));
+
+  disconnect(this->vacuum(), SIGNAL(vacuum_enabled()), this, SLOT(EnableVacuumSpacers_finish()));
+  disconnect(this->vacuum(), SIGNAL(vacuum_toggled()), this, SLOT(EnableVacuumSpacers_finish()));
+  disconnect(this->vacuum(), SIGNAL(vacuum_error  ()), this, SLOT(EnableVacuumSpacers_finish()));
+
+  if(in_action_){ in_action_ = false; }
+
+  NQLog("AssemblySubassemblyPickup", NQLog::Spam) << "EnableVacuumSpacers_finish"
+     << ": emitting signal \"EnableVacuumSpacers_finished\"";
+
+  emit EnableVacuumSpacers_finished();
+
+  NQLog("AssemblySubassemblyPickup", NQLog::Message) << "EnableVacuumSpacers_finish"
+     << ": assembly-step completed";
+
+  emit DBLogMessage("== Assembly step completed : [Enable spacers vacuum]");
+}
+// ----------------------------------------------------------------------------------------------------
+
+// ----------------------------------------------------------------------------------------------------
+// switchToAlignmentTab_PSS ------------------------------------------------------------------------------
+// ----------------------------------------------------------------------------------------------------
+void AssemblySubassemblyPickup::switchToAlignmentTab_PSS()
+{
+  if(in_action_){
+
+    NQLog("AssemblySubassemblyPickup", NQLog::Warning) << "switchToAlignmentTab_PSS"
+       << ": logic error, an assembly step is still in progress, will not take further action";
+
+    return;
+  }
+
+  in_action_ = true;
+
+  NQLog("AssemblySubassemblyPickup", NQLog::Spam) << "switchToAlignmentTab_PSS"
+    << ": emitting signal \"switchToAlignmentTab_PSS_request\"";
+
+  emit switchToAlignmentTab_PSS_request(); //Will auto-switch to 'Alignment' sub-tab, and select PSS mode
+
+  in_action_ = false;
+
+  return;
+}
+// ----------------------------------------------------------------------------------------------------
+
+// ----------------------------------------------------------------------------------------------------
+// GoFromSensorMarkerToPickupXY -----------------------------------------------------------------------
+// ----------------------------------------------------------------------------------------------------
+void AssemblySubassemblyPickup::GoFromSensorMarkerToPickupXY_start()
+{
+  if(in_action_){
+
+    NQLog("AssemblySubassemblyPickup", NQLog::Warning) << "GoFromSensorMarkerToPickupXY_start"
+       << ": logic error, an assembly step is still in progress, will not take further action";
+
+    return;
+  }
+
+  const double dx0 = config_->getValue<double>("parameters", "FromSensorRefPointToSensorPickup_dX");
+  const double dy0 = config_->getValue<double>("parameters", "FromSensorRefPointToSensorPickup_dY");
+  const double dz0 = 0.0;
+  const double da0 = 0.0;
+
+  connect(this, SIGNAL(move_relative_request(double, double, double, double)), motion_, SLOT(moveRelative(double, double, double, double)));
+  connect(motion_, SIGNAL(motion_finished()), this, SLOT(GoFromSensorMarkerToPickupXY_finish()));
+
+  in_action_ = true;
+
+  NQLog("AssemblySubassemblyPickup", NQLog::Spam) << "GoFromSensorMarkerToPickupXY_start"
+     << ": emitting signal \"move_relative_request(" << dx0 << ", " << dy0 << ", " << dz0 << ", " << da0 << ")\"";
+
+  emit move_relative_request(dx0, dy0, dz0, da0);
+}
+
+void AssemblySubassemblyPickup::GoFromSensorMarkerToPickupXY_finish()
+{
+  disconnect(this, SIGNAL(move_relative_request(double, double, double, double)), motion_, SLOT(moveRelative(double, double, double, double)));
+  disconnect(motion_, SIGNAL(motion_finished()), this, SLOT(GoFromSensorMarkerToPickupXY_finish()));
+
+  if(in_action_){ in_action_ = false; }
+
+  NQLog("AssemblySubassemblyPickup", NQLog::Spam) << "GoFromSensorMarkerToPickupXY_finish"
+     << ": emitting signal \"GoFromSensorMarkerToPickupXY_finished\"";
+
+  emit GoFromSensorMarkerToPickupXY_finished();
+
+  NQLog("AssemblySubassemblyPickup", NQLog::Message) << "GoFromSensorMarkerToPickupXY_finish"
+     << ": assembly-step completed";
+
+  emit DBLogMessage("== Assembly step completed : [Move from sensor's reference marker to pickup XY position]");
+}
+// ----------------------------------------------------------------------------------------------------
+
+// ----------------------------------------------------------------------------------------------------
+// LowerPickupToolOntoSubassembly ---------------------------------------------------------------------------
+// ----------------------------------------------------------------------------------------------------
+void AssemblySubassemblyPickup::LowerPickupToolOntoSubassembly_start()
+{
+  if(in_action_){
+
+    NQLog("AssemblySubassemblyPickup", NQLog::Warning) << "LowerPickupToolOntoSubassembly_start"
+       << ": logic error, an assembly step is still in progress, will not take further action";
+
+    return;
+  }
+
+  if(alreadyClicked_LowerPickupToolOntoSubassembly)
+  {
+    NQLog("AssemblySubassemblyPickup", NQLog::Warning) << "LowerPickupToolOntoSubassembly_start"
+        << ": this button was pressed more than once already";
+
+    QMessageBox* msgBox = new QMessageBox;
+    msgBox->setInformativeText("WARNING: this button was already clicked at least once. Do you want to proceed?");
+    msgBox->setStandardButtons(QMessageBox::No | QMessageBox::Yes);
+    msgBox->setDefaultButton(QMessageBox::No);
+    int ret = msgBox->exec();
+    switch(ret)
+    {
+      case QMessageBox::No: return; //Exit
+      case QMessageBox::Yes: break; //Continue function execution
+      default: return; //Exit
+    }
+  }
+  alreadyClicked_LowerPickupToolOntoSubassembly = true; //Remember that this button already got clicked (repeating this action involuntarily can cause crash)
+
+  if(use_smartMove_)
+  {
+    const double dx0 = 0.0;
+    const double dy0 = 0.0;
+    const double dz0 =
+        config_->getValue<double>("parameters", "FromCameraBestFocusToPickupHeight_dZ")
+      + config_->getValue<double>("parameters", "Thickness_MPA") //NB: focused on PS-p marker --> to get correct distance to Subassembly, only need to account for additional width due to MPAs (not that of PS-p itself)
+    ;
+    const double da0 = 0.0;
+
+    connect(this, SIGNAL(move_relative_request(double, double, double, double)), smart_motion_, SLOT(move_relative(double, double, double, double)));
+    connect(smart_motion_, SIGNAL(motion_completed()), this, SLOT(LowerPickupToolOntoSubassembly_finish()));
+
+    in_action_ = true;
+
+    NQLog("AssemblySubassemblyPickup", NQLog::Spam) << "LowerPickupToolOntoSubassembly_start"
+       << ": emitting signal \"move_relative_request(" << dx0 << ", " << dy0 << ", " << dz0 << ", " << da0 << ")\"";
+
+    emit move_relative_request(dx0, dy0, dz0, da0);
+  }
+  else
+  {
+    NQLog("AssemblySubassemblyPickup", NQLog::Critical) << "LowerPickupToolOntoSubassembly_start"
+       << ": please enable \"smartMove\" mode (tick box in top-left corner of Assembly tab), required for this step";
+
+    QMessageBox msgBox;
+    msgBox.setText(tr("AssemblySubassemblyPickup::LowerPickupToolOntoSubassembly_start -- please enable \"smartMove\" mode (tick box in top-left corner of Assembly tab), required for this step"));
+    msgBox.exec();
+
+    NQLog("AssemblySubassemblyPickup", NQLog::Spam) << "LowerPickupToolOntoSubassembly_finish"
+       << ": emitting signal \"LowerPickupToolOntoSubassembly_finished\"";
+
+    emit LowerPickupToolOntoSubassembly_finished();
+
+    return;
+  }
+}
+
+void AssemblySubassemblyPickup::LowerPickupToolOntoSubassembly_finish()
+{
+  disconnect(this, SIGNAL(move_relative_request(double, double, double, double)), smart_motion_, SLOT(move_relative(double, double, double, double)));
+  disconnect(smart_motion_, SIGNAL(motion_completed()), this, SLOT(LowerPickupToolOntoSubassembly_finish()));
+
+  if(in_action_){ in_action_ = false; }
+
+  NQLog("AssemblySubassemblyPickup", NQLog::Spam) << "LowerPickupToolOntoSubassembly_finish"
+     << ": emitting signal \"LowerPickupToolOntoSubassembly_finished\"";
+
+  emit LowerPickupToolOntoSubassembly_finished();
+
+  NQLog("AssemblySubassemblyPickup", NQLog::Message) << "LowerPickupToolOntoSubassembly_finish"
+     << ": assembly-step completed";
+
+  emit DBLogMessage("== Assembly step completed : [Lower pickup tool onto Subassembly]");
+}
+// ----------------------------------------------------------------------------------------------------
+
+// ----------------------------------------------------------------------------------------------------
+// EnableVacuumPickupTool -----------------------------------------------------------------------------
+// ----------------------------------------------------------------------------------------------------
+void AssemblySubassemblyPickup::EnableVacuumPickupTool_start()
+{
+  if(in_action_){
+
+    NQLog("AssemblySubassemblyPickup", NQLog::Warning) << "EnableVacuumPickupTool_start"
+       << ": logic error, an assembly step is still in progress, will not take further action";
+
+    return;
+  }
+
+  connect(this, SIGNAL(vacuum_ON_request(int)), this->vacuum(), SLOT(enableVacuum(int)));
+
+  connect(this->vacuum(), SIGNAL(vacuum_enabled()), this, SLOT(EnableVacuumPickupTool_finish()));
+  connect(this->vacuum(), SIGNAL(vacuum_toggled()), this, SLOT(EnableVacuumPickupTool_finish()));
+  connect(this->vacuum(), SIGNAL(vacuum_error  ()), this, SLOT(EnableVacuumPickupTool_finish()));
+
+  in_action_ = true;
+
+  NQLog("AssemblySubassemblyPickup", NQLog::Spam) << "EnableVacuumPickupTool_start"
+     << ": emitting signal \"vacuum_ON_request(" << vacuum_pickup_ << ")\"";
+
+  emit vacuum_ON_request(vacuum_pickup_);
+}
+
+void AssemblySubassemblyPickup::EnableVacuumPickupTool_finish()
+{
+  disconnect(this, SIGNAL(vacuum_ON_request(int)), this->vacuum(), SLOT(enableVacuum(int)));
+
+  disconnect(this->vacuum(), SIGNAL(vacuum_enabled()), this, SLOT(EnableVacuumPickupTool_finish()));
+  disconnect(this->vacuum(), SIGNAL(vacuum_toggled()), this, SLOT(EnableVacuumPickupTool_finish()));
+  disconnect(this->vacuum(), SIGNAL(vacuum_error  ()), this, SLOT(EnableVacuumPickupTool_finish()));
+
+  if(in_action_){ in_action_ = false; }
+
+  NQLog("AssemblySubassemblyPickup", NQLog::Spam) << "EnableVacuumPickupTool_finish"
+     << ": emitting signal \"EnableVacuumPickupTool_finished\"";
+
+  emit EnableVacuumPickupTool_finished();
+
+  NQLog("AssemblySubassemblyPickup", NQLog::Message) << "EnableVacuumPickupTool_finish"
+     << ": assembly-step completed";
+
+  emit DBLogMessage("== Assembly step completed : [Enable pickup tool vacuum]");
+}
+// ----------------------------------------------------------------------------------------------------
+
+// ----------------------------------------------------------------------------------------------------
+// DisableVacuumSpacers -------------------------------------------------------------------------------
+// ----------------------------------------------------------------------------------------------------
+void AssemblySubassemblyPickup::DisableVacuumSpacers_start()
+{
+  if(in_action_){
+
+    NQLog("AssemblySubassemblyPickup", NQLog::Warning) << "DisableVacuumSpacers_start"
+       << ": logic error, an assembly step is still in progress, will not take further action";
+
+    return;
+  }
+
+  connect(this, SIGNAL(vacuum_OFF_request(int)), this->vacuum(), SLOT(disableVacuum(int)));
+
+  connect(this->vacuum(), SIGNAL(vacuum_disabled()), this, SLOT(DisableVacuumSpacers_finish()));
+  connect(this->vacuum(), SIGNAL(vacuum_toggled ()), this, SLOT(DisableVacuumSpacers_finish()));
+  connect(this->vacuum(), SIGNAL(vacuum_error   ()), this, SLOT(DisableVacuumSpacers_finish()));
+
+  in_action_ = true;
+
+  NQLog("AssemblySubassemblyPickup", NQLog::Spam) << "DisableVacuumSpacers_start"
+     << ": emitting signal \"vacuum_OFF_request(" << vacuum_spacer_ << ")\"";
+
+  emit vacuum_OFF_request(vacuum_spacer_);
+}
+
+void AssemblySubassemblyPickup::DisableVacuumSpacers_finish()
+{
+  disconnect(this, SIGNAL(vacuum_OFF_request(int)), this->vacuum(), SLOT(disableVacuum(int)));
+
+  disconnect(this->vacuum(), SIGNAL(vacuum_disabled()), this, SLOT(DisableVacuumSpacers_finish()));
+  disconnect(this->vacuum(), SIGNAL(vacuum_toggled ()), this, SLOT(DisableVacuumSpacers_finish()));
+  disconnect(this->vacuum(), SIGNAL(vacuum_error   ()), this, SLOT(DisableVacuumSpacers_finish()));
+
+  if(in_action_){ in_action_ = false; }
+
+  NQLog("AssemblySubassemblyPickup", NQLog::Spam) << "DisableVacuumSpacers_finish"
+     << ": emitting signal \"DisableVacuumSpacers_finished\"";
+
+  emit DisableVacuumSpacers_finished();
+
+  NQLog("AssemblySubassemblyPickup", NQLog::Message) << "DisableVacuumSpacers_finish"
+     << ": assembly-step completed";
+
+  emit DBLogMessage("== Assembly step completed : [Disable spacers vacuum]");
+}
+// ----------------------------------------------------------------------------------------------------
+
+// ----------------------------------------------------------------------------------------------------
+// PickupSubassembly ----------------------------------------------------------------------------------------
+// ----------------------------------------------------------------------------------------------------
+void AssemblySubassemblyPickup::PickupSubassembly_start()
+{
+  if(in_action_){
+
+    NQLog("AssemblySubassemblyPickup", NQLog::Warning) << "PickupSubassembly_start"
+       << ": logic error, an assembly step is still in progress, will not take further action";
+
+    return;
+  }
+
+  const double dx0 = 0.0;
+  const double dy0 = 0.0;
+  const double dz0 = (pickup1_Z_ - motion_->get_position_Z());
+  const double da0 = 0.0;
+
+  if(dz0 <= 0.)
+  {
+    NQLog("AssemblySubassemblyPickup", NQLog::Critical) << "PickupSubassembly_start"
+       << ": invalid (non-positive) value for vertical upward movement for pickup #1 (dz=" << dz0 << "), no action taken";
+
+    NQLog("AssemblySubassemblyPickup", NQLog::Spam) << "PickupSubassembly_finish"
+       << ": emitting signal \"PickupSubassembly_finished\"";
+
+    emit PickupSubassembly_finished();
+
+    return;
+  }
+
+  connect(this, SIGNAL(move_relative_request(double, double, double, double)), motion_, SLOT(moveRelative(double, double, double, double)));
+  connect(motion_, SIGNAL(motion_finished()), this, SLOT(PickupSubassembly_finish()));
+
+  in_action_ = true;
+
+  NQLog("AssemblySubassemblyPickup", NQLog::Spam) << "PickupSubassembly_start"
+     << ": emitting signal \"move_relative_request(" << dx0 << ", " << dy0 << ", " << dz0 << ", " << da0 << ")\"";
+
+  emit move_relative_request(dx0, dy0, dz0, da0);
+}
+
+void AssemblySubassemblyPickup::PickupSubassembly_finish()
+{
+  disconnect(this, SIGNAL(move_relative_request(double, double, double, double)), motion_, SLOT(moveRelative(double, double, double, double)));
+  disconnect(motion_, SIGNAL(motion_finished()), this, SLOT(PickupSubassembly_finish()));
+
+  if(in_action_){ in_action_ = false; }
+
+  NQLog("AssemblySubassemblyPickup", NQLog::Spam) << "PickupSubassembly_finish"
+     << ": emitting signal \"PickupSubassembly_finished\"";
+
+  emit PickupSubassembly_finished();
+
+  NQLog("AssemblySubassemblyPickup", NQLog::Message) << "PickupSubassembly_finish"
+     << ": assembly-step completed";
+}
+// ----------------------------------------------------------------------------------------------------

--- a/assembly/assemblyCommon/AssemblySubassemblyPickup.cc
+++ b/assembly/assemblyCommon/AssemblySubassemblyPickup.cc
@@ -531,8 +531,13 @@ void AssemblySubassemblyPickup::PickupSubassembly_start()
     return;
   }
 
-  connect(this, SIGNAL(move_relative_request(double, double, double, double)), motion_, SLOT(moveRelative(double, double, double, double)));
-  connect(motion_, SIGNAL(motion_finished()), this, SLOT(PickupSubassembly_finish()));
+  if(use_smartMove_) {
+    connect(this, SIGNAL(move_relative_request(double, double, double, double)), smart_motion_, SLOT(move_relative(double, double, double, double)));
+    connect(smart_motion_, SIGNAL(motion_completed()), this, SLOT(PickupSubassembly_finish()));
+  } else {
+    connect(this, SIGNAL(move_relative_request(double, double, double, double)), motion_, SLOT(moveRelative(double, double, double, double)));
+    connect(motion_, SIGNAL(motion_finished()), this, SLOT(PickupSubassembly_finish()));
+  }
 
   in_action_ = true;
 
@@ -544,8 +549,13 @@ void AssemblySubassemblyPickup::PickupSubassembly_start()
 
 void AssemblySubassemblyPickup::PickupSubassembly_finish()
 {
-  disconnect(this, SIGNAL(move_relative_request(double, double, double, double)), motion_, SLOT(moveRelative(double, double, double, double)));
-  disconnect(motion_, SIGNAL(motion_finished()), this, SLOT(PickupSubassembly_finish()));
+  if(use_smartMove_) {
+    disconnect(this, SIGNAL(move_relative_request(double, double, double, double)), smart_motion_, SLOT(move_relative(double, double, double, double)));
+    disconnect(smart_motion_, SIGNAL(motion_completed()), this, SLOT(PickupSubassembly_finish()));
+  } else {
+    disconnect(this, SIGNAL(move_relative_request(double, double, double, double)), motion_, SLOT(moveRelative(double, double, double, double)));
+    disconnect(motion_, SIGNAL(motion_finished()), this, SLOT(PickupSubassembly_finish()));
+  }
 
   if(in_action_){ in_action_ = false; }
 

--- a/assembly/assemblyCommon/AssemblySubassemblyPickup.cc
+++ b/assembly/assemblyCommon/AssemblySubassemblyPickup.cc
@@ -1,0 +1,89 @@
+/////////////////////////////////////////////////////////////////////////////////
+//                                                                             //
+//               Copyright (C) 2011-2022 - The DESY CMS Group                  //
+//                           All rights reserved                               //
+//                                                                             //
+//      The CMStkModLab source code is licensed under the GNU GPL v3.0.        //
+//      You have the right to modify and/or redistribute this source code      //
+//      under the terms specified in the license, which may be found online    //
+//      at http://www.gnu.org/licenses or at License.txt.                      //
+//                                                                             //
+/////////////////////////////////////////////////////////////////////////////////
+
+#include <nqlogger.h>
+#include <ApplicationConfig.h>
+
+#include <AssemblySubassemblyPickup.h>
+
+AssemblySubassemblyPickup::AssemblySubassemblyPickup(const LStepExpressMotionManager* motion_manager, QObject* parent)
+ : QObject(parent)
+
+ , motion_manager_(motion_manager)
+ , motion_manager_enabled_(false)
+{
+  if(motion_manager_ == nullptr)
+  {
+    NQLog("AssemblySubassemblyPickup", NQLog::Critical) << "input error"
+       << ": null pointer to LStepExpressMotionManager object, initialization stopped";
+
+    return;
+  }
+
+  ApplicationConfig* config = ApplicationConfig::instance();
+  if(config == nullptr)
+  {
+    NQLog("AssemblySubassemblyPickup", NQLog::Fatal)
+       << "ApplicationConfig::instance() not initialized (null pointer), stopped constructor";
+
+    return;
+  }
+
+
+  this->reset();
+
+  NQLog("AssemblySubassemblyPickup", NQLog::Debug) << "constructed";
+}
+
+AssemblySubassemblyPickup::~AssemblySubassemblyPickup()
+{
+}
+
+void AssemblySubassemblyPickup::enable_motion_manager(const bool arg)
+{
+  if(arg == motion_manager_enabled_)
+  {
+    NQLog("AssemblySubassemblyPickup", NQLog::Debug) << "enable_motion_manager(" << arg << ")"
+       << ": motion-manager for multi-pickup test already " << (arg ? "enabled" : "disabled") << ", no action taken";
+
+    return;
+  }
+
+  if(arg)
+  {
+    connect(this, SIGNAL(move_relative(double, double, double, double)), motion_manager_, SLOT(moveRelative(double, double, double, double)));
+    connect(motion_manager_, SIGNAL(motion_finished()), this, SLOT(setup_next_step()));
+
+    motion_manager_enabled_ = true;
+
+    NQLog("AssemblySubassemblyPickup", NQLog::Spam) << "enable_motion_manager(" << arg << ")"
+       << ": motion-manager for multi-pickup test enabled";
+  }
+  else
+  {
+    disconnect(this, SIGNAL(move_relative(double, double, double, double)), motion_manager_, SLOT(moveRelative(double, double, double, double)));
+    disconnect(motion_manager_, SIGNAL(motion_finished()), this, SLOT(setup_next_step()));
+
+    motion_manager_enabled_ = false;
+
+    NQLog("AssemblySubassemblyPickup", NQLog::Spam) << "enable_motion_manager(" << arg << ")"
+       << ": motion-manager for multi-pickup test disabled";
+  }
+
+  return;
+}
+
+void AssemblySubassemblyPickup::reset()
+{
+
+  this->disconnect_motion_manager();
+}

--- a/assembly/assemblyCommon/AssemblySubassemblyPickup.cc
+++ b/assembly/assemblyCommon/AssemblySubassemblyPickup.cc
@@ -352,10 +352,7 @@ void AssemblySubassemblyPickup::LowerPickupToolOntoSubassembly_start()
   {
     const double dx0 = 0.0;
     const double dy0 = 0.0;
-    const double dz0 =
-        config_->getValue<double>("parameters", "FromCameraBestFocusToPickupHeight_dZ")
-      + config_->getValue<double>("parameters", "Thickness_MPA") //NB: focused on PS-p marker --> to get correct distance to Subassembly, only need to account for additional width due to MPAs (not that of PS-p itself)
-    ;
+    const double dz0 = config_->getValue<double>("parameters", "FromCameraBestFocusToPickupHeight_dZ");
     const double da0 = 0.0;
 
     connect(this, SIGNAL(move_relative_request(double, double, double, double)), smart_motion_, SLOT(move_relative(double, double, double, double)));

--- a/assembly/assemblyCommon/AssemblySubassemblyPickup.h
+++ b/assembly/assemblyCommon/AssemblySubassemblyPickup.h
@@ -14,6 +14,10 @@
 #define ASSEMBLYSUBASSEMBLYPICKUP_H
 
 #include <LStepExpressMotionManager.h>
+#include <RelayCardManager.h>
+
+#include <AssemblySmartMotionManager.h>
+#include <ApplicationConfig.h>
 
 class AssemblySubassemblyPickup : public QObject
 {
@@ -21,34 +25,86 @@ class AssemblySubassemblyPickup : public QObject
 
  public:
 
-  explicit AssemblySubassemblyPickup(const LStepExpressMotionManager*, QObject* parent=nullptr);
+  explicit AssemblySubassemblyPickup(const LStepExpressMotionManager* const, const RelayCardManager* const, const AssemblySmartMotionManager* const smart_motion=nullptr, QObject* parent=nullptr);
   virtual ~AssemblySubassemblyPickup();
 
-  const LStepExpressMotionManager* motion_manager() const { return motion_manager_; }
+  const LStepExpressMotionManager* motion() const;
+  const RelayCardManager* vacuum() const;
 
- private:
-  Q_DISABLE_COPY(AssemblySubassemblyPickup)
+  const AssemblySmartMotionManager* smart_motion() const;
 
  protected:
+  const LStepExpressMotionManager* const motion_;
+  const RelayCardManager* const vacuum_;
 
-  mutable QMutex mutex_;
+  const AssemblySmartMotionManager* const smart_motion_;
 
-  const LStepExpressMotionManager* motion_manager_;
+  const ApplicationConfig* config_;
 
-  bool motion_manager_enabled_;
+  int vacuum_pickup_;
+  int vacuum_spacer_;
+  int vacuum_basepl_;
 
-  void enable_motion_manager(const bool);
+  bool use_smartMove_;
+  bool in_action_;
 
-  void    connect_motion_manager() { this->enable_motion_manager(true) ; }
-  void disconnect_motion_manager() { this->enable_motion_manager(false); }
+  bool alreadyClicked_LowerPickupToolOntoSubassembly;
+
+  double pickup1_Z_;
 
   void reset();
 
 
  public slots:
 
+  void use_smartMove(const int);
+
+  void GoToSensorMarkerPreAlignment_start();
+  void GoToSensorMarkerPreAlignment_finish();
+
+  void EnableVacuumSpacers_start();
+  void EnableVacuumSpacers_finish();
+
+  void switchToAlignmentTab_PSS();
+
+  void GoFromSensorMarkerToPickupXY_start();
+  void GoFromSensorMarkerToPickupXY_finish();
+
+  void EnableVacuumPickupTool_start();
+  void EnableVacuumPickupTool_finish();
+
+  void LowerPickupToolOntoSubassembly_start();
+  void LowerPickupToolOntoSubassembly_finish();
+
+  void DisableVacuumSpacers_start();
+  void DisableVacuumSpacers_finish();
+
+  void PickupSubassembly_start();
+  void PickupSubassembly_finish();
 
  signals:
+
+  // motion
+  void move_absolute_request(const double, const double, const double, const double);
+  void move_relative_request(const double, const double, const double, const double);
+
+  void GoToSensorMarkerPreAlignment_finished();
+  void GoFromSensorMarkerToPickupXY_finished();
+  void LowerPickupToolOntoSubassembly_finished();
+  void PickupSubassembly_finished();
+
+  void vacuum_ON_request(const int);
+  void vacuum_OFF_request(const int);
+
+  void EnableVacuumPickupTool_finished();
+  void DisableVacuumPickupTool_finished();
+
+  void EnableVacuumSpacers_finished();
+  void DisableVacuumSpacers_finished();
+
+  void switchToAlignmentTab_PSS_request();
+
+  void DBLogMessage(const QString);
 
 };
 

--- a/assembly/assemblyCommon/AssemblySubassemblyPickup.h
+++ b/assembly/assemblyCommon/AssemblySubassemblyPickup.h
@@ -1,0 +1,55 @@
+/////////////////////////////////////////////////////////////////////////////////
+//                                                                             //
+//               Copyright (C) 2011-2017 - The DESY CMS Group                  //
+//                           All rights reserved                               //
+//                                                                             //
+//      The CMStkModLab source code is licensed under the GNU GPL v3.0.        //
+//      You have the right to modify and/or redistribute this source code      //
+//      under the terms specified in the license, which may be found online    //
+//      at http://www.gnu.org/licenses or at License.txt.                      //
+//                                                                             //
+/////////////////////////////////////////////////////////////////////////////////
+
+#ifndef ASSEMBLYSUBASSEMBLYPICKUP_H
+#define ASSEMBLYSUBASSEMBLYPICKUP_H
+
+#include <LStepExpressMotionManager.h>
+
+class AssemblySubassemblyPickup : public QObject
+{
+ Q_OBJECT
+
+ public:
+
+  explicit AssemblySubassemblyPickup(const LStepExpressMotionManager*, QObject* parent=nullptr);
+  virtual ~AssemblySubassemblyPickup();
+
+  const LStepExpressMotionManager* motion_manager() const { return motion_manager_; }
+
+ private:
+  Q_DISABLE_COPY(AssemblySubassemblyPickup)
+
+ protected:
+
+  mutable QMutex mutex_;
+
+  const LStepExpressMotionManager* motion_manager_;
+
+  bool motion_manager_enabled_;
+
+  void enable_motion_manager(const bool);
+
+  void    connect_motion_manager() { this->enable_motion_manager(true) ; }
+  void disconnect_motion_manager() { this->enable_motion_manager(false); }
+
+  void reset();
+
+
+ public slots:
+
+
+ signals:
+
+};
+
+#endif // ASSEMBLYSUBASSEMBLYPICKUP_H

--- a/assembly/assemblyCommon/AssemblySubassemblyPickupWidget.cc
+++ b/assembly/assemblyCommon/AssemblySubassemblyPickupWidget.cc
@@ -50,6 +50,8 @@ AssemblySubassemblyPickupWidget::AssemblySubassemblyPickupWidget(const QObject* 
   smartMove_checkbox_->setChecked(true);
   //// -----------------------------------------------
 
+  QVBoxLayout* sub_pick_lay = new QVBoxLayout;
+  layout->addLayout(sub_pick_lay);
 
   uint pickup_step_N = 0;
 
@@ -60,7 +62,7 @@ AssemblySubassemblyPickupWidget::AssemblySubassemblyPickupWidget(const QObject* 
     AssemblyAssemblyTextWidget* tmp_wid = new AssemblyAssemblyTextWidget;
     tmp_wid->label()->setText(QString::number(pickup_step_N));
     tmp_wid->text()->setText("Place PSS+spacers subassembly on assembly platform with the spacers aligned in their spacer pockets");
-    layout->addWidget(tmp_wid);
+    sub_pick_lay->addWidget(tmp_wid);
   }
   // ----------
 
@@ -71,7 +73,7 @@ AssemblySubassemblyPickupWidget::AssemblySubassemblyPickupWidget(const QObject* 
     AssemblyAssemblyActionWidget* tmp_wid = new AssemblyAssemblyActionWidget;
     tmp_wid->label()->setText(QString::number(pickup_step_N));
     tmp_wid->button()->setText("Go To Measurement Position on PS-s - Spacer height considered");
-    layout->addWidget(tmp_wid);
+    sub_pick_lay->addWidget(tmp_wid);
 
     tmp_wid->connect_action(subassembly_pickup, SLOT(GoToSensorMarkerPreAlignment_start()), SIGNAL(GoToSensorMarkerPreAlignment_finished()));
   }
@@ -84,7 +86,7 @@ AssemblySubassemblyPickupWidget::AssemblySubassemblyPickupWidget(const QObject* 
     AssemblyAssemblyActionWidget* tmp_wid = new AssemblyAssemblyActionWidget;
     tmp_wid->label()->setText(QString::number(pickup_step_N));
     tmp_wid->button()->setText("Enable vacuum on spacers");
-    layout->addWidget(tmp_wid);
+    sub_pick_lay->addWidget(tmp_wid);
 
     tmp_wid->connect_action(subassembly_pickup, SLOT(EnableVacuumSpacers_start()), SIGNAL(EnableVacuumSpacers_finished()));
   }
@@ -97,7 +99,7 @@ AssemblySubassemblyPickupWidget::AssemblySubassemblyPickupWidget(const QObject* 
     AssemblyAssemblyActionWidget* tmp_wid = new AssemblyAssemblyActionWidget;
     tmp_wid->label()->setText(QString::number(pickup_step_N));
     tmp_wid->button()->setText("Align PS-s to Motion Stage (Go to \"Alignment\" Tab and select \"PS-s Sensor\")");
-    layout->addWidget(tmp_wid);
+    sub_pick_lay->addWidget(tmp_wid);
 
     tmp_wid->connect_action(subassembly_pickup, SLOT(switchToAlignmentTab_PSS()), SIGNAL(switchToAlignmentTab_PSS_request()));
   }
@@ -110,7 +112,7 @@ AssemblySubassemblyPickupWidget::AssemblySubassemblyPickupWidget(const QObject* 
     AssemblyAssemblyActionWidget* tmp_wid = new AssemblyAssemblyActionWidget;
     tmp_wid->label()->setText(QString::number(pickup_step_N));
     tmp_wid->button()->setText("Go From Sensor Marker Ref-Point to Pickup XY");
-    layout->addWidget(tmp_wid);
+    sub_pick_lay->addWidget(tmp_wid);
 
     tmp_wid->connect_action(subassembly_pickup, SLOT(GoFromSensorMarkerToPickupXY_start()), SIGNAL(GoFromSensorMarkerToPickupXY_finished()));
   }
@@ -123,7 +125,7 @@ AssemblySubassemblyPickupWidget::AssemblySubassemblyPickupWidget(const QObject* 
     AssemblyAssemblyActionWidget* tmp_wid = new AssemblyAssemblyActionWidget;
     tmp_wid->label()->setText(QString::number(pickup_step_N));
     tmp_wid->button()->setText("Lower Pickup-Tool onto PSS+spacers subassembly");
-    layout->addWidget(tmp_wid);
+    sub_pick_lay->addWidget(tmp_wid);
 
     tmp_wid->connect_action(subassembly_pickup, SLOT(LowerPickupToolOntoSubassembly_start()), SIGNAL(LowerPickupToolOntoSubassembly_finished()));
   }
@@ -136,7 +138,7 @@ AssemblySubassemblyPickupWidget::AssemblySubassemblyPickupWidget(const QObject* 
     AssemblyAssemblyActionWidget* tmp_wid = new AssemblyAssemblyActionWidget;
     tmp_wid->label()->setText(QString::number(pickup_step_N));
     tmp_wid->button()->setText("Enable Vacuum on Pickup-Tool");
-    layout->addWidget(tmp_wid);
+    sub_pick_lay->addWidget(tmp_wid);
 
     tmp_wid->connect_action(subassembly_pickup, SLOT(EnableVacuumPickupTool_start()), SIGNAL(EnableVacuumPickupTool_finished()));
   }
@@ -149,7 +151,7 @@ AssemblySubassemblyPickupWidget::AssemblySubassemblyPickupWidget(const QObject* 
     AssemblyAssemblyActionWidget* tmp_wid = new AssemblyAssemblyActionWidget;
     tmp_wid->label()->setText(QString::number(pickup_step_N));
     tmp_wid->button()->setText("Disable Vacuum on Spacers");
-    layout->addWidget(tmp_wid);
+    sub_pick_lay->addWidget(tmp_wid);
 
     tmp_wid->connect_action(subassembly_pickup, SLOT(DisableVacuumSpacers_start()), SIGNAL(DisableVacuumSpacers_finished()));
   }
@@ -162,11 +164,11 @@ AssemblySubassemblyPickupWidget::AssemblySubassemblyPickupWidget(const QObject* 
     AssemblyAssemblyActionWidget* tmp_wid = new AssemblyAssemblyActionWidget;
     tmp_wid->label()->setText(QString::number(pickup_step_N));
     tmp_wid->button()->setText("Pick Up PSS+spacers subassembly");
-    layout->addWidget(tmp_wid);
+    sub_pick_lay->addWidget(tmp_wid);
 
     tmp_wid->connect_action(subassembly_pickup, SLOT(PickupSubassembly_start()), SIGNAL(PickupSubassembly_finished()));
   }
   // ----------
 
-  layout->addStretch(1);
+  sub_pick_lay->addStretch(1);
 }

--- a/assembly/assemblyCommon/AssemblySubassemblyPickupWidget.cc
+++ b/assembly/assemblyCommon/AssemblySubassemblyPickupWidget.cc
@@ -1,0 +1,68 @@
+/////////////////////////////////////////////////////////////////////////////////
+//                                                                             //
+//               Copyright (C) 2011-2017 - The DESY CMS Group                  //
+//                           All rights reserved                               //
+//                                                                             //
+//      The CMStkModLab source code is licensed under the GNU GPL v3.0.        //
+//      You have the right to modify and/or redistribute this source code      //
+//      under the terms specified in the license, which may be found online    //
+//      at http://www.gnu.org/licenses or at License.txt.                      //
+//                                                                             //
+/////////////////////////////////////////////////////////////////////////////////
+
+#include <nqlogger.h>
+
+#include <AssemblySubassemblyPickupWidget.h>
+
+#include <sstream>
+#include <iomanip>
+#include <stdlib.h>
+
+#include <QVBoxLayout>
+#include <QStringList>
+
+AssemblySubassemblyPickupWidget::AssemblySubassemblyPickupWidget(const LStepExpressMotionManager* const motion_manager, QWidget* parent) :
+  QWidget(parent),
+
+  motion_manager_(motion_manager)
+{
+  if(motion_manager_ == nullptr)
+  {
+    NQLog("AssemblySubassemblyPickupWidget", NQLog::Critical)
+       << "input error: null pointer to LStepExpressMotionManager object, exiting constructor";
+
+    return;
+  }
+
+  QVBoxLayout* layout = new QVBoxLayout;
+  this->setLayout(layout);
+
+  uint pickup_step_N = 0;
+
+  // step: Place MaPSA on Assembly Platform
+  {
+    ++pickup_step_N;
+
+    AssemblyAssemblyTextWidget* tmp_wid = new AssemblyAssemblyTextWidget;
+    tmp_wid->label()->setText(QString::number(pickup_step_N));
+    tmp_wid->text()->setText("Place PSS+spacers subassembly on assembly platform with the spacers in their spacer pockets");
+    layout->addWidget(tmp_wid);
+  }
+  // ----------
+
+  // step: Go To Measurement Position on MaPSA
+  {
+    ++pickup_step_N;
+
+    AssemblyAssemblyActionWidget* tmp_wid = new AssemblyAssemblyActionWidget;
+    tmp_wid->label()->setText(QString::number(pickup_step_N));
+    tmp_wid->button()->setText("Go To Measurement Position on PSS");
+    layout->addWidget(tmp_wid);
+
+    //tmp_wid->connect_action(assembly, SLOT(GoToSensorMarkerPreAlignment_start()), SIGNAL(GoToSensorMarkerPreAlignment_finished()));
+  }
+  // ----------
+
+
+  layout->addStretch(1);
+}

--- a/assembly/assemblyCommon/AssemblySubassemblyPickupWidget.cc
+++ b/assembly/assemblyCommon/AssemblySubassemblyPickupWidget.cc
@@ -36,6 +36,12 @@ AssemblySubassemblyPickupWidget::AssemblySubassemblyPickupWidget(const QObject* 
 
   QVBoxLayout* layout = new QVBoxLayout;
   this->setLayout(layout);
+  //// -----------------------------------------------
+
+  QLabel* disclaimer = new QLabel("Note: This is an experimental procedure!");
+  disclaimer->setStyleSheet("QLabel { color : red ; font: bold }");
+
+  layout->addWidget(disclaimer);
 
   //// Assembly Options ------------------------------
   QHBoxLayout* opts_lay = new QHBoxLayout;

--- a/assembly/assemblyCommon/AssemblySubassemblyPickupWidget.h
+++ b/assembly/assemblyCommon/AssemblySubassemblyPickupWidget.h
@@ -33,14 +33,14 @@ class AssemblySubassemblyPickupWidget : public QWidget
 
  public:
 
-  explicit AssemblySubassemblyPickupWidget(const LStepExpressMotionManager* const, QWidget* parent=nullptr);
+  explicit AssemblySubassemblyPickupWidget(const QObject* const, QWidget* parent=nullptr);
   virtual ~AssemblySubassemblyPickupWidget() {}
 
   QGridLayout* layout() const { return layout_; }
 
  protected:
 
-  const LStepExpressMotionManager* const motion_manager_;
+  QCheckBox* smartMove_checkbox_;
 
   QGridLayout* layout_;
 

--- a/assembly/assemblyCommon/AssemblySubassemblyPickupWidget.h
+++ b/assembly/assemblyCommon/AssemblySubassemblyPickupWidget.h
@@ -1,0 +1,69 @@
+/////////////////////////////////////////////////////////////////////////////////
+//                                                                             //
+//               Copyright (C) 2011-2017 - The DESY CMS Group                  //
+//                           All rights reserved                               //
+//                                                                             //
+//      The CMStkModLab source code is licensed under the GNU GPL v3.0.        //
+//      You have the right to modify and/or redistribute this source code      //
+//      under the terms specified in the license, which may be found online    //
+//      at http://www.gnu.org/licenses or at License.txt.                      //
+//                                                                             //
+/////////////////////////////////////////////////////////////////////////////////
+
+#ifndef ASSEMBLYSUBASSEMBLYPICKUPWIDGET_H
+#define ASSEMBLYSUBASSEMBLYPICKUPWIDGET_H
+
+#include <LStepExpressMotionManager.h>
+#include <AssemblySubassemblyPickup.h>
+#include <AssemblyAssemblyTextWidget.h>
+#include <AssemblyAssemblyActionWidget.h>
+
+#include <QWidget>
+#include <QString>
+#include <QGridLayout>
+#include <QPushButton>
+#include <QLineEdit>
+#include <QLabel>
+
+#include <opencv2/opencv.hpp>
+
+class AssemblySubassemblyPickupWidget : public QWidget
+{
+ Q_OBJECT
+
+ public:
+
+  explicit AssemblySubassemblyPickupWidget(const LStepExpressMotionManager* const, QWidget* parent=nullptr);
+  virtual ~AssemblySubassemblyPickupWidget() {}
+
+  QGridLayout* layout() const { return layout_; }
+
+ protected:
+
+  const LStepExpressMotionManager* const motion_manager_;
+
+  QGridLayout* layout_;
+
+  QPushButton* exe_button_;
+
+  QLabel *     pickup_label_;
+  QLineEdit*   pickup_lineed_;
+  QPushButton* pickup_button_;
+
+  QLabel*      measur_label_;
+  QLineEdit*   measur_lineed_;
+  QPushButton* measur_button_;
+
+  QLabel*      iteraN_label_;
+  QLineEdit*   iteraN_lineed_;
+
+ public slots:
+
+
+
+ signals:
+
+  //void multipickup_request(const AssemblySubassemblyPickup::Configuration&);
+};
+
+#endif // ASSEMBLYSUBASSEMBLYPICKUPWIDGET_H

--- a/assembly/assemblyCommon/AssemblyToolboxView.cc
+++ b/assembly/assemblyCommon/AssemblyToolboxView.cc
@@ -69,8 +69,6 @@ AssemblyToolboxView::AssemblyToolboxView(const LStepExpressMotionManager* const 
 
   toolbox->addItem(mupite_wid_, tr("Multi-Pickup Tester (PatRec + pick-up + put-down)"));
   // ---------------------
-
-  layout->addStretch(1);
 }
 
 //-- Information about this tab in GUI

--- a/assembly/assemblyCommon/AssemblyToolboxView.cc
+++ b/assembly/assemblyCommon/AssemblyToolboxView.cc
@@ -17,7 +17,7 @@
 #include <QVBoxLayout>
 #include <QToolBox>
 
-AssemblyToolboxView::AssemblyToolboxView(const LStepExpressMotionManager* const motion_manager, QWidget* parent) :
+AssemblyToolboxView::AssemblyToolboxView(const LStepExpressMotionManager* const motion_manager, const AssemblySubassemblyPickup* const subassembly_pickup, QWidget* parent) :
   QWidget(parent),
 
   posreg_wid_(nullptr),
@@ -53,7 +53,7 @@ AssemblyToolboxView::AssemblyToolboxView(const LStepExpressMotionManager* const 
   //  * widget to pick up PSS+spacers subassembly
   //  * used to process subassembly
   //
-  subassembly_pickup_wid_ = new AssemblySubassemblyPickupWidget(motion_manager);
+  subassembly_pickup_wid_ = new AssemblySubassemblyPickupWidget(subassembly_pickup);
 
   toolbox->addItem(subassembly_pickup_wid_, tr("PSS+spacers subassembly pickup"));
   // ---------------------

--- a/assembly/assemblyCommon/AssemblyToolboxView.cc
+++ b/assembly/assemblyCommon/AssemblyToolboxView.cc
@@ -49,6 +49,15 @@ AssemblyToolboxView::AssemblyToolboxView(const LStepExpressMotionManager* const 
   // ---------------------
 
   //
+  // Subassembly Pickup
+  //  * widget to pick up PSS+spacers subassembly
+  //  * used to process subassembly
+  //
+  subassembly_pickup_wid_ = new AssemblySubassemblyPickupWidget(motion_manager);
+
+  toolbox->addItem(subassembly_pickup_wid_, tr("PSS+spacers subassembly pickup"));
+  // ---------------------
+  //
   // Multi-Pickup Tester Widget
   //  * multiple iterations of "PatRec + pick-up + put-down" sequence
   //  * used to measure module-misplacement introduced by the pick-up
@@ -76,6 +85,8 @@ void AssemblyToolboxView::display_infoTab()
 
     "<ul>"
     "<li> <u>Record positions</u>: Save the current absolute position of the Motion Stage, and comment it if desired. It is possible to determine the relative distance between 2 registered positions.</li>"
+    "<br>"
+    "<li> <u>PSS+spacers Subassembly Pickup:</u> Pick up PSS+spacers assembly for processing such a subassembly</li>"
     "<br>"
     "<li> <u>Multi-Pickup Tester</u>: advanced functionality. Used to calibrate the relative movement required along the z-axis to pickup an object, when the camera is focused on that object. The basic procedure is: a) PatRec on sensor ref. marker; b) lower pickup tool; c) pickup object; d) lift up; e) put back down; f) rerun PatRec; g) repeat. At each repetition, can monitor in the PatRec tab whether the object was displaced in XY by the pickup, which indicates that excessive/insufficient pressure was applied to the object. Repeat this test until you are satisfied with the z-axis movement, and store its value in the cfg file.</li>"
     "<p style=color:orange><b>WARNING: you must activate the baseplate vacuum before starting !</p></b>"

--- a/assembly/assemblyCommon/AssemblyToolboxView.h
+++ b/assembly/assemblyCommon/AssemblyToolboxView.h
@@ -27,7 +27,7 @@ class AssemblyToolboxView : public QWidget
 
  public:
 
-  explicit AssemblyToolboxView(const LStepExpressMotionManager* const, QWidget* parent=nullptr);
+  explicit AssemblyToolboxView(const LStepExpressMotionManager* const, const AssemblySubassemblyPickup* const, QWidget* parent=nullptr);
   virtual ~AssemblyToolboxView() {}
 
   AssemblyPositionsRegistryWidget* PositionsRegistry_Widget() { return posreg_wid_; }

--- a/assembly/assemblyCommon/AssemblyToolboxView.h
+++ b/assembly/assemblyCommon/AssemblyToolboxView.h
@@ -16,6 +16,7 @@
 #include <LStepExpressMotionManager.h>
 #include <AssemblyMultiPickupTesterWidget.h>
 #include <AssemblyPositionsRegistryWidget.h>
+#include <AssemblySubassemblyPickupWidget.h>
 
 #include <QWidget>
 #include <QMessageBox>
@@ -30,11 +31,13 @@ class AssemblyToolboxView : public QWidget
   virtual ~AssemblyToolboxView() {}
 
   AssemblyPositionsRegistryWidget* PositionsRegistry_Widget() { return posreg_wid_; }
+  AssemblySubassemblyPickupWidget* SubassemblyPickup_Widget() { return subassembly_pickup_wid_; }
   AssemblyMultiPickupTesterWidget* MultiPickupTester_Widget() { return mupite_wid_; }
 
  protected:
 
   AssemblyPositionsRegistryWidget* posreg_wid_;
+  AssemblySubassemblyPickupWidget* subassembly_pickup_wid_;
   AssemblyMultiPickupTesterWidget* mupite_wid_;
 
  public slots:

--- a/assembly/assemblyCommon/CMakeLists.txt
+++ b/assembly/assemblyCommon/CMakeLists.txt
@@ -29,6 +29,8 @@ add_library(AssemblyCommon SHARED
         AssemblyAssemblyTextWidget.cc
         AssemblyMultiPickupTester.cc
         AssemblyMultiPickupTesterWidget.cc
+        AssemblySubassemblyPickup.cc
+        AssemblySubassemblyPickupWidget.cc
         AssemblyPositionsRegistryWidget.cc
         AssemblyToolboxView.cc
         AssemblySmartMotionManager.cc


### PR DESCRIPTION
This introduces a tool to pick up a PSS+Spacers subassembly. The mechanism is very similar to the usual assembly workflow, but takes the spacer heights into account.

This can be used in case a prepared PSS+Spacer subassembly should be glued to a MaPSA+BP subassembly.

The routine can be found in the `Toolbox` tab. After the successful pickup, the user can continue with Assembly part 3.

Requires #184 to be merged.