### PR TITLE
Qt version > 5.14 required due to earlier commits

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,7 +88,7 @@ endif(CURL_FOUND)
 
 set(CMAKE_AUTOMOC ON)
 
-find_package(Qt5 COMPONENTS Core Gui Widgets OpenGL Script Xml Svg Network Charts REQUIRED)
+find_package(Qt5 5.14 COMPONENTS Core Gui Widgets OpenGL Script Xml Svg Network Charts REQUIRED)
 
 set(ENV{ROOT_DIR} ENV{ROOTSYS}/cmake)
 find_package(ROOT 6.16 REQUIRED)


### PR DESCRIPTION
Due to #181 , Qt > 5.14 is required. This is now checked and issued by cmake.