### PR TITLE
Fix Lang Controller Communication

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,13 @@ SET(CMAKE_SKIP_INSTALL_RPATH FALSE)
 SET(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
 SET(CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_FULL_LIBDIR})
 
+# Set default build type
+IF(NOT CMAKE_BUILD_TYPE)
+    SET(CMAKE_BUILD_TYPE
+        "RelWithDebInfo"
+        CACHE STRING "Choose the type of build, options are: Debug Release RelWithDebInfo MinSizeRel." FORCE)
+ENDIF(NOT CMAKE_BUILD_TYPE)
+
 # Add the automatically determined parts of the RPATH which point to directories outside the build tree to the install RPATH
 SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 

--- a/assembly/assemblyCommon/LStepExpressModel.cc
+++ b/assembly/assemblyCommon/LStepExpressModel.cc
@@ -1050,8 +1050,7 @@ void LStepExpressModel::initialize()
          << ": successfully accessed port " << controller_->ioPort();
 
       QMutexLocker locker(&mutex_);
-
-      controller_->SetAutoStatus(2);
+      controller_->SetAutoStatus(0);
 
       std::vector<int> allZerosI{ 0, 0, 0, 0 };
       std::vector<int> OnI{1,1,1,1};

--- a/devices/Lang/LStepExpress.cpp
+++ b/devices/Lang/LStepExpress.cpp
@@ -59,13 +59,15 @@ void LStepExpress::SendCommand(const std::string & command)
   comHandler_->SendCommand(command.c_str());
 }
 
-void LStepExpress::ReceiveString(std::string & buffer)
+std::string LStepExpress::ReceiveString()
 {
-  buffer = comHandler_->ReceiveString();
+  auto buffer = comHandler_->ReceiveString();
 
 #ifdef LSTEPDEBUG
   std::cout << "Device ReceiveString: " << buffer << std::endl;
 #endif
+
+  return buffer;
 }
 
 void LStepExpress::DeviceInit(const std::string& lstep_ver, const std::string& lstep_iver)

--- a/devices/Lang/LStepExpress.cpp
+++ b/devices/Lang/LStepExpress.cpp
@@ -68,16 +68,6 @@ void LStepExpress::ReceiveString(std::string & buffer)
 #endif
 }
 
-void LStepExpress::StripBuffer(char* buffer) const
-{
-  for (unsigned int c=0; c<strlen(buffer);++c) {
-    if(buffer[c]=='\r') {
-      buffer[c] = '\0';
-      break;
-    }
-  }
-}
-
 void LStepExpress::DeviceInit(const std::string& lstep_ver, const std::string& lstep_iver)
 {
   isDeviceAvailable_ = false;
@@ -124,7 +114,6 @@ void LStepExpress::DeviceInit(const std::string& lstep_ver, const std::string& l
     comHandler_->SendCommand("readsn"); // read serial number
     comHandler_->ReceiveString(buffer);
 
-    StripBuffer(buffer);
     unsigned long serialNumber = std::atol(buffer);
 
     if(   (serialNumber != 40052435759) // pre-DAF

--- a/devices/Lang/LStepExpress.cpp
+++ b/devices/Lang/LStepExpress.cpp
@@ -61,15 +61,11 @@ void LStepExpress::SendCommand(const std::string & command)
 
 void LStepExpress::ReceiveString(std::string & buffer)
 {
-  char buf[1000];
-  comHandler_->ReceiveString(buf);
+  buffer = comHandler_->ReceiveString();
 
 #ifdef LSTEPDEBUG
-  std::cout << "Device ReceiveString: " << buf << std::endl;
+  std::cout << "Device ReceiveString: " << buffer << std::endl;
 #endif
-
-  StripBuffer(buf);
-  buffer = buf;
 }
 
 void LStepExpress::StripBuffer(char* buffer) const
@@ -90,14 +86,9 @@ void LStepExpress::DeviceInit(const std::string& lstep_ver, const std::string& l
   {
     isDeviceAvailable_ = true;
 
-    char buffer[1000];
-    std::string buf;
-
     // read version
     comHandler_->SendCommand("ver");
-    comHandler_->ReceiveString(buffer);
-    StripBuffer(buffer);
-    buf = buffer;
+    auto buf = comHandler_->ReceiveString();
 
     if(buf != lstep_ver)
     {
@@ -114,9 +105,7 @@ void LStepExpress::DeviceInit(const std::string& lstep_ver, const std::string& l
 
     // read internal version
     comHandler_->SendCommand("iver");
-    comHandler_->ReceiveString(buffer);
-    StripBuffer(buffer);
-    buf = buffer;
+    buf = comHandler_->ReceiveString();
 
     if(buf != lstep_iver)
     {

--- a/devices/Lang/LStepExpress.cpp
+++ b/devices/Lang/LStepExpress.cpp
@@ -45,11 +45,6 @@ std::string LStepExpress::ioPort()
   return comHandler_->ioPort();
 }
 
-bool LStepExpress::DeviceAvailable()
-{
-  return isDeviceAvailable_;
-}
-
 // low level debugging methods
 void LStepExpress::SendCommand(const std::string & command)
 {

--- a/devices/Lang/LStepExpress.cpp
+++ b/devices/Lang/LStepExpress.cpp
@@ -37,14 +37,15 @@ LStepExpress::~LStepExpress()
 }
 
 //! Return name of port used to initialize LStepExpressComHandler
-std::string LStepExpress::ioPort() const
+std::string LStepExpress::ioPort()
 {
   assert(comHandler_);
 
+  std::lock_guard<std::mutex> lock(mutex_);
   return comHandler_->ioPort();
 }
 
-bool LStepExpress::DeviceAvailable() const
+bool LStepExpress::DeviceAvailable()
 {
   return isDeviceAvailable_;
 }
@@ -56,6 +57,7 @@ void LStepExpress::SendCommand(const std::string & command)
   std::cout << "Device SendCommand: " << command << std::endl;
 #endif
 
+  std::lock_guard<std::mutex> lock(mutex_);
   comHandler_->SendCommand(command.c_str());
 }
 
@@ -65,8 +67,8 @@ std::string LStepExpress::ReceiveString(const std::string & command)
   std::cout << "Device SendCommand: " << command << std::endl;
 #endif
 
+  std::lock_guard<std::mutex> lock(mutex_);
   comHandler_->SendCommand(command.c_str());
-
   auto buffer = comHandler_->ReceiveString();
 
 #ifdef LSTEPDEBUG
@@ -80,6 +82,7 @@ void LStepExpress::DeviceInit(const std::string& lstep_ver, const std::string& l
 {
   isDeviceAvailable_ = false;
 
+  std::lock_guard<std::mutex> lock(mutex_);
   if(comHandler_->DeviceAvailable())
   {
     isDeviceAvailable_ = true;

--- a/devices/Lang/LStepExpress.cpp
+++ b/devices/Lang/LStepExpress.cpp
@@ -59,8 +59,14 @@ void LStepExpress::SendCommand(const std::string & command)
   comHandler_->SendCommand(command.c_str());
 }
 
-std::string LStepExpress::ReceiveString()
+std::string LStepExpress::ReceiveString(const std::string & command)
 {
+#ifdef LSTEPDEBUG
+  std::cout << "Device SendCommand: " << command << std::endl;
+#endif
+
+  comHandler_->SendCommand(command.c_str());
+
   auto buffer = comHandler_->ReceiveString();
 
 #ifdef LSTEPDEBUG

--- a/devices/Lang/LStepExpress.cpp
+++ b/devices/Lang/LStepExpress.cpp
@@ -61,8 +61,6 @@ void LStepExpress::SendCommand(const std::string & command)
 
 void LStepExpress::ReceiveString(std::string & buffer)
 {
-  usleep(1000);
-
   char buf[1000];
   comHandler_->ReceiveString(buf);
 

--- a/devices/Lang/LStepExpress.h
+++ b/devices/Lang/LStepExpress.h
@@ -42,7 +42,7 @@ class LStepExpress : public VLStepExpress
 
   std::string ioPort();
 
-  bool DeviceAvailable();
+  bool DeviceAvailable() const { return isDeviceAvailable_; };
 
   void GetAutoStatus(int & value);
   void SetAutoStatus(int value);

--- a/devices/Lang/LStepExpress.h
+++ b/devices/Lang/LStepExpress.h
@@ -135,13 +135,12 @@ class LStepExpress : public VLStepExpress
   void Calibrate();
   void EmergencyStop();
 
+ private:
+
   // low level debugging methods
   void SendCommand(const std::string &);
   void ReceiveString(std::string &);
 
- private:
-
-  void StripBuffer( char* ) const;
   void DeviceInit(const std::string& lstep_ver, const std::string& lstep_iver);
 
   LStepExpressComHandler* comHandler_;

--- a/devices/Lang/LStepExpress.h
+++ b/devices/Lang/LStepExpress.h
@@ -20,6 +20,7 @@
 #include <utility>
 #include <fstream>
 #include <cmath>
+#include <mutex>
 
 #include "VLStepExpress.h"
 #include "LStepExpressComHandler.h"
@@ -39,9 +40,9 @@ class LStepExpress : public VLStepExpress
   LStepExpress(const std::string& ioPort, const std::string& lstep_ver="", const std::string& lstep_iver="");
   ~LStepExpress();
 
-  std::string ioPort() const;
+  std::string ioPort();
 
-  bool DeviceAvailable() const;
+  bool DeviceAvailable();
 
   void GetAutoStatus(int & value);
   void SetAutoStatus(int value);
@@ -135,7 +136,9 @@ class LStepExpress : public VLStepExpress
 
  private:
 
-  // low level debugging methods
+  // Device access mutex:
+  std::mutex mutex_;
+
   void SendCommand(const std::string &);
   std::string ReceiveString(const std::string &);
 

--- a/devices/Lang/LStepExpress.h
+++ b/devices/Lang/LStepExpress.h
@@ -39,8 +39,6 @@ class LStepExpress : public VLStepExpress
   LStepExpress(const std::string& ioPort, const std::string& lstep_ver="", const std::string& lstep_iver="");
   ~LStepExpress();
 
- public:
-
   std::string ioPort() const;
 
   bool DeviceAvailable() const;
@@ -139,7 +137,7 @@ class LStepExpress : public VLStepExpress
 
   // low level debugging methods
   void SendCommand(const std::string &);
-  void ReceiveString(std::string &);
+  std::string ReceiveString();
 
   void DeviceInit(const std::string& lstep_ver, const std::string& lstep_iver);
 

--- a/devices/Lang/LStepExpress.h
+++ b/devices/Lang/LStepExpress.h
@@ -137,7 +137,7 @@ class LStepExpress : public VLStepExpress
 
   // low level debugging methods
   void SendCommand(const std::string &);
-  std::string ReceiveString();
+  std::string ReceiveString(const std::string &);
 
   void DeviceInit(const std::string& lstep_ver, const std::string& lstep_iver);
 

--- a/devices/Lang/LStepExpressComHandler.cpp
+++ b/devices/Lang/LStepExpressComHandler.cpp
@@ -68,8 +68,9 @@ void LStepExpressComHandler::SendCommand( const char *commandString )
 */
 void LStepExpressComHandler::ReceiveString( char *receiveString )
 {
+  // Nothing ready, send null-terminated empty buffer back:
   if (!fDeviceAvailable) {
-    receiveString[0] = 0;
+    receiveString[0] = '\0';
     return;
   }
 

--- a/devices/Lang/LStepExpressComHandler.cpp
+++ b/devices/Lang/LStepExpressComHandler.cpp
@@ -75,7 +75,7 @@ std::string LStepExpressComHandler::ReceiveString()
   }
 
   // Define a timeout and start a timer:
-  const auto timeout = std::chrono::duration<double, std::milli>(3000);
+  const auto timeout = std::chrono::duration<double, std::milli>(500);
   const auto start_time = std::chrono::steady_clock::now();
 
   std::string value{};

--- a/devices/Lang/LStepExpressComHandler.cpp
+++ b/devices/Lang/LStepExpressComHandler.cpp
@@ -76,8 +76,6 @@ void LStepExpressComHandler::ReceiveString( char *receiveString )
 
   receiveString[0] = 0;
 
-  usleep( 20000 );
-
   int timeout = 0;
   size_t readResult = 0;
 

--- a/devices/Lang/LStepExpressComHandler.cpp
+++ b/devices/Lang/LStepExpressComHandler.cpp
@@ -87,9 +87,8 @@ std::string LStepExpressComHandler::ReceiveString()
     size_t n_read = read(fIoPortFileDescriptor, &readbyte, 1);
 
     if(n_read != 0) {
-      // Read until we see the end-of-command CR
+      // Read until we see the end-of-command (CR) marker
       if(readbyte == '\r') {
-        std::cout << "[LStepExpressComHandler::OpenIoPort] Found command-end marker" << std::endl;
         break;
       }
 
@@ -97,13 +96,13 @@ std::string LStepExpressComHandler::ReceiveString()
       value += readbyte;
     }
 
+    // Check for communication timeout:
     if(std::chrono::steady_clock::now() - start_time > timeout) {
-      std::cout << "[LStepExpressComHandler::OpenIoPort] ** ERROR: Communication seems to have timed out" << std::endl;
+      std::cout << "[LStepExpressComHandler::ReceiveString] ** ERROR: Communication seems to have timed out" << std::endl;
       return {};
     }
   }
 
-  std::cout << "[LStepExpressComHandler::OpenIoPort] Returning reading \"" << value << "\"" << std::endl;
   return value;
 }
 

--- a/devices/Lang/LStepExpressComHandler.cpp
+++ b/devices/Lang/LStepExpressComHandler.cpp
@@ -82,12 +82,9 @@ void LStepExpressComHandler::ReceiveString( char *receiveString )
   do {
 
     // Let's read byte-by-byte from the file descriptor:
-    nbytes_read = read(fIoPortFileDescriptor, &readbyte, 1);
+    size_t n_read = read(fIoPortFileDescriptor, &readbyte, 1);
 
-    if(nbytes_read == 0) {
-      // No bytes read from descriptor indicates eof / no data
-      std::cout << "[LStepExpressComHandler::OpenIoPort] Reached EOF, communication still ongoing" << std::endl;
-    } else {
+    if(n_read != 0) {
       // We read one byte, let's add it to the output and continue.
       receiveString[nbytes_read] = readbyte;
       nbytes_read++;

--- a/devices/Lang/LStepExpressComHandler.h
+++ b/devices/Lang/LStepExpressComHandler.h
@@ -45,7 +45,7 @@ class LStepExpressComHandler {
   const std::string& ioPort() const { return fIoPort; }
 
   void SendCommand( const char* );
-  void ReceiveString( char* );
+  std::string ReceiveString();
 
   bool DeviceAvailable();
 

--- a/devices/Lang/VLStepExpress.cpp
+++ b/devices/Lang/VLStepExpress.cpp
@@ -166,7 +166,7 @@ void VLStepExpress::GetValue(const std::string & command,
                              std::string & value)
 {
   this->SendCommand(command);
-  this->ReceiveString(value);
+  value = this->ReceiveString();
 }
 
 void VLStepExpress::GetValue(const std::string & command,
@@ -174,9 +174,8 @@ void VLStepExpress::GetValue(const std::string & command,
 {
   this->SendCommand(command);
 
-  std::string buffer;
   int temp;
-  this->ReceiveString(buffer);
+  auto buffer = this->ReceiveString();
   std::istringstream is(buffer);
   is >> temp;
   value = temp;
@@ -187,9 +186,8 @@ void VLStepExpress::GetValue(const std::string & command,
 {
   this->SendCommand(command);
 
-  std::string buffer;
   double temp;
-  this->ReceiveString(buffer);
+  auto buffer = this->ReceiveString();
   std::istringstream is(buffer);
   is >> temp;
   value = temp;
@@ -201,7 +199,7 @@ void VLStepExpress::GetValue(const std::string & command, VLStepExpress::Axis ax
   std::ostringstream os;
   os << command << " " << GetAxisName(axis);
   this->SendCommand(os.str());
-  this->ReceiveString(value);
+  value = this->ReceiveString();
 }
 
 void VLStepExpress::GetValue(const std::string & command,
@@ -209,9 +207,8 @@ void VLStepExpress::GetValue(const std::string & command,
 {
   this->SendCommand(command);
 
-  std::string buffer;
   int temp;
-  this->ReceiveString(buffer);
+  auto buffer = this->ReceiveString();
 
   values.clear();
   std::istringstream is(buffer);
@@ -227,9 +224,8 @@ void VLStepExpress::GetValue(const std::string & command,
   os << command << " " << GetAxisName(axis);
   this->SendCommand(os.str());
 
-  std::string buffer;
   int temp;
-  this->ReceiveString(buffer);
+  auto buffer = this->ReceiveString();
   std::istringstream is(buffer);
   is >> temp;
   value = temp;
@@ -240,9 +236,8 @@ void VLStepExpress::GetValue(const std::string & command,
 {
   this->SendCommand(command);
 
-  std::string buffer;
   double temp;
-  this->ReceiveString(buffer);
+  auto buffer = this->ReceiveString();
 
   values.clear();
   std::istringstream is(buffer);
@@ -258,9 +253,8 @@ void VLStepExpress::GetValue(const std::string & command, VLStepExpress::Axis ax
   os << command << " " << GetAxisName(axis);
   this->SendCommand(os.str());
 
-  std::string buffer;
   double temp;
-  this->ReceiveString(buffer);
+  auto buffer = this->ReceiveString();
   std::istringstream is(buffer);
   is >> temp;
   value = temp;
@@ -273,9 +267,8 @@ void VLStepExpress::GetValue(const std::string & command, VLStepExpress::Axis ax
   os << command << " " << GetAxisName(axis);
   this->SendCommand(os.str());
 
-  std::string buffer;
   double temp;
-  this->ReceiveString(buffer);
+  auto buffer = this->ReceiveString();
 
   values.clear();
   std::istringstream is(buffer);

--- a/devices/Lang/VLStepExpress.cpp
+++ b/devices/Lang/VLStepExpress.cpp
@@ -165,17 +165,14 @@ void VLStepExpress::SetValue(const std::string & command,
 void VLStepExpress::GetValue(const std::string & command,
                              std::string & value)
 {
-  this->SendCommand(command);
-  value = this->ReceiveString();
+  value = this->ReceiveString(command);
 }
 
 void VLStepExpress::GetValue(const std::string & command,
                              int & value)
 {
-  this->SendCommand(command);
-
   int temp;
-  auto buffer = this->ReceiveString();
+  auto buffer = this->ReceiveString(command);
   std::istringstream is(buffer);
   is >> temp;
   value = temp;
@@ -184,10 +181,8 @@ void VLStepExpress::GetValue(const std::string & command,
 void VLStepExpress::GetValue(const std::string & command,
                              double & value)
 {
-  this->SendCommand(command);
-
   double temp;
-  auto buffer = this->ReceiveString();
+  auto buffer = this->ReceiveString(command);
   std::istringstream is(buffer);
   is >> temp;
   value = temp;
@@ -198,17 +193,14 @@ void VLStepExpress::GetValue(const std::string & command, VLStepExpress::Axis ax
 {
   std::ostringstream os;
   os << command << " " << GetAxisName(axis);
-  this->SendCommand(os.str());
-  value = this->ReceiveString();
+  value = this->ReceiveString(os.str());
 }
 
 void VLStepExpress::GetValue(const std::string & command,
                              std::vector<int> & values)
 {
-  this->SendCommand(command);
-
   int temp;
-  auto buffer = this->ReceiveString();
+  auto buffer = this->ReceiveString(command);
 
   values.clear();
   std::istringstream is(buffer);
@@ -222,10 +214,9 @@ void VLStepExpress::GetValue(const std::string & command,
 {
   std::ostringstream os;
   os << command << " " << GetAxisName(axis);
-  this->SendCommand(os.str());
 
   int temp;
-  auto buffer = this->ReceiveString();
+  auto buffer = this->ReceiveString(os.str());
   std::istringstream is(buffer);
   is >> temp;
   value = temp;
@@ -234,10 +225,8 @@ void VLStepExpress::GetValue(const std::string & command,
 void VLStepExpress::GetValue(const std::string & command,
                              std::vector<double> & values)
 {
-  this->SendCommand(command);
-
   double temp;
-  auto buffer = this->ReceiveString();
+  auto buffer = this->ReceiveString(command);
 
   values.clear();
   std::istringstream is(buffer);
@@ -251,10 +240,9 @@ void VLStepExpress::GetValue(const std::string & command, VLStepExpress::Axis ax
 {
   std::ostringstream os;
   os << command << " " << GetAxisName(axis);
-  this->SendCommand(os.str());
 
   double temp;
-  auto buffer = this->ReceiveString();
+  auto buffer = this->ReceiveString(os.str());
   std::istringstream is(buffer);
   is >> temp;
   value = temp;
@@ -265,10 +253,9 @@ void VLStepExpress::GetValue(const std::string & command, VLStepExpress::Axis ax
 {
   std::ostringstream os;
   os << command << " " << GetAxisName(axis);
-  this->SendCommand(os.str());
 
   double temp;
-  auto buffer = this->ReceiveString();
+  auto buffer = this->ReceiveString(os.str());
 
   values.clear();
   std::istringstream is(buffer);

--- a/devices/Lang/VLStepExpress.h
+++ b/devices/Lang/VLStepExpress.h
@@ -65,7 +65,7 @@ class VLStepExpress
 
   virtual std::string ioPort() = 0;
 
-  virtual bool DeviceAvailable() = 0;
+  virtual bool DeviceAvailable() const = 0;
 
   virtual void GetAutoStatus(int & value) = 0;
   virtual void SetAutoStatus(int value) = 0;

--- a/devices/Lang/VLStepExpress.h
+++ b/devices/Lang/VLStepExpress.h
@@ -157,7 +157,7 @@ class VLStepExpress
 
   // low level methods
   virtual void SendCommand(const std::string &) = 0;
-  virtual std::string ReceiveString() = 0;
+  virtual std::string ReceiveString(const std::string &) = 0;
 
   void SetValue(const std::string & command, const std::string & value);
   void SetValue(const std::string & command, VLStepExpress::Axis axis, const std::string & value);

--- a/devices/Lang/VLStepExpress.h
+++ b/devices/Lang/VLStepExpress.h
@@ -157,7 +157,7 @@ class VLStepExpress
 
   // low level methods
   virtual void SendCommand(const std::string &) = 0;
-  virtual void ReceiveString(std::string &) = 0;
+  virtual std::string ReceiveString() = 0;
 
   void SetValue(const std::string & command, const std::string & value);
   void SetValue(const std::string & command, VLStepExpress::Axis axis, const std::string & value);

--- a/devices/Lang/VLStepExpress.h
+++ b/devices/Lang/VLStepExpress.h
@@ -63,9 +63,9 @@ class VLStepExpress
 
   virtual ~VLStepExpress();
 
-  virtual std::string ioPort() const = 0;
+  virtual std::string ioPort() = 0;
 
-  virtual bool DeviceAvailable() const = 0;
+  virtual bool DeviceAvailable() = 0;
 
   virtual void GetAutoStatus(int & value) = 0;
   virtual void SetAutoStatus(int value) = 0;

--- a/devices/Marta/MartaComHandler.h
+++ b/devices/Marta/MartaComHandler.h
@@ -18,6 +18,7 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <unistd.h>
+#include <stdint.h>
 
 #include <string>
 

--- a/devices/Marta/VMarta.h
+++ b/devices/Marta/VMarta.h
@@ -14,6 +14,7 @@
 #define _VMARTA_H_
 
 #include <string>
+#include <stdint.h>
 
 typedef const char* ipaddress_t;
 typedef unsigned int port_t;


### PR DESCRIPTION
This PR reworks the Lang controller communication because

* Currently there were many simultaneous calls from the Qt gui to the device, b0rking communication
* There was lots of  unnecessary `char*` fiddling
* There was no transaction definition

This PR adds a low-level mutex to the controller class and changes the `ReceiveString` method to act as full transaction (send command, wait for response). This way, a mutex covers the entire life cycle of the communication with the device and no simultaneous command can intervene.

It also sets the build type to `RelWithDebInfo` so we can get backtraces.