### PR TITLE
Adapt assembly sequence to glue distribution on spacers + bugfix

### DIFF
--- a/assembly/assembly/AssemblyMainWindow.cc
+++ b/assembly/assembly/AssemblyMainWindow.cc
@@ -133,6 +133,8 @@ AssemblyMainWindow::AssemblyMainWindow(const QString& outputdir_path, const QStr
     motion_thread_->start();
 
     connect(motion_manager_, SIGNAL(restartMotionStage_request()), this, SLOT(messageBox_restartMotionStage())); //Display a pop-up GUI message whenever the MS gets automatically restarted
+
+    connect(motion_manager_, SIGNAL(warn_user_limit(double, char, double, double)), this, SLOT(warn_on_stage_limits(double, char, double, double)));
     /// -------------------
 
     /// Camera
@@ -1016,4 +1018,12 @@ void AssemblyMainWindow::switchAndUpdate_alignment_tab(bool psp_mode)
     else {emit set_alignmentMode_PSS_request();}
 
     return;
+}
+
+void AssemblyMainWindow::warn_on_stage_limits(const double target_pos, const char axis, const double limit_pos_lower, const double limit_pos_upper)
+{
+    QMessageBox::warning(0, QString("[AssemblyMainWindow]"),
+    QString("Attempting to move %1-axis to %2 . This is beyond the limit of this stage: [ %3 , %4 ]").arg(axis).arg(target_pos).arg(limit_pos_lower).arg(limit_pos_upper),
+        QMessageBox::Ok
+    );
 }

--- a/assembly/assembly/AssemblyMainWindow.h
+++ b/assembly/assembly/AssemblyMainWindow.h
@@ -115,6 +115,8 @@ class AssemblyMainWindow : public QMainWindow
   void update_alignment_tab_psp();
   void update_alignment_tab_pss();
 
+  void warn_on_stage_limits(const double target_pos, const char axis, const double limit_pos_lower, const double limit_pos_upper);
+
  signals:
 
   void images_ON();

--- a/assembly/assemblyCommon/AssemblyAssemblyV2.cc
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2.cc
@@ -34,6 +34,7 @@ AssemblyAssemblyV2::AssemblyAssemblyV2(const LStepExpressMotionManager* const mo
 
  , pickup1_Z_(0.)
  , pickup2_Z_(0.)
+ , makespace_Z(0.)
 
  , use_smartMove_(false)
  , in_action_(false)
@@ -1382,7 +1383,7 @@ void AssemblyAssemblyV2::ReturnToPlatform_finish()
   NQLog("AssemblyAssemblyV2", NQLog::Spam) << "ReturnToPlatform_finish"
      << ": emitting signal \"ReturnToPlatform_finished\"";
 
-  emit MakeSpaceOnPlatform_finished();
+  emit ReturnToPlatform_finished();
 
   NQLog("AssemblyAssemblyV2", NQLog::Message) << "ReturnToPlatform_finish"
      << ": assembly-step completed";

--- a/assembly/assemblyCommon/AssemblyAssemblyV2.cc
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2.cc
@@ -1285,7 +1285,7 @@ void AssemblyAssemblyV2::MakeSpaceOnPlatform_start()
 
   const double dx0 = 0.0;
   const double dy0 = 0.0;
-  const double dz0 = (makespace_Z - motion_->get_position_Z());
+  const double dz0 = makespace_Z;
   const double da0 = 0.0;
 
   if(dz0 <= 0.)
@@ -1346,7 +1346,7 @@ void AssemblyAssemblyV2::ReturnToPlatform_start()
 
   const double dx0 = 0.0;
   const double dy0 = 0.0;
-  const double dz0 = (-makespace_Z - motion_->get_position_Z());
+  const double dz0 = -makespace_Z;
   const double da0 = 0.0;
 
   if(dz0 >= 0.)

--- a/assembly/assemblyCommon/AssemblyAssemblyV2.cc
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2.cc
@@ -34,7 +34,7 @@ AssemblyAssemblyV2::AssemblyAssemblyV2(const LStepExpressMotionManager* const mo
 
  , pickup1_Z_(0.)
  , pickup2_Z_(0.)
- , makespace_Z(0.)
+ , makespace_Z_(0.)
 
  , use_smartMove_(false)
  , in_action_(false)
@@ -67,7 +67,7 @@ AssemblyAssemblyV2::AssemblyAssemblyV2(const LStepExpressMotionManager* const mo
   // (1: PSs to Spacers, 2: PSs+Spacers to MaPSA)
   pickup1_Z_ = config_->getValue<double>("main", "AssemblyAssembly_pickup1_Z");
   pickup2_Z_ = config_->getValue<double>("main", "AssemblyAssembly_pickup2_Z");
-  makespace_Z = config_->getValue<double>("main", "AssemblyAssembly_makespace_Z");
+  makespace_Z_ = config_->getValue<double>("main", "AssemblyAssembly_makespace_Z");
 
   alreadyClicked_LowerPickupToolOntoMaPSA = false; alreadyClicked_LowerPickupToolOntoPSS = false; alreadyClicked_LowerMaPSAOntoBaseplate = false; alreadyClicked_LowerPSSOntoSpacers = false; alreadyClicked_LowerPSSPlusSpacersOntoGluingStage = false; alreadyClicked_LowerPSSPlusSpacersOntoMaPSA = false;
 
@@ -1285,7 +1285,7 @@ void AssemblyAssemblyV2::MakeSpaceOnPlatform_start()
 
   const double dx0 = 0.0;
   const double dy0 = 0.0;
-  const double dz0 = makespace_Z;
+  const double dz0 = makespace_Z_;
   const double da0 = 0.0;
 
   if(dz0 <= 0.)
@@ -1346,7 +1346,7 @@ void AssemblyAssemblyV2::ReturnToPlatform_start()
 
   const double dx0 = 0.0;
   const double dy0 = 0.0;
-  const double dz0 = -makespace_Z;
+  const double dz0 = -makespace_Z_;
   const double da0 = 0.0;
 
   if(dz0 >= 0.)

--- a/assembly/assemblyCommon/AssemblyAssemblyV2.h
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2.h
@@ -100,6 +100,12 @@ class AssemblyAssemblyV2 : public QObject
   void ApplyPSPToPSSXYOffset_start();
   void ApplyPSPToPSSXYOffset_finish();
 
+  void MakeSpaceOnPlatform_start();
+  void MakeSpaceOnPlatform_finish();
+
+  void ReturnToPlatform_start();
+  void ReturnToPlatform_finish();
+
   void GoFromPSSPlusSpacersToMaPSAPositionToGluingStageRefPointXY_start();
   void GoFromPSSPlusSpacersToMaPSAPositionToGluingStageRefPointXY_finish();
 
@@ -182,6 +188,8 @@ class AssemblyAssemblyV2 : public QObject
   void GoToPSPMarkerIdealPosition_finished();
 
   void ApplyPSPToPSSXYOffset_finished();
+  void MakeSpaceOnPlatform_finished();
+  void ReturnToPlatform_finished();
   void PSSPlusSpacersToMaPSAPosition_registered();
 
   void GoFromPSSPlusSpacersToMaPSAPositionToGluingStageRefPointXY_finished();

--- a/assembly/assemblyCommon/AssemblyAssemblyV2.h
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2.h
@@ -48,6 +48,7 @@ class AssemblyAssemblyV2 : public QObject
 
   double pickup1_Z_;
   double pickup2_Z_;
+  double makespace_Z;
 
   bool use_smartMove_;
   bool in_action_;

--- a/assembly/assemblyCommon/AssemblyAssemblyV2.h
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2.h
@@ -49,6 +49,8 @@ class AssemblyAssemblyV2 : public QObject
   double pickup1_Z_;
   double pickup2_Z_;
   double makespace_Z_;
+  double position_z_before_makespace_;
+  bool position_z_before_makespace_stored_;
 
   bool use_smartMove_;
   bool in_action_;

--- a/assembly/assemblyCommon/AssemblyAssemblyV2.h
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2.h
@@ -48,7 +48,7 @@ class AssemblyAssemblyV2 : public QObject
 
   double pickup1_Z_;
   double pickup2_Z_;
-  double makespace_Z;
+  double makespace_Z_;
 
   bool use_smartMove_;
   bool in_action_;

--- a/assembly/assemblyCommon/AssemblyAssemblyV2View.cc
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2View.cc
@@ -625,9 +625,35 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const QObject* const assembly, QW
   // ----------
 
   bool skip = dynamic_cast<const AssemblyAssemblyV2*>(assembly) -> IsSkipDipping();
-  if (!skip)
+  if (skip)
+      {
+          // step: Make space on the platform by raising the pickup tool
+          {
+            ++assembly_step_N;
 
-  {
+            AssemblyAssemblyTextWidget* tmp_wid = new AssemblyAssemblyTextWidget;
+            tmp_wid->label()->setText(QString::number(assembly_step_N));
+            tmp_wid->text()->setText("Move up pickup tool to make space for glue dispensing");
+            PSSToMaPSA_lay->addWidget(tmp_wid);
+
+            tmp_wid->connect_action(assembly, SLOT(MakeSpaceOnPlatform_start()), SIGNAL(MakeSpaceOnPlatform_finished()));
+          }
+          // ----------
+
+          // step: Return to the platform by lowering the pickup tool
+          {
+            ++assembly_step_N;
+
+            AssemblyAssemblyTextWidget* tmp_wid = new AssemblyAssemblyTextWidget;
+            tmp_wid->label()->setText(QString::number(assembly_step_N));
+            tmp_wid->text()->setText("Return to previous position");
+            PSSToMaPSA_lay->addWidget(tmp_wid);
+
+            tmp_wid->connect_action(assembly, SLOT(ReturnToPlatform_start()), SIGNAL(ReturnToPlatform_finished()));
+          }
+          // ----------
+
+      } else {
       // step: Register "PS-s to MaPSA" XYZA Position
       // (position that will be used as starting point to lower "PS-s + Spacers" on MaPSA;
       //  the height corresponds to the best-focus height on PS-p surface, as resulting from the PS-p alignment,

--- a/assembly/assemblyCommon/AssemblyAssemblyV2View.cc
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2View.cc
@@ -631,9 +631,9 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const QObject* const assembly, QW
           {
             ++assembly_step_N;
 
-            AssemblyAssemblyTextWidget* tmp_wid = new AssemblyAssemblyTextWidget;
+            AssemblyAssemblyActionWidget* tmp_wid = new AssemblyAssemblyActionWidget;
             tmp_wid->label()->setText(QString::number(assembly_step_N));
-            tmp_wid->text()->setText("Move up pickup tool to make space for glue dispensing");
+            tmp_wid->button()->setText("Move up pickup tool to make space for glue dispensing");
             PSSToMaPSA_lay->addWidget(tmp_wid);
 
             tmp_wid->connect_action(assembly, SLOT(MakeSpaceOnPlatform_start()), SIGNAL(MakeSpaceOnPlatform_finished()));
@@ -644,9 +644,9 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const QObject* const assembly, QW
           {
             ++assembly_step_N;
 
-            AssemblyAssemblyTextWidget* tmp_wid = new AssemblyAssemblyTextWidget;
+            AssemblyAssemblyActionWidget* tmp_wid = new AssemblyAssemblyActionWidget;
             tmp_wid->label()->setText(QString::number(assembly_step_N));
-            tmp_wid->text()->setText("Return to previous position");
+            tmp_wid->button()->setText("Return to previous position");
             PSSToMaPSA_lay->addWidget(tmp_wid);
 
             tmp_wid->connect_action(assembly, SLOT(ReturnToPlatform_start()), SIGNAL(ReturnToPlatform_finished()));

--- a/assembly/assemblyCommon/AssemblyAssemblyV2View.cc
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2View.cc
@@ -37,6 +37,8 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const QObject* const assembly, QW
     return;
   }
 
+  bool skip_dipping = dynamic_cast<const AssemblyAssemblyV2*>(assembly) -> IsSkipDipping();
+
   QVBoxLayout* layout = new QVBoxLayout;
   this->setLayout(layout);
 
@@ -449,29 +451,66 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const QObject* const assembly, QW
   }
   // ----------
 
-  // step: Dispense Glue on Spacers and Place them on Assembly Platform
-  {
-    ++assembly_step_N;
+  if(skip_dipping){
+    // step: Dispense Slow Glue on Spacers and Place them on Assembly Platform
+    {
+      ++assembly_step_N;
 
-    AssemblyAssemblyTextWidget* tmp_wid = new AssemblyAssemblyTextWidget;
-    tmp_wid->label()->setText(QString::number(assembly_step_N));
-    tmp_wid->text()->setText("Dispense Glue on Spacers and Place them on Assembly Platform");
-    PSSToSpacers_lay->addWidget(tmp_wid);
+      AssemblyAssemblyTextWidget* tmp_wid = new AssemblyAssemblyTextWidget;
+      tmp_wid->label()->setText(QString::number(assembly_step_N));
+      tmp_wid->text()->setText("Dispense Slow Glue on Spacers and Place them on Assembly Platform");
+      PSSToSpacers_lay->addWidget(tmp_wid);
+    }
+    // ----------
+
+    // step: Enable Vacuum on Spacers
+    {
+      ++assembly_step_N;
+
+      AssemblyAssemblyActionWidget* tmp_wid = new AssemblyAssemblyActionWidget;
+      tmp_wid->label()->setText(QString::number(assembly_step_N));
+      tmp_wid->button()->setText("Enable Vacuum on Spacers");
+      PSSToSpacers_lay->addWidget(tmp_wid);
+
+      tmp_wid->connect_action(assembly, SLOT(EnableVacuumSpacers_start()), SIGNAL(EnableVacuumSpacers_finished()));
+    }
+    // ----------
+
+    // step: Dispense Fast Glue on Spacers
+    {
+      ++assembly_step_N;
+
+      AssemblyAssemblyTextWidget* tmp_wid = new AssemblyAssemblyTextWidget;
+      tmp_wid->label()->setText(QString::number(assembly_step_N));
+      tmp_wid->text()->setText("Dispense Fast Glue on Spacers");
+      PSSToSpacers_lay->addWidget(tmp_wid);
+    }
+    // ----------
+  } else {
+    // step: Dispense Glue on Spacers and Place them on Assembly Platform
+    {
+      ++assembly_step_N;
+
+      AssemblyAssemblyTextWidget* tmp_wid = new AssemblyAssemblyTextWidget;
+      tmp_wid->label()->setText(QString::number(assembly_step_N));
+      tmp_wid->text()->setText("Dispense Glue on Spacers and Place them on Assembly Platform");
+      PSSToSpacers_lay->addWidget(tmp_wid);
+    }
+    // ----------
+
+    // step: Enable Vacuum on Spacers
+    {
+      ++assembly_step_N;
+
+      AssemblyAssemblyActionWidget* tmp_wid = new AssemblyAssemblyActionWidget;
+      tmp_wid->label()->setText(QString::number(assembly_step_N));
+      tmp_wid->button()->setText("Enable Vacuum on Spacers");
+      PSSToSpacers_lay->addWidget(tmp_wid);
+
+      tmp_wid->connect_action(assembly, SLOT(EnableVacuumSpacers_start()), SIGNAL(EnableVacuumSpacers_finished()));
+    }
+    // ----------
   }
-  // ----------
-
-  // step: Enable Vacuum on Spacers
-  {
-    ++assembly_step_N;
-
-    AssemblyAssemblyActionWidget* tmp_wid = new AssemblyAssemblyActionWidget;
-    tmp_wid->label()->setText(QString::number(assembly_step_N));
-    tmp_wid->button()->setText("Enable Vacuum on Spacers");
-    PSSToSpacers_lay->addWidget(tmp_wid);
-
-    tmp_wid->connect_action(assembly, SLOT(EnableVacuumSpacers_start()), SIGNAL(EnableVacuumSpacers_finished()));
-  }
-  // ----------
 
   // step: Lower PS-s onto Spacers
   {
@@ -540,7 +579,11 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const QObject* const assembly, QW
 
     AssemblyAssemblyTextWidget* tmp_wid = new AssemblyAssemblyTextWidget;
     tmp_wid->label()->setText(QString::number(assembly_step_N));
-    tmp_wid->text()->setText("Place \"MaPSA + Baseplate\" on Assembly Platform with Baseplate Pins");
+    if(skip_dipping){
+      tmp_wid->text()->setText("Dispense Slow Glue on \"MaPSA + Baseplate\" and Place on Assembly Platform with Baseplate Pins");
+    } else {
+      tmp_wid->text()->setText("Place \"MaPSA + Baseplate\" on Assembly Platform with Baseplate Pins");
+    }
     PSSToMaPSA_lay->addWidget(tmp_wid);
   }
   // ----------
@@ -624,8 +667,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const QObject* const assembly, QW
   }
   // ----------
 
-  bool skip = dynamic_cast<const AssemblyAssemblyV2*>(assembly) -> IsSkipDipping();
-  if (skip)
+  if (skip_dipping)
       {
           // step: Make space on the platform by raising the pickup tool
           {
@@ -637,6 +679,17 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const QObject* const assembly, QW
             PSSToMaPSA_lay->addWidget(tmp_wid);
 
             tmp_wid->connect_action(assembly, SLOT(MakeSpaceOnPlatform_start()), SIGNAL(MakeSpaceOnPlatform_finished()));
+          }
+          // ----------
+
+          // step: Dispense Fast Glue on "MaPSA + Baseplate"
+          {
+            ++assembly_step_N;
+
+            AssemblyAssemblyTextWidget* tmp_wid = new AssemblyAssemblyTextWidget;
+            tmp_wid->label()->setText(QString::number(assembly_step_N));
+            tmp_wid->text()->setText("Dispense Fast Glue on \"MaPSA + Baseplate\"");
+            PSSToMaPSA_lay->addWidget(tmp_wid);
           }
           // ----------
 

--- a/assembly/assemblyCommon/AssemblyAssemblyV2View.cc
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2View.cc
@@ -418,7 +418,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const QObject* const assembly, QW
 
     AssemblyAssemblyActionWidget* tmp_wid = new AssemblyAssemblyActionWidget;
     tmp_wid->label()->setText(QString::number(assembly_step_N));
-    tmp_wid->button()->setText("Disable Vacuum on PS-s");
+    tmp_wid->button()->setText("Disable Vacuum on Assembly Platform");
     PSSToSpacers_lay->addWidget(tmp_wid);
 
     tmp_wid->connect_action(assembly, SLOT(DisableVacuumBaseplate_start()), SIGNAL(DisableVacuumBaseplate_finished()));

--- a/assembly/assemblyCommon/AssemblyParametersView.cc
+++ b/assembly/assemblyCommon/AssemblyParametersView.cc
@@ -545,7 +545,7 @@ AssemblyParametersView::AssemblyParametersView(QWidget* parent)
   // Connections to text changes
   for(const auto& key : this->entries_map())
   {
-    connect(this->get(key.first), SIGNAL(textChanged(const QString&)), this, SLOT(overwriteParameter(const QString&)));
+    connect(this->get(key.first), SIGNAL(textEdited(const QString&)), this, SLOT(overwriteParameter(const QString&)));
   }
 }
 
@@ -693,6 +693,7 @@ void AssemblyParametersView::overwriteParameter(const QString& value)
            << ": changing parameter " << key.first << " to " << val;
         ptr_qedit->setStyleSheet("");
         config_->setValue("parameters", key.first, value);
+        ptr_qedit->setText(value);
       } else
       {
         NQLog("AssemblyParametersView", NQLog::Fatal) << "overwriteParameter"

--- a/assembly/assemblyCommon/LStepExpressMotionManager.cc
+++ b/assembly/assemblyCommon/LStepExpressMotionManager.cc
@@ -211,24 +211,28 @@ void LStepExpressMotionManager::moveRelative(const std::vector<double>& values)
     const double x1(this->get_position_X() + values[0]);
     if(x1 < x_lowerBound_ || x1 > x_upperBound_){
       NQLog("LStepExpressMotionManager", NQLog::Warning) << "ERROR ! Relative movement not executed, Motion Stage would exceed its boundary in X:" << x1;
+      warn_user_limit(x1, 'x', x_lowerBound_, x_upperBound_);
       return;
     }
 
     const double y1(this->get_position_Y() + values[1]);
     if(y1 < y_lowerBound_ || y1 > y_upperBound_){
       NQLog("LStepExpressMotionManager", NQLog::Warning) << "ERROR ! Relative movement not executed, Motion Stage would exceed its boundary in Y:" << y1;
+      warn_user_limit(y1, 'y', y_lowerBound_, y_upperBound_);
       return;
     }
 
     const double z1(this->get_position_Z() + values[2]);
     if(z1 < z_lowerBound_ || z1 > z_upperBound_){
       NQLog("LStepExpressMotionManager", NQLog::Warning) << "ERROR ! Relative movement not executed, Motion Stage would exceed its boundary in Z:" << z1;
+      warn_user_limit(z1, 'z', z_lowerBound_, z_upperBound_);
       return;
     }
 
     const double a1(this->get_position_A() + values[3]);
     if(a1 < a_lowerBound_ || a1 > a_upperBound_){
       NQLog("LStepExpressMotionManager", NQLog::Warning) << "ERROR ! Relative movement not executed, Motion Stage would exceed its boundary in A:" << a1;
+      warn_user_limit(a1, 'a', a_lowerBound_, a_upperBound_);
       return;
     }
 
@@ -247,24 +251,28 @@ void LStepExpressMotionManager::moveRelative(const double dx, const double dy, c
     const double x1(this->get_position_X() + dx);
     if(x1 < x_lowerBound_ || x1 > x_upperBound_){
       NQLog("LStepExpressMotionManager", NQLog::Warning) << "ERROR ! Relative movement not executed, Motion Stage would exceed its boundary in X:" << x1;
+      warn_user_limit(x1, 'x', x_lowerBound_, x_upperBound_);
       return;
     }
 
     const double y1(this->get_position_Y() + dy);
     if(y1 < y_lowerBound_ || y1 > y_upperBound_){
       NQLog("LStepExpressMotionManager", NQLog::Warning) << "ERROR ! Relative movement not executed, Motion Stage would exceed its boundary in Y:" << y1;
+      warn_user_limit(y1, 'y', y_lowerBound_, y_upperBound_);
       return;
     }
 
     const double z1(this->get_position_Z() + dz);
     if(z1 < z_lowerBound_ || z1 > z_upperBound_){
       NQLog("LStepExpressMotionManager", NQLog::Warning) << "ERROR ! Relative movement not executed, Motion Stage would exceed its boundary in Z:" << z1;
+      warn_user_limit(z1, 'z', z_lowerBound_, z_upperBound_);
       return;
     }
 
     const double a1(this->get_position_A() + da);
     if(a1 < a_lowerBound_ || a1 > a_upperBound_){
       NQLog("LStepExpressMotionManager", NQLog::Warning) << "ERROR ! Relative movement not executed, Motion Stage would exceed its boundary in A:" << a1;
+      warn_user_limit(a1, 'a', a_lowerBound_, a_upperBound_);
       return;
     }
 
@@ -284,6 +292,7 @@ void LStepExpressMotionManager::moveRelative(const unsigned int axis, const doub
       const double x1(this->get_position_X() + value);
       if(x1 < x_lowerBound_ || x1 > x_upperBound_){
         NQLog("LStepExpressMotionManager", NQLog::Warning) << "ERROR ! Relative movement not executed, Motion Stage would exceed its boundary in X:" << x1;
+        warn_user_limit(x1, 'x', x_lowerBound_, x_upperBound_);
         return;
       }
     }
@@ -291,6 +300,7 @@ void LStepExpressMotionManager::moveRelative(const unsigned int axis, const doub
       const double y1(this->get_position_Y() + value);
       if(y1 < y_lowerBound_ || y1 > y_upperBound_){
         NQLog("LStepExpressMotionManager", NQLog::Warning) << "ERROR ! Relative movement not executed, Motion Stage would exceed its boundary in Y:" << y1;
+        warn_user_limit(y1, 'y', y_lowerBound_, y_upperBound_);
         return;
       }
     }
@@ -298,6 +308,7 @@ void LStepExpressMotionManager::moveRelative(const unsigned int axis, const doub
       const double z1(this->get_position_Z() + value);
       if(z1 < z_lowerBound_ || z1 > z_upperBound_){
         NQLog("LStepExpressMotionManager", NQLog::Warning) << "ERROR ! Relative movement not executed, Motion Stage would exceed its boundary in Z:" << z1;
+        warn_user_limit(z1, 'z', z_lowerBound_, z_upperBound_);
         return;
       }
     }
@@ -305,6 +316,7 @@ void LStepExpressMotionManager::moveRelative(const unsigned int axis, const doub
       const double a1(this->get_position_A() + value);
       if(a1 < a_lowerBound_ || a1 > a_upperBound_){
         NQLog("LStepExpressMotionManager", NQLog::Warning) << "ERROR ! Relative movement not executed, Motion Stage would exceed its boundary in A:" << a1;
+        warn_user_limit(a1, 'a', a_lowerBound_, a_upperBound_);
         return;
       }
     }
@@ -329,24 +341,28 @@ void LStepExpressMotionManager::moveAbsolute(const std::vector<double>& values)
     const double x1(values[0]);
     if(x1 < x_lowerBound_ || x1 > x_upperBound_){
       NQLog("LStepExpressMotionManager", NQLog::Warning) << "ERROR ! Absolute movement not executed, Motion Stage would exceed its boundary in X:" << x1;
+      warn_user_limit(x1, 'x', x_lowerBound_, x_upperBound_);
       return;
     }
 
     const double y1(values[1]);
     if(y1 < y_lowerBound_ || y1 > y_upperBound_){
       NQLog("LStepExpressMotionManager", NQLog::Warning) << "ERROR ! Absolute movement not executed, Motion Stage would exceed its boundary in Y:" << y1;
+      warn_user_limit(y1, 'y', y_lowerBound_, y_upperBound_);
       return;
     }
 
     const double z1(values[2]);
     if(z1 < z_lowerBound_ || z1 > z_upperBound_){
       NQLog("LStepExpressMotionManager", NQLog::Warning) << "ERROR ! Absolute movement not executed, Motion Stage would exceed its boundary in Z:" << z1;
+      warn_user_limit(z1, 'z', z_lowerBound_, z_upperBound_);
       return;
     }
 
     const double a1(values[3]);
     if(a1 < a_lowerBound_ || a1 > a_upperBound_){
       NQLog("LStepExpressMotionManager", NQLog::Warning) << "ERROR ! Absolute movement not executed, Motion Stage would exceed its boundary in A:" << a1;
+      warn_user_limit(a1, 'a', a_lowerBound_, a_upperBound_);
       return;
     }
 
@@ -364,21 +380,25 @@ void LStepExpressMotionManager::moveAbsolute(const double x, const double y, con
     //Checks on MS boundaries
     if(x < x_lowerBound_ || x > x_upperBound_){
       NQLog("LStepExpressMotionManager", NQLog::Warning) << "ERROR ! Absolute movement not executed, Motion Stage would exceed its boundary in X:" << x;
+      warn_user_limit(x, 'x', x_lowerBound_, x_upperBound_);
       return;
     }
 
     if(y < y_lowerBound_ || y > y_upperBound_){
       NQLog("LStepExpressMotionManager", NQLog::Warning) << "ERROR ! Absolute movement not executed, Motion Stage would exceed its boundary in Y:" << y;
+      warn_user_limit(y, 'y', y_lowerBound_, y_upperBound_);
       return;
     }
 
     if(z < z_lowerBound_ || z > z_upperBound_){
       NQLog("LStepExpressMotionManager", NQLog::Warning) << "ERROR ! Absolute movement not executed, Motion Stage would exceed its boundary in Z:" << z;
+      warn_user_limit(z, 'z', z_lowerBound_, z_upperBound_);
       return;
     }
 
     if(a < a_lowerBound_ || a > a_upperBound_){
       NQLog("LStepExpressMotionManager", NQLog::Warning) << "ERROR ! Absolute movement not executed, Motion Stage would exceed its boundary in A:" << a;
+      warn_user_limit(a, 'a', a_lowerBound_, a_upperBound_);
       return;
     }
 
@@ -397,24 +417,28 @@ void LStepExpressMotionManager::moveAbsolute(const unsigned int axis, const doub
     if(axis == 0){
       if(value < x_lowerBound_ || value > x_upperBound_){
         NQLog("LStepExpressMotionManager", NQLog::Warning) << "ERROR ! Absolute movement not executed, Motion Stage would exceed its boundary in X:" << value;
+        warn_user_limit(value, 'x', x_lowerBound_, x_upperBound_);
         return;
       }
     }
     else if(axis == 1){
       if(value < y_lowerBound_ || value > y_upperBound_){
         NQLog("LStepExpressMotionManager", NQLog::Warning) << "ERROR ! Absolute movement not executed, Motion Stage would exceed its boundary in Y:" << value;
+        warn_user_limit(value, 'y', y_lowerBound_, y_upperBound_);
         return;
       }
     }
     else if(axis == 2){
       if(value < z_lowerBound_ || value > z_upperBound_){
         NQLog("LStepExpressMotionManager", NQLog::Warning) << "ERROR ! Absolute movement not executed, Motion Stage would exceed its boundary in Z:" << value;
+        warn_user_limit(value, 'z', z_lowerBound_, z_upperBound_);
         return;
       }
     }
     else if(axis == 3){
       if(value < a_lowerBound_ || value > a_upperBound_){
         NQLog("LStepExpressMotionManager", NQLog::Warning) << "ERROR ! Absolute movement not executed, Motion Stage would exceed its boundary in A:" << value;
+        warn_user_limit(value, 'a', a_lowerBound_, a_upperBound_);
         return;
       }
     }
@@ -631,4 +655,12 @@ void LStepExpressMotionManager::set_movements_priorities_XYZA(const double x, co
     }
 
     return;
+}
+
+void LStepExpressMotionManager::warn_user_limit(double target_pos, char axis, double limit_pos_lower, double limit_pos_upper)
+{
+    QMessageBox::warning(0, tr("[LStepExpressMotionManager]"),
+    QString("Attempting to move %1-axis to %2 . This is beyond the limit of this stage: [ %3 , %4 ]").arg(axis).arg(target_pos).arg(limit_pos_lower).arg(limit_pos_upper),
+        QMessageBox::Ok
+    );
 }

--- a/assembly/assemblyCommon/LStepExpressMotionManager.cc
+++ b/assembly/assemblyCommon/LStepExpressMotionManager.cc
@@ -211,28 +211,28 @@ void LStepExpressMotionManager::moveRelative(const std::vector<double>& values)
     const double x1(this->get_position_X() + values[0]);
     if(x1 < x_lowerBound_ || x1 > x_upperBound_){
       NQLog("LStepExpressMotionManager", NQLog::Warning) << "ERROR ! Relative movement not executed, Motion Stage would exceed its boundary in X:" << x1;
-      warn_user_limit(x1, 'x', x_lowerBound_, x_upperBound_);
+      emit warn_user_limit(x1, 'x', x_lowerBound_, x_upperBound_);
       return;
     }
 
     const double y1(this->get_position_Y() + values[1]);
     if(y1 < y_lowerBound_ || y1 > y_upperBound_){
       NQLog("LStepExpressMotionManager", NQLog::Warning) << "ERROR ! Relative movement not executed, Motion Stage would exceed its boundary in Y:" << y1;
-      warn_user_limit(y1, 'y', y_lowerBound_, y_upperBound_);
+      emit warn_user_limit(y1, 'y', y_lowerBound_, y_upperBound_);
       return;
     }
 
     const double z1(this->get_position_Z() + values[2]);
     if(z1 < z_lowerBound_ || z1 > z_upperBound_){
       NQLog("LStepExpressMotionManager", NQLog::Warning) << "ERROR ! Relative movement not executed, Motion Stage would exceed its boundary in Z:" << z1;
-      warn_user_limit(z1, 'z', z_lowerBound_, z_upperBound_);
+      emit warn_user_limit(z1, 'z', z_lowerBound_, z_upperBound_);
       return;
     }
 
     const double a1(this->get_position_A() + values[3]);
     if(a1 < a_lowerBound_ || a1 > a_upperBound_){
       NQLog("LStepExpressMotionManager", NQLog::Warning) << "ERROR ! Relative movement not executed, Motion Stage would exceed its boundary in A:" << a1;
-      warn_user_limit(a1, 'a', a_lowerBound_, a_upperBound_);
+      emit warn_user_limit(a1, 'a', a_lowerBound_, a_upperBound_);
       return;
     }
 
@@ -251,28 +251,28 @@ void LStepExpressMotionManager::moveRelative(const double dx, const double dy, c
     const double x1(this->get_position_X() + dx);
     if(x1 < x_lowerBound_ || x1 > x_upperBound_){
       NQLog("LStepExpressMotionManager", NQLog::Warning) << "ERROR ! Relative movement not executed, Motion Stage would exceed its boundary in X:" << x1;
-      warn_user_limit(x1, 'x', x_lowerBound_, x_upperBound_);
+      emit warn_user_limit(x1, 'x', x_lowerBound_, x_upperBound_);
       return;
     }
 
     const double y1(this->get_position_Y() + dy);
     if(y1 < y_lowerBound_ || y1 > y_upperBound_){
       NQLog("LStepExpressMotionManager", NQLog::Warning) << "ERROR ! Relative movement not executed, Motion Stage would exceed its boundary in Y:" << y1;
-      warn_user_limit(y1, 'y', y_lowerBound_, y_upperBound_);
+      emit warn_user_limit(y1, 'y', y_lowerBound_, y_upperBound_);
       return;
     }
 
     const double z1(this->get_position_Z() + dz);
     if(z1 < z_lowerBound_ || z1 > z_upperBound_){
       NQLog("LStepExpressMotionManager", NQLog::Warning) << "ERROR ! Relative movement not executed, Motion Stage would exceed its boundary in Z:" << z1;
-      warn_user_limit(z1, 'z', z_lowerBound_, z_upperBound_);
+      emit warn_user_limit(z1, 'z', z_lowerBound_, z_upperBound_);
       return;
     }
 
     const double a1(this->get_position_A() + da);
     if(a1 < a_lowerBound_ || a1 > a_upperBound_){
       NQLog("LStepExpressMotionManager", NQLog::Warning) << "ERROR ! Relative movement not executed, Motion Stage would exceed its boundary in A:" << a1;
-      warn_user_limit(a1, 'a', a_lowerBound_, a_upperBound_);
+      emit warn_user_limit(a1, 'a', a_lowerBound_, a_upperBound_);
       return;
     }
 
@@ -292,7 +292,7 @@ void LStepExpressMotionManager::moveRelative(const unsigned int axis, const doub
       const double x1(this->get_position_X() + value);
       if(x1 < x_lowerBound_ || x1 > x_upperBound_){
         NQLog("LStepExpressMotionManager", NQLog::Warning) << "ERROR ! Relative movement not executed, Motion Stage would exceed its boundary in X:" << x1;
-        warn_user_limit(x1, 'x', x_lowerBound_, x_upperBound_);
+        emit warn_user_limit(x1, 'x', x_lowerBound_, x_upperBound_);
         return;
       }
     }
@@ -300,7 +300,7 @@ void LStepExpressMotionManager::moveRelative(const unsigned int axis, const doub
       const double y1(this->get_position_Y() + value);
       if(y1 < y_lowerBound_ || y1 > y_upperBound_){
         NQLog("LStepExpressMotionManager", NQLog::Warning) << "ERROR ! Relative movement not executed, Motion Stage would exceed its boundary in Y:" << y1;
-        warn_user_limit(y1, 'y', y_lowerBound_, y_upperBound_);
+        emit warn_user_limit(y1, 'y', y_lowerBound_, y_upperBound_);
         return;
       }
     }
@@ -308,7 +308,7 @@ void LStepExpressMotionManager::moveRelative(const unsigned int axis, const doub
       const double z1(this->get_position_Z() + value);
       if(z1 < z_lowerBound_ || z1 > z_upperBound_){
         NQLog("LStepExpressMotionManager", NQLog::Warning) << "ERROR ! Relative movement not executed, Motion Stage would exceed its boundary in Z:" << z1;
-        warn_user_limit(z1, 'z', z_lowerBound_, z_upperBound_);
+        emit warn_user_limit(z1, 'z', z_lowerBound_, z_upperBound_);
         return;
       }
     }
@@ -316,7 +316,7 @@ void LStepExpressMotionManager::moveRelative(const unsigned int axis, const doub
       const double a1(this->get_position_A() + value);
       if(a1 < a_lowerBound_ || a1 > a_upperBound_){
         NQLog("LStepExpressMotionManager", NQLog::Warning) << "ERROR ! Relative movement not executed, Motion Stage would exceed its boundary in A:" << a1;
-        warn_user_limit(a1, 'a', a_lowerBound_, a_upperBound_);
+        emit warn_user_limit(a1, 'a', a_lowerBound_, a_upperBound_);
         return;
       }
     }
@@ -341,28 +341,28 @@ void LStepExpressMotionManager::moveAbsolute(const std::vector<double>& values)
     const double x1(values[0]);
     if(x1 < x_lowerBound_ || x1 > x_upperBound_){
       NQLog("LStepExpressMotionManager", NQLog::Warning) << "ERROR ! Absolute movement not executed, Motion Stage would exceed its boundary in X:" << x1;
-      warn_user_limit(x1, 'x', x_lowerBound_, x_upperBound_);
+      emit warn_user_limit(x1, 'x', x_lowerBound_, x_upperBound_);
       return;
     }
 
     const double y1(values[1]);
     if(y1 < y_lowerBound_ || y1 > y_upperBound_){
       NQLog("LStepExpressMotionManager", NQLog::Warning) << "ERROR ! Absolute movement not executed, Motion Stage would exceed its boundary in Y:" << y1;
-      warn_user_limit(y1, 'y', y_lowerBound_, y_upperBound_);
+      emit warn_user_limit(y1, 'y', y_lowerBound_, y_upperBound_);
       return;
     }
 
     const double z1(values[2]);
     if(z1 < z_lowerBound_ || z1 > z_upperBound_){
       NQLog("LStepExpressMotionManager", NQLog::Warning) << "ERROR ! Absolute movement not executed, Motion Stage would exceed its boundary in Z:" << z1;
-      warn_user_limit(z1, 'z', z_lowerBound_, z_upperBound_);
+      emit warn_user_limit(z1, 'z', z_lowerBound_, z_upperBound_);
       return;
     }
 
     const double a1(values[3]);
     if(a1 < a_lowerBound_ || a1 > a_upperBound_){
       NQLog("LStepExpressMotionManager", NQLog::Warning) << "ERROR ! Absolute movement not executed, Motion Stage would exceed its boundary in A:" << a1;
-      warn_user_limit(a1, 'a', a_lowerBound_, a_upperBound_);
+      emit warn_user_limit(a1, 'a', a_lowerBound_, a_upperBound_);
       return;
     }
 
@@ -380,25 +380,25 @@ void LStepExpressMotionManager::moveAbsolute(const double x, const double y, con
     //Checks on MS boundaries
     if(x < x_lowerBound_ || x > x_upperBound_){
       NQLog("LStepExpressMotionManager", NQLog::Warning) << "ERROR ! Absolute movement not executed, Motion Stage would exceed its boundary in X:" << x;
-      warn_user_limit(x, 'x', x_lowerBound_, x_upperBound_);
+      emit warn_user_limit(x, 'x', x_lowerBound_, x_upperBound_);
       return;
     }
 
     if(y < y_lowerBound_ || y > y_upperBound_){
       NQLog("LStepExpressMotionManager", NQLog::Warning) << "ERROR ! Absolute movement not executed, Motion Stage would exceed its boundary in Y:" << y;
-      warn_user_limit(y, 'y', y_lowerBound_, y_upperBound_);
+      emit warn_user_limit(y, 'y', y_lowerBound_, y_upperBound_);
       return;
     }
 
     if(z < z_lowerBound_ || z > z_upperBound_){
       NQLog("LStepExpressMotionManager", NQLog::Warning) << "ERROR ! Absolute movement not executed, Motion Stage would exceed its boundary in Z:" << z;
-      warn_user_limit(z, 'z', z_lowerBound_, z_upperBound_);
+      emit warn_user_limit(z, 'z', z_lowerBound_, z_upperBound_);
       return;
     }
 
     if(a < a_lowerBound_ || a > a_upperBound_){
       NQLog("LStepExpressMotionManager", NQLog::Warning) << "ERROR ! Absolute movement not executed, Motion Stage would exceed its boundary in A:" << a;
-      warn_user_limit(a, 'a', a_lowerBound_, a_upperBound_);
+      emit warn_user_limit(a, 'a', a_lowerBound_, a_upperBound_);
       return;
     }
 
@@ -417,28 +417,28 @@ void LStepExpressMotionManager::moveAbsolute(const unsigned int axis, const doub
     if(axis == 0){
       if(value < x_lowerBound_ || value > x_upperBound_){
         NQLog("LStepExpressMotionManager", NQLog::Warning) << "ERROR ! Absolute movement not executed, Motion Stage would exceed its boundary in X:" << value;
-        warn_user_limit(value, 'x', x_lowerBound_, x_upperBound_);
+        emit warn_user_limit(value, 'x', x_lowerBound_, x_upperBound_);
         return;
       }
     }
     else if(axis == 1){
       if(value < y_lowerBound_ || value > y_upperBound_){
         NQLog("LStepExpressMotionManager", NQLog::Warning) << "ERROR ! Absolute movement not executed, Motion Stage would exceed its boundary in Y:" << value;
-        warn_user_limit(value, 'y', y_lowerBound_, y_upperBound_);
+        emit warn_user_limit(value, 'y', y_lowerBound_, y_upperBound_);
         return;
       }
     }
     else if(axis == 2){
       if(value < z_lowerBound_ || value > z_upperBound_){
         NQLog("LStepExpressMotionManager", NQLog::Warning) << "ERROR ! Absolute movement not executed, Motion Stage would exceed its boundary in Z:" << value;
-        warn_user_limit(value, 'z', z_lowerBound_, z_upperBound_);
+        emit warn_user_limit(value, 'z', z_lowerBound_, z_upperBound_);
         return;
       }
     }
     else if(axis == 3){
       if(value < a_lowerBound_ || value > a_upperBound_){
         NQLog("LStepExpressMotionManager", NQLog::Warning) << "ERROR ! Absolute movement not executed, Motion Stage would exceed its boundary in A:" << value;
-        warn_user_limit(value, 'a', a_lowerBound_, a_upperBound_);
+        emit warn_user_limit(value, 'a', a_lowerBound_, a_upperBound_);
         return;
       }
     }
@@ -655,12 +655,4 @@ void LStepExpressMotionManager::set_movements_priorities_XYZA(const double x, co
     }
 
     return;
-}
-
-void LStepExpressMotionManager::warn_user_limit(double target_pos, char axis, double limit_pos_lower, double limit_pos_upper)
-{
-    QMessageBox::warning(0, tr("[LStepExpressMotionManager]"),
-    QString("Attempting to move %1-axis to %2 . This is beyond the limit of this stage: [ %3 , %4 ]").arg(axis).arg(target_pos).arg(limit_pos_lower).arg(limit_pos_upper),
-        QMessageBox::Ok
-    );
 }

--- a/assembly/assemblyCommon/LStepExpressMotionManager.cc
+++ b/assembly/assemblyCommon/LStepExpressMotionManager.cc
@@ -210,29 +210,25 @@ void LStepExpressMotionManager::moveRelative(const std::vector<double>& values)
     //Checks on MS boundaries
     const double x1(this->get_position_X() + values[0]);
     if(x1 < x_lowerBound_ || x1 > x_upperBound_){
-      NQLog("LStepExpressMotionManager", NQLog::Warning) << "ERROR ! Relative movement not executed, Motion Stage would exceed its boundary in X:" << x1;
-      emit warn_user_limit(x1, 'x', x_lowerBound_, x_upperBound_);
+      warn_on_limit(x1, 'x', x_lowerBound_, x_upperBound_);
       return;
     }
 
     const double y1(this->get_position_Y() + values[1]);
     if(y1 < y_lowerBound_ || y1 > y_upperBound_){
-      NQLog("LStepExpressMotionManager", NQLog::Warning) << "ERROR ! Relative movement not executed, Motion Stage would exceed its boundary in Y:" << y1;
-      emit warn_user_limit(y1, 'y', y_lowerBound_, y_upperBound_);
+      warn_on_limit(y1, 'y', y_lowerBound_, y_upperBound_);
       return;
     }
 
     const double z1(this->get_position_Z() + values[2]);
     if(z1 < z_lowerBound_ || z1 > z_upperBound_){
-      NQLog("LStepExpressMotionManager", NQLog::Warning) << "ERROR ! Relative movement not executed, Motion Stage would exceed its boundary in Z:" << z1;
-      emit warn_user_limit(z1, 'z', z_lowerBound_, z_upperBound_);
+      warn_on_limit(z1, 'z', z_lowerBound_, z_upperBound_);
       return;
     }
 
     const double a1(this->get_position_A() + values[3]);
     if(a1 < a_lowerBound_ || a1 > a_upperBound_){
-      NQLog("LStepExpressMotionManager", NQLog::Warning) << "ERROR ! Relative movement not executed, Motion Stage would exceed its boundary in A:" << a1;
-      emit warn_user_limit(a1, 'a', a_lowerBound_, a_upperBound_);
+      warn_on_limit(a1, 'a', a_lowerBound_, a_upperBound_);
       return;
     }
 
@@ -250,29 +246,25 @@ void LStepExpressMotionManager::moveRelative(const double dx, const double dy, c
     //Checks on MS boundaries
     const double x1(this->get_position_X() + dx);
     if(x1 < x_lowerBound_ || x1 > x_upperBound_){
-      NQLog("LStepExpressMotionManager", NQLog::Warning) << "ERROR ! Relative movement not executed, Motion Stage would exceed its boundary in X:" << x1;
-      emit warn_user_limit(x1, 'x', x_lowerBound_, x_upperBound_);
+      warn_on_limit(x1, 'x', x_lowerBound_, x_upperBound_);
       return;
     }
 
     const double y1(this->get_position_Y() + dy);
     if(y1 < y_lowerBound_ || y1 > y_upperBound_){
-      NQLog("LStepExpressMotionManager", NQLog::Warning) << "ERROR ! Relative movement not executed, Motion Stage would exceed its boundary in Y:" << y1;
-      emit warn_user_limit(y1, 'y', y_lowerBound_, y_upperBound_);
+      warn_on_limit(y1, 'y', y_lowerBound_, y_upperBound_);
       return;
     }
 
     const double z1(this->get_position_Z() + dz);
     if(z1 < z_lowerBound_ || z1 > z_upperBound_){
-      NQLog("LStepExpressMotionManager", NQLog::Warning) << "ERROR ! Relative movement not executed, Motion Stage would exceed its boundary in Z:" << z1;
-      emit warn_user_limit(z1, 'z', z_lowerBound_, z_upperBound_);
+      warn_on_limit(z1, 'z', z_lowerBound_, z_upperBound_);
       return;
     }
 
     const double a1(this->get_position_A() + da);
     if(a1 < a_lowerBound_ || a1 > a_upperBound_){
-      NQLog("LStepExpressMotionManager", NQLog::Warning) << "ERROR ! Relative movement not executed, Motion Stage would exceed its boundary in A:" << a1;
-      emit warn_user_limit(a1, 'a', a_lowerBound_, a_upperBound_);
+      warn_on_limit(a1, 'a', a_lowerBound_, a_upperBound_);
       return;
     }
 
@@ -291,32 +283,28 @@ void LStepExpressMotionManager::moveRelative(const unsigned int axis, const doub
     if(axis == 0){
       const double x1(this->get_position_X() + value);
       if(x1 < x_lowerBound_ || x1 > x_upperBound_){
-        NQLog("LStepExpressMotionManager", NQLog::Warning) << "ERROR ! Relative movement not executed, Motion Stage would exceed its boundary in X:" << x1;
-        emit warn_user_limit(x1, 'x', x_lowerBound_, x_upperBound_);
+        warn_on_limit(x1, 'x', x_lowerBound_, x_upperBound_);
         return;
       }
     }
     else if(axis == 1){
       const double y1(this->get_position_Y() + value);
       if(y1 < y_lowerBound_ || y1 > y_upperBound_){
-        NQLog("LStepExpressMotionManager", NQLog::Warning) << "ERROR ! Relative movement not executed, Motion Stage would exceed its boundary in Y:" << y1;
-        emit warn_user_limit(y1, 'y', y_lowerBound_, y_upperBound_);
+        warn_on_limit(y1, 'y', y_lowerBound_, y_upperBound_);
         return;
       }
     }
     else if(axis == 2){
       const double z1(this->get_position_Z() + value);
       if(z1 < z_lowerBound_ || z1 > z_upperBound_){
-        NQLog("LStepExpressMotionManager", NQLog::Warning) << "ERROR ! Relative movement not executed, Motion Stage would exceed its boundary in Z:" << z1;
-        emit warn_user_limit(z1, 'z', z_lowerBound_, z_upperBound_);
+        warn_on_limit(z1, 'z', z_lowerBound_, z_upperBound_);
         return;
       }
     }
     else if(axis == 3){
       const double a1(this->get_position_A() + value);
       if(a1 < a_lowerBound_ || a1 > a_upperBound_){
-        NQLog("LStepExpressMotionManager", NQLog::Warning) << "ERROR ! Relative movement not executed, Motion Stage would exceed its boundary in A:" << a1;
-        emit warn_user_limit(a1, 'a', a_lowerBound_, a_upperBound_);
+        warn_on_limit(a1, 'a', a_lowerBound_, a_upperBound_);
         return;
       }
     }
@@ -340,29 +328,25 @@ void LStepExpressMotionManager::moveAbsolute(const std::vector<double>& values)
     //Checks on MS boundaries
     const double x1(values[0]);
     if(x1 < x_lowerBound_ || x1 > x_upperBound_){
-      NQLog("LStepExpressMotionManager", NQLog::Warning) << "ERROR ! Absolute movement not executed, Motion Stage would exceed its boundary in X:" << x1;
-      emit warn_user_limit(x1, 'x', x_lowerBound_, x_upperBound_);
+      warn_on_limit(x1, 'x', x_lowerBound_, x_upperBound_);
       return;
     }
 
     const double y1(values[1]);
     if(y1 < y_lowerBound_ || y1 > y_upperBound_){
-      NQLog("LStepExpressMotionManager", NQLog::Warning) << "ERROR ! Absolute movement not executed, Motion Stage would exceed its boundary in Y:" << y1;
-      emit warn_user_limit(y1, 'y', y_lowerBound_, y_upperBound_);
+      warn_on_limit(y1, 'y', y_lowerBound_, y_upperBound_);
       return;
     }
 
     const double z1(values[2]);
     if(z1 < z_lowerBound_ || z1 > z_upperBound_){
-      NQLog("LStepExpressMotionManager", NQLog::Warning) << "ERROR ! Absolute movement not executed, Motion Stage would exceed its boundary in Z:" << z1;
-      emit warn_user_limit(z1, 'z', z_lowerBound_, z_upperBound_);
+      warn_on_limit(z1, 'z', z_lowerBound_, z_upperBound_);
       return;
     }
 
     const double a1(values[3]);
     if(a1 < a_lowerBound_ || a1 > a_upperBound_){
-      NQLog("LStepExpressMotionManager", NQLog::Warning) << "ERROR ! Absolute movement not executed, Motion Stage would exceed its boundary in A:" << a1;
-      emit warn_user_limit(a1, 'a', a_lowerBound_, a_upperBound_);
+      warn_on_limit(a1, 'a', a_lowerBound_, a_upperBound_);
       return;
     }
 
@@ -379,26 +363,22 @@ void LStepExpressMotionManager::moveAbsolute(const double x, const double y, con
 {
     //Checks on MS boundaries
     if(x < x_lowerBound_ || x > x_upperBound_){
-      NQLog("LStepExpressMotionManager", NQLog::Warning) << "ERROR ! Absolute movement not executed, Motion Stage would exceed its boundary in X:" << x;
-      emit warn_user_limit(x, 'x', x_lowerBound_, x_upperBound_);
+      warn_on_limit(x, 'x', x_lowerBound_, x_upperBound_);
       return;
     }
 
     if(y < y_lowerBound_ || y > y_upperBound_){
-      NQLog("LStepExpressMotionManager", NQLog::Warning) << "ERROR ! Absolute movement not executed, Motion Stage would exceed its boundary in Y:" << y;
-      emit warn_user_limit(y, 'y', y_lowerBound_, y_upperBound_);
+      warn_on_limit(y, 'y', y_lowerBound_, y_upperBound_);
       return;
     }
 
     if(z < z_lowerBound_ || z > z_upperBound_){
-      NQLog("LStepExpressMotionManager", NQLog::Warning) << "ERROR ! Absolute movement not executed, Motion Stage would exceed its boundary in Z:" << z;
-      emit warn_user_limit(z, 'z', z_lowerBound_, z_upperBound_);
+      warn_on_limit(z, 'z', z_lowerBound_, z_upperBound_);
       return;
     }
 
     if(a < a_lowerBound_ || a > a_upperBound_){
-      NQLog("LStepExpressMotionManager", NQLog::Warning) << "ERROR ! Absolute movement not executed, Motion Stage would exceed its boundary in A:" << a;
-      emit warn_user_limit(a, 'a', a_lowerBound_, a_upperBound_);
+      warn_on_limit(a, 'a', a_lowerBound_, a_upperBound_);
       return;
     }
 
@@ -416,29 +396,25 @@ void LStepExpressMotionManager::moveAbsolute(const unsigned int axis, const doub
     //Checks on MS boundaries
     if(axis == 0){
       if(value < x_lowerBound_ || value > x_upperBound_){
-        NQLog("LStepExpressMotionManager", NQLog::Warning) << "ERROR ! Absolute movement not executed, Motion Stage would exceed its boundary in X:" << value;
-        emit warn_user_limit(value, 'x', x_lowerBound_, x_upperBound_);
+        warn_on_limit(value, 'x', x_lowerBound_, x_upperBound_);
         return;
       }
     }
     else if(axis == 1){
       if(value < y_lowerBound_ || value > y_upperBound_){
-        NQLog("LStepExpressMotionManager", NQLog::Warning) << "ERROR ! Absolute movement not executed, Motion Stage would exceed its boundary in Y:" << value;
-        emit warn_user_limit(value, 'y', y_lowerBound_, y_upperBound_);
+        warn_on_limit(value, 'y', y_lowerBound_, y_upperBound_);
         return;
       }
     }
     else if(axis == 2){
       if(value < z_lowerBound_ || value > z_upperBound_){
-        NQLog("LStepExpressMotionManager", NQLog::Warning) << "ERROR ! Absolute movement not executed, Motion Stage would exceed its boundary in Z:" << value;
-        emit warn_user_limit(value, 'z', z_lowerBound_, z_upperBound_);
+        warn_on_limit(value, 'z', z_lowerBound_, z_upperBound_);
         return;
       }
     }
     else if(axis == 3){
       if(value < a_lowerBound_ || value > a_upperBound_){
-        NQLog("LStepExpressMotionManager", NQLog::Warning) << "ERROR ! Absolute movement not executed, Motion Stage would exceed its boundary in A:" << value;
-        emit warn_user_limit(value, 'a', a_lowerBound_, a_upperBound_);
+        warn_on_limit(value, 'a', a_lowerBound_, a_upperBound_);
         return;
       }
     }
@@ -655,4 +631,11 @@ void LStepExpressMotionManager::set_movements_priorities_XYZA(const double x, co
     }
 
     return;
+}
+
+void LStepExpressMotionManager::warn_on_limit(const double target_pos, const char axis, const double limit_pos_lower, const double limit_pos_upper)
+{
+  NQLog("LStepExpressMotionManager", NQLog::Warning) << "ERROR ! Motion not executed, motion Stage would exceed its boundary in " << axis << ": " << target_pos;
+  emit warn_user_limit(target_pos, axis, limit_pos_lower, limit_pos_upper);
+  emit motion_finished();
 }

--- a/assembly/assemblyCommon/LStepExpressMotionManager.h
+++ b/assembly/assemblyCommon/LStepExpressMotionManager.h
@@ -92,6 +92,8 @@ class LStepExpressMotionManager : public QObject
 
     void set_movements_priorities_XYZA(const double x, const double y, const double z, const double a, const bool is_absolute_movements);
 
+    void warn_on_limit(const double target_pos, const char axis, const double limit_pos_lower, const double limit_pos_upper);
+
   protected slots:
 
     void motionStarted();

--- a/assembly/assemblyCommon/LStepExpressMotionManager.h
+++ b/assembly/assemblyCommon/LStepExpressMotionManager.h
@@ -92,8 +92,6 @@ class LStepExpressMotionManager : public QObject
 
     void set_movements_priorities_XYZA(const double x, const double y, const double z, const double a, const bool is_absolute_movements);
 
-    void warn_user_limit(double target_pos, char axis, double limit_pos_lower, double limit_pos_upper);
-
   protected slots:
 
     void motionStarted();
@@ -114,6 +112,8 @@ class LStepExpressMotionManager : public QObject
 
     void position3D(const double, const double, const double);
     void position4D(const double, const double, const double, const double);
+
+    void warn_user_limit(const double, const char, const double, const double);
 };
 
 #endif // LSTEPEXPRESSMOTIONMANAGER_H

--- a/assembly/assemblyCommon/LStepExpressMotionManager.h
+++ b/assembly/assemblyCommon/LStepExpressMotionManager.h
@@ -92,6 +92,8 @@ class LStepExpressMotionManager : public QObject
 
     void set_movements_priorities_XYZA(const double x, const double y, const double z, const double a, const bool is_absolute_movements);
 
+    void warn_user_limit(double target_pos, char axis, double limit_pos_lower, double limit_pos_upper);
+
   protected slots:
 
     void motionStarted();

--- a/assembly/assembly_SiDummyPS.cfg
+++ b/assembly/assembly_SiDummyPS.cfg
@@ -98,3 +98,4 @@ AssemblySmartMotionManager_initial_step_up_dZ   1.0
 # AssemblyAssembly
 AssemblyAssembly_pickup1_Z                         130.0
 AssemblyAssembly_pickup2_Z                         130.0
+AssemblyAssembly_makespace_Z                       130.0

--- a/assembly/assembly_glass.cfg
+++ b/assembly/assembly_glass.cfg
@@ -99,3 +99,4 @@ AssemblySmartMotionManager_initial_step_up_dZ   1.0
 # AssemblyAssembly
 AssemblyAssembly_pickup1_Z                         130.0
 AssemblyAssembly_pickup2_Z                         130.0
+AssemblyAssembly_makespace_Z                       130.0


### PR DESCRIPTION
This PR includes further changes in the assembly sequence in case of glue distribution directly on spacers. This is treated as alternative, hence only has an impact if `skip_dipping == 1`. If this is the case ...

 * this changes the order of a few steps in the PSp+PSs assembly part
 * adds a step where the pickup tool + PSs is lifted up by a configurable distance to make space for the manual application of fast curing glue

In addition, a bug was fixed that prevented the users from entering decimal points in the parameter view.

This closes #189 .
This closes #188 .