### PR TITLE
Vacuum status

### DIFF
--- a/assembly/assembly/AssemblyMainWindow.cc
+++ b/assembly/assembly/AssemblyMainWindow.cc
@@ -20,6 +20,7 @@
 #include <AssemblyLogFileController.h>
 #include <AssemblyLogFileView.h>
 #include <AssemblyUtilities.h>
+#include <DeviceState.h>
 
 #include <string>
 
@@ -330,7 +331,7 @@ AssemblyMainWindow::AssemblyMainWindow(const QString& outputdir_path, const QStr
     connect(hwctr_view_->Vacuum_Widget(), SIGNAL(toggleVacuum(int))              , relayCardManager_, SLOT(toggleVacuum(int)));
     connect(hwctr_view_->Vacuum_Widget(), SIGNAL(vacuumChannelState_request(int)), relayCardManager_, SLOT(transmit_vacuumChannelState(int)));
 
-    connect(relayCardManager_, SIGNAL(vacuumChannelState(int, bool)), hwctr_view_->Vacuum_Widget(), SLOT(updateVacuumChannelState(int, bool)));
+    connect(relayCardManager_, SIGNAL(vacuumChannelState(int, SwitchState)), hwctr_view_->Vacuum_Widget(), SLOT(updateVacuumChannelState(int, SwitchState)));
 
     connect(relayCardManager_, SIGNAL( enableVacuumButton()), hwctr_view_->Vacuum_Widget(), SLOT( enableVacuumButton()));
     connect(relayCardManager_, SIGNAL(disableVacuumButton()), hwctr_view_->Vacuum_Widget(), SLOT(disableVacuumButton()));

--- a/assembly/assembly/AssemblyMainWindow.cc
+++ b/assembly/assembly/AssemblyMainWindow.cc
@@ -161,6 +161,17 @@ AssemblyMainWindow::AssemblyMainWindow(const QString& outputdir_path, const QStr
     	relayCardModel_ = new ConradModel(config->getValue<std::string>("main", "ConradDevice"));
     }
 
+    if(relayCardModel_->getDeviceState()==State::OFF) {
+      NQLog("AssemblyMainWindow", NQLog::Fatal) << "Relay card device off - cannot continue.";
+
+      QMessageBox* msgBox = new QMessageBox;
+      msgBox->setInformativeText("Relay card device not available!");
+
+      msgBox->setStandardButtons(QMessageBox::Ok);
+
+      int ret = msgBox->exec();
+    }
+
     relayCardManager_ = new RelayCardManager(relayCardModel_);
     /// -------------------
 
@@ -336,6 +347,9 @@ AssemblyMainWindow::AssemblyMainWindow(const QString& outputdir_path, const QStr
     connect(relayCardManager_, SIGNAL( enableVacuumButton()), hwctr_view_->Vacuum_Widget(), SLOT( enableVacuumButton()));
     connect(relayCardManager_, SIGNAL(disableVacuumButton()), hwctr_view_->Vacuum_Widget(), SLOT(disableVacuumButton()));
 
+    if(relayCardModel_->getDeviceState()==State::OFF) {
+      hwctr_view_->Vacuum_Widget()->disableVacuumButton();
+    }
     hwctr_view_->Vacuum_Widget()->updateVacuumChannelsStatus();
 
     // enable motion stage controllers at startup

--- a/assembly/assembly/AssemblyMainWindow.cc
+++ b/assembly/assembly/AssemblyMainWindow.cc
@@ -45,6 +45,7 @@ AssemblyMainWindow::AssemblyMainWindow(const QString& outputdir_path, const QStr
   status_grey_(nullptr),
   status_green_(nullptr),
   status_red_(nullptr),
+  status_orange_(nullptr),
   PU_status_(nullptr),
   SP_status_(nullptr),
   BP_status_(nullptr),
@@ -507,6 +508,7 @@ AssemblyMainWindow::AssemblyMainWindow(const QString& outputdir_path, const QStr
     status_grey_ = new QPixmap(filename + "/share/common/button_grey.png");
     status_green_ = new QPixmap(filename + "/share/common/button_green.png");
     status_red_ = new QPixmap(filename + "/share/common/button_red.png");
+    status_orange_ = new QPixmap(filename + "/share/common/button_orange.png");
     vacuum_pickup_ = config->getValue<int>("main", "Vacuum_PickupTool");
     vacuum_spacer_ = config->getValue<int>("main", "Vacuum_Spacers");
     vacuum_basepl_ = config->getValue<int>("main", "Vacuum_Baseplate");
@@ -530,6 +532,8 @@ AssemblyMainWindow::AssemblyMainWindow(const QString& outputdir_path, const QStr
     connect(hwctr_view_->Vacuum_Widget(), SIGNAL(vacuumChannelState_request(int)), relayCardManager_, SLOT(transmit_vacuumChannelState(int)));
 
     connect(relayCardManager_, SIGNAL(vacuumChannelState(int, SwitchState)), hwctr_view_->Vacuum_Widget(), SLOT(updateVacuumChannelState(int, SwitchState)));
+
+    connect(relayCardManager_, SIGNAL(vacuumChannelState(int, SwitchState)), this, SLOT(update_vacuum_information(int, SwitchState)));
 
     connect(relayCardManager_, SIGNAL( enableVacuumButton()), hwctr_view_->Vacuum_Widget(), SLOT( enableVacuumButton()));
     connect(relayCardManager_, SIGNAL(disableVacuumButton()), hwctr_view_->Vacuum_Widget(), SLOT(disableVacuumButton()));
@@ -1136,10 +1140,10 @@ void AssemblyMainWindow::update_stage_position()
   }
 }
 
-void AssemblyMainWindow::update_vacuum_information(const int channel, const bool state)
+void AssemblyMainWindow::update_vacuum_information(const int channel, const SwitchState state)
 {
   NQLog("AssemblyMainWindow", NQLog::Debug) << "update_vacuum_information("
-  << channel << ", " << state << "): updating vacuum information";
+  << channel << ", " << static_cast<int>(state) << "): updating vacuum information";
 
   QLabel* to_be_updated;
   if(channel == vacuum_pickup_)
@@ -1161,10 +1165,19 @@ void AssemblyMainWindow::update_vacuum_information(const int channel, const bool
   }
 
   to_be_updated->clear();
-  if(state)
+  if(state==SwitchState::CHANNEL_ON)
   {
     to_be_updated->setPixmap(status_red_->scaled(20,20));
-  } else {
+} else if(state==SwitchState::CHANNEL_SWITCHING)
+  {
+    to_be_updated->setPixmap(status_orange_->scaled(20,20));
+  }
+  else if(state==SwitchState::CHANNEL_OFF)
+  {
     to_be_updated->setPixmap(status_green_->scaled(20,20));
+  }
+  else if(state==SwitchState::DEVICE_OFF)
+  {
+    to_be_updated->setPixmap(status_grey_->scaled(20,20));
   }
 }

--- a/assembly/assembly/AssemblyMainWindow.h
+++ b/assembly/assembly/AssemblyMainWindow.h
@@ -117,7 +117,7 @@ class AssemblyMainWindow : public QMainWindow
 
   void update_stage_position();
 
-  void update_vacuum_information(const int, const bool);
+  void update_vacuum_information(const int, const SwitchState);
 
  signals:
 
@@ -167,6 +167,7 @@ class AssemblyMainWindow : public QMainWindow
   QPixmap* status_grey_;
   QPixmap* status_green_;
   QPixmap* status_red_;
+  QPixmap* status_orange_;
   int vacuum_basepl_;
   int vacuum_pickup_;
   int vacuum_spacer_;

--- a/assembly/assemblyCommon/AssemblyVacuumWidget.cc
+++ b/assembly/assemblyCommon/AssemblyVacuumWidget.cc
@@ -137,26 +137,36 @@ void AssemblyVacuumWidget::disableVacuumButton()
   button_->setEnabled(false);
 }
 
-void AssemblyVacuumWidget::updateVacuumChannelState(const int channelNumber, const bool channelState)
+void AssemblyVacuumWidget::updateVacuumChannelState(const int channelNumber, const SwitchState channelState)
 {
   if(this->has(channelNumber) == false)
   {
     NQLog("AssemblyVacuumWidget", NQLog::Warning) << "updateVacuumChannelState"
-       << "(" << channelNumber << ", " << channelState << ")"
+       << "(" << channelNumber << ", " << static_cast<int>(channelState) << ")"
        << ": vacuum line with index " << channelNumber << " not found, no action taken";
 
     return;
   }
 
-  if(channelState)
+  if(channelState==SwitchState::CHANNEL_ON)
   {
     this->get(channelNumber).label_->setText(" VACUUM ON");
     this->get(channelNumber).label_->setStyleSheet("QLabel { background-color : red; color : black; }");
   }
-  else
+  else if(channelState==SwitchState::CHANNEL_SWITCHING)
+  {
+    this->get(channelNumber).label_->setText(" VACUUM SWITCHING");
+    this->get(channelNumber).label_->setStyleSheet("QLabel { background-color : orange; color : black; }");
+  }
+  else if(channelState==SwitchState::CHANNEL_OFF)
   {
     this->get(channelNumber).label_->setText(" VACUUM OFF");
     this->get(channelNumber).label_->setStyleSheet("QLabel { background-color : green; color : black; }");
+  }
+  else if(channelState==SwitchState::DEVICE_OFF)
+  {
+    this->get(channelNumber).label_->setText(" DEVICE OFF");
+    this->get(channelNumber).label_->setStyleSheet("QLabel { background-color : grey; color : black; }");
   }
 
   return;

--- a/assembly/assemblyCommon/AssemblyVacuumWidget.cc
+++ b/assembly/assemblyCommon/AssemblyVacuumWidget.cc
@@ -140,8 +140,8 @@ void AssemblyVacuumWidget::disableVacuumButton()
 void AssemblyVacuumWidget::updateVacuumChannelState(const int channelNumber, const SwitchState channelState)
 {
   NQLog("AssemblyVacuumWidget", NQLog::Debug) << "updateVacuumChannelState"
-  << "(" << channelNumber << ", " << channelState << ")"
-  << ": vacuum line with index " << channelNumber << " found. Updating status to " << channelState;
+  << "(" << channelNumber << ", " << static_cast<int>(channelState) << ")"
+  << ": vacuum line with index " << channelNumber << " found. Updating status to " << static_cast<int>(channelState);
 
   if(this->has(channelNumber) == false)
   {

--- a/assembly/assemblyCommon/AssemblyVacuumWidget.h
+++ b/assembly/assemblyCommon/AssemblyVacuumWidget.h
@@ -20,6 +20,8 @@
 #include <QRadioButton>
 #include <QLabel>
 
+#include <RelayCardManager.h>
+
 #include <map>
 
 class AssemblyVacuumWidget : public QWidget
@@ -56,7 +58,7 @@ class AssemblyVacuumWidget : public QWidget
  public slots:
 
   void toggleVacuum();
-  void updateVacuumChannelState(const int, const bool);
+  void updateVacuumChannelState(const int, const SwitchState);
 
   void updateVacuumChannelsStatus();
 

--- a/assembly/assemblyCommon/RelayCardManager.cc
+++ b/assembly/assemblyCommon/RelayCardManager.cc
@@ -56,6 +56,8 @@ void RelayCardManager::toggleVacuum(const int chNumber)
     relayCardModel()->setSwitchEnabled(chNumber, true);
     channelNumber_ = chNumber;
 
+    emit vacuumChannelState(channelNumber_, SwitchState::CHANNEL_SWITCHING);
+
     // here will be a QtTimer for about 2 secs
     liveTimer_->start(togglingVacuumDelay);
 
@@ -71,6 +73,8 @@ void RelayCardManager::toggleVacuum(const int chNumber)
     //NQLog("RelayCardManager") << ": attempt to turn OFF the vacuum on channel " << chNumber;
     relayCardModel()->setSwitchEnabled(chNumber, false);
     channelNumber_ = chNumber;
+
+    emit vacuumChannelState(channelNumber_, SwitchState::CHANNEL_SWITCHING);
 
     // here will be a QtTimer for about 2 secs
     liveTimer_->start(togglingVacuumDelay);
@@ -164,6 +168,8 @@ void RelayCardManager::enableVacuum(const int chNumber)
   	relayCardModel()->setSwitchEnabled(chNumber, true);
     channelNumber_ = chNumber;
 
+    emit vacuumChannelState(channelNumber_, SwitchState::CHANNEL_SWITCHING);
+
     liveTimer_->start(togglingVacuumDelay);
 
     emit DBLogMessage("Turned vacuum ON");
@@ -208,6 +214,8 @@ void RelayCardManager::disableVacuum(const int chNumber)
   {
   	relayCardModel()->setSwitchEnabled(chNumber, false);
     channelNumber_ = chNumber;
+
+    emit vacuumChannelState(channelNumber_, SwitchState::CHANNEL_SWITCHING);
 
     liveTimer_->start(togglingVacuumDelay);
 

--- a/assembly/assemblyCommon/RelayCardManager.cc
+++ b/assembly/assemblyCommon/RelayCardManager.cc
@@ -91,7 +91,27 @@ void RelayCardManager::vacuumToggled()
   NQLog("RelayCardManager", NQLog::Debug) << "vacuumToggled"
      << ": emitting signal \"vacuumChannelState(" << channelNumber_ << ", " << relayCardModel()->getSwitchState(channelNumber_) << ")\"";
 
-  emit vacuumChannelState(channelNumber_, relayCardModel()->getSwitchState(channelNumber_));
+  SwitchState state;
+  if(relayCardModel()->getDeviceState() == State::OFF) {
+    state = SwitchState::DEVICE_OFF;
+  } else {
+    switch(relayCardModel()->getSwitchState(channelNumber_)) {
+      case OFF:
+        state = SwitchState::CHANNEL_OFF;
+        break;
+      case READY:
+        state = SwitchState::CHANNEL_ON;
+        break;
+      case INITIALIZING:
+        state = SwitchState::CHANNEL_SWITCHING;
+        break;
+      case CLOSING:
+        state = SwitchState::CHANNEL_SWITCHING;
+        break;
+    }
+  }
+
+  emit vacuumChannelState(channelNumber_, state);
 
   NQLog("RelayCardManager", NQLog::Debug) << "vacuumToggled"
      << ": emitting signal \"enableVacuumButton\"";
@@ -110,7 +130,27 @@ void RelayCardManager::transmit_vacuumChannelState(const int chNumber)
      << ": emitting signal \"vacuumChannelState("
      << chNumber << ", " << relayCardModel()->getSwitchState(chNumber) << ")\"";
 
-  emit vacuumChannelState(chNumber, relayCardModel()->getSwitchState(chNumber));
+  SwitchState state;
+  if(relayCardModel()->getDeviceState() == State::OFF) {
+    state = SwitchState::DEVICE_OFF;
+  } else {
+    switch(relayCardModel()->getSwitchState(chNumber)) {
+      case OFF:
+        state = SwitchState::CHANNEL_OFF;
+        break;
+      case READY:
+        state = SwitchState::CHANNEL_ON;
+        break;
+      case INITIALIZING:
+        state = SwitchState::CHANNEL_SWITCHING;
+        break;
+      case CLOSING:
+        state = SwitchState::CHANNEL_SWITCHING;
+        break;
+    }
+  }
+
+  emit vacuumChannelState(chNumber, state);
 }
 
 // maybe need checkStatus SLOT

--- a/assembly/assemblyCommon/RelayCardManager.h
+++ b/assembly/assemblyCommon/RelayCardManager.h
@@ -22,7 +22,7 @@ enum class SwitchState {
   DEVICE_OFF = 0             // Device is off
   , CHANNEL_OFF = 1          // Channel is off
   , CHANNEL_ON = 2           // Channel is on
-  , CHANNEL_SWITCHING = 3    // Channekl is currently switching
+  , CHANNEL_SWITCHING = 3    // Channel is currently switching
 };
 
 class RelayCardManager : public QObject

--- a/assembly/assemblyCommon/RelayCardManager.h
+++ b/assembly/assemblyCommon/RelayCardManager.h
@@ -18,6 +18,13 @@
 #include <QObject>
 #include <QTimer>
 
+enum class SwitchState {
+  DEVICE_OFF = 0             // Device is off
+  , CHANNEL_OFF = 1          // Channel is off
+  , CHANNEL_ON = 2           // Channel is on
+  , CHANNEL_SWITCHING = 3    // Channekl is currently switching
+};
+
 class RelayCardManager : public QObject
 {
  Q_OBJECT
@@ -53,7 +60,7 @@ class RelayCardManager : public QObject
 
  signals:
 
-  void vacuumChannelState(int, bool);
+  void vacuumChannelState(int, SwitchState);
 
   void  enableVacuumButton();
   void disableVacuumButton();

--- a/common/ConradModel.h
+++ b/common/ConradModel.h
@@ -61,6 +61,10 @@ public:
   // Methods for power control and status querying of the devices connected to the switch
   const State& getSwitchState( int device ) const;
 
+  /// Returns the current (cached) state of the device.
+  const State& getDeviceState() const {
+      return state_; }
+
 public slots:
   // Methods for control and status querying of the device itself, as specified
   // by the abstract parent class

--- a/common/VRelayCardModel.h
+++ b/common/VRelayCardModel.h
@@ -41,6 +41,9 @@ public:
   // Methods for power control and status querying of the devices connected to the switch
   virtual const State& getSwitchState( int device ) const = 0;
 
+  /// Returns the current (cached) state of the device.
+  virtual const State& getDeviceState() const = 0;
+
 public slots:
   // Methods for control and status querying of the device itself, as specified
   // by the abstract parent class

--- a/common/VellemanModel.h
+++ b/common/VellemanModel.h
@@ -63,6 +63,10 @@ public:
   const State& getChannelState(int channel) const;
   const State& getSwitchState( int device ) const { return getChannelState(device); }
 
+  /// Returns the current (cached) state of the device.
+  const State& getDeviceState() const {
+      return state_; }
+
 public slots:
   // Methods for control and querying statuses of device itself (as specified
   // by abstract parent class)


### PR DESCRIPTION
This PR introduces a few changes to how the status of vacuum channels are treated.
New features in the background are ...
 * The status of the relay card device can now be queried
 * There's now a `enum SwitchState` that can be used to indicate the status of individual vacuum channels (relays)
 * New status: "switching"

In the GUI this leads to the following changes:
 * In case of an unavailability of the relay card device ... (see issue #195 )
   * there's a warning during startup
   * the vacuum toggle button is greyed out
   * the status indicators turn grey
 * There's a new status "switching" for vacuum channels, which is indicated by an orange colour.

This closes issue #195 .