### PR TITLE
Toolbar shows position & vacuum status

### DIFF
--- a/assembly/assembly/AssemblyMainWindow.h
+++ b/assembly/assembly/AssemblyMainWindow.h
@@ -115,6 +115,8 @@ class AssemblyMainWindow : public QMainWindow
   void update_alignment_tab_psp();
   void update_alignment_tab_pss();
 
+  void update_stage_position();
+
  signals:
 
   void images_ON();
@@ -157,6 +159,8 @@ class AssemblyMainWindow : public QMainWindow
   LStepExpressMotionThread*   motion_thread_;
   LStepExpressSettings*       motionSettings_;
   LStepExpressSettingsWidget* motionSettingsWidget_;
+
+  std::vector<QLabel*>        stage_values_;
 
   AssemblyUEyeModel_t*      camera_model_;
   AssemblyUEyeCameraThread* camera_thread_;

--- a/assembly/assembly/AssemblyMainWindow.h
+++ b/assembly/assembly/AssemblyMainWindow.h
@@ -117,6 +117,8 @@ class AssemblyMainWindow : public QMainWindow
 
   void update_stage_position();
 
+  void update_vacuum_information(const int, const bool);
+
  signals:
 
   void images_ON();
@@ -161,6 +163,16 @@ class AssemblyMainWindow : public QMainWindow
   LStepExpressSettingsWidget* motionSettingsWidget_;
 
   std::vector<QLabel*>        stage_values_;
+
+  QPixmap* status_grey_;
+  QPixmap* status_green_;
+  QPixmap* status_red_;
+  int vacuum_basepl_;
+  int vacuum_pickup_;
+  int vacuum_spacer_;
+  QLabel* PU_status_;
+  QLabel* SP_status_;
+  QLabel* BP_status_;
 
   AssemblyUEyeModel_t*      camera_model_;
   AssemblyUEyeCameraThread* camera_thread_;


### PR DESCRIPTION
The toolbar now shows the stage positions and the status of the vacuum relays. For the latter, green means "vacuum off" and red means "vacuum on".

Still to be tested at the actual setup.

This fixes #192 