### PR TITLE
Config path and logger

### DIFF
--- a/assembly/assembly/AssemblyMainWindow.cc
+++ b/assembly/assembly/AssemblyMainWindow.cc
@@ -22,6 +22,7 @@
 #include <AssemblyUtilities.h>
 
 #include <string>
+#include <filesystem>
 
 #include <QApplication>
 
@@ -107,7 +108,19 @@ AssemblyMainWindow::AssemblyMainWindow(const QString& outputdir_path, const QStr
     /// Parameters
     ///   * instance created up here, so controllers can access it
     try{
-      config->append(config->getValue<std::string>("main", "AssemblyParameters_file_path"), "parameters");
+      auto parameters_file_str = config->getValue<std::string>("main", "AssemblyParameters_file_path");
+      std::filesystem::path parameters_file_path(parameters_file_str);
+      if(parameters_file_path.is_absolute())
+      {
+        NQLog("AssemblyMainWindow", NQLog::Debug) << "Provided absolute path to parameter file. Opening file: " << parameters_file_path;
+        config->append(parameters_file_path, "parameters");
+      } else {
+        auto abs_path = std::filesystem::path(Config::CMSTkModLabBasePath);
+        abs_path /= parameters_file_path;
+        NQLog("AssemblyMainWindow", NQLog::Debug) << "Provided relative path to parameter file - compiled absolute path. Opening file: " << abs_path;
+        config->append(abs_path, "parameters");
+      }
+
     } catch (...) {
       NQLog("AssemblyMainWindow", NQLog::Fatal) << "\e[1;31m-------------------------------------------------------------------------------------------------------\e[0m";
       NQLog("AssemblyMainWindow", NQLog::Fatal) << "\e[1;31mInitialization error: ApplicationConfig::append(\"parameters\") is invalid ! Abort !\e[0m";

--- a/assembly/assembly/AssemblyMainWindow.cc
+++ b/assembly/assembly/AssemblyMainWindow.cc
@@ -107,26 +107,17 @@ AssemblyMainWindow::AssemblyMainWindow(const QString& outputdir_path, const QStr
 
     /// Parameters
     ///   * instance created up here, so controllers can access it
-    try{
-      auto parameters_file_str = config->getValue<std::string>("main", "AssemblyParameters_file_path");
-      std::filesystem::path parameters_file_path(parameters_file_str);
-      if(parameters_file_path.is_absolute())
-      {
-        NQLog("AssemblyMainWindow", NQLog::Debug) << "Provided absolute path to parameter file. Opening file: " << parameters_file_path;
-        config->append(parameters_file_path, "parameters");
-      } else {
-        auto abs_path = std::filesystem::path(Config::CMSTkModLabBasePath);
-        abs_path /= parameters_file_path;
-        NQLog("AssemblyMainWindow", NQLog::Debug) << "Provided relative path to parameter file - compiled absolute path. Opening file: " << abs_path;
-        config->append(abs_path, "parameters");
-      }
-
-    } catch (...) {
-      NQLog("AssemblyMainWindow", NQLog::Fatal) << "\e[1;31m-------------------------------------------------------------------------------------------------------\e[0m";
-      NQLog("AssemblyMainWindow", NQLog::Fatal) << "\e[1;31mInitialization error: ApplicationConfig::append(\"parameters\") is invalid ! Abort !\e[0m";
-      NQLog("AssemblyMainWindow", NQLog::Fatal) << "\e[1;31m-------------------------------------------------------------------------------------------------------\e[0m";
-
-      return;
+    auto parameters_file_str = config->getValue<std::string>("main", "AssemblyParameters_file_path");
+    std::filesystem::path parameters_file_path(parameters_file_str);
+    if(parameters_file_path.is_absolute())
+    {
+      NQLog("AssemblyMainWindow", NQLog::Debug) << "Provided absolute path to parameter file. Opening file: " << parameters_file_path;
+      config->append(parameters_file_path, "parameters");
+    } else {
+      auto abs_path = std::filesystem::path(Config::CMSTkModLabBasePath);
+      abs_path /= parameters_file_path;
+      NQLog("AssemblyMainWindow", NQLog::Debug) << "Provided relative path to parameter file - compiled absolute path. Opening file: " << abs_path;
+      config->append(abs_path, "parameters");
     }
     /// -------------------
 

--- a/assembly/assembly/assembly.cc
+++ b/assembly/assembly/assembly.cc
@@ -123,13 +123,19 @@ int main(int argc, char** argv)
     }
     // ----------------------
 
-    AssemblyMainWindow mainWindow(outputdir_path, logfile_path, DBlogfile_path);
+    try{
+        AssemblyMainWindow mainWindow(outputdir_path, logfile_path, DBlogfile_path);
+        mainWindow.setWindowTitle("Automated Pixel-Strip Module Assembly ["+QString(APPLICATIONVERSIONSTR)+"]");
+        mainWindow.setWindowState(Qt::WindowMaximized);
 
-    mainWindow.setWindowTitle("Automated Pixel-Strip Module Assembly ["+QString(APPLICATIONVERSIONSTR)+"]");
-    mainWindow.setWindowState(Qt::WindowMaximized);
+        mainWindow.show();
 
-    mainWindow.show();
-
-    return app.exec();
+        return app.exec();
+    } catch (ApplicationConfig::InvalidConfigFileException) {
+        NQLog("AssemblyMainWindow", NQLog::Fatal) << "\e[1;31m-------------------------------------------------------------------------------------------------------\e[0m";
+        NQLog("AssemblyMainWindow", NQLog::Fatal) << "\e[1;31mInitialization error: ApplicationConfig::append(\"parameters\") is invalid ! Abort !\e[0m";
+        NQLog("AssemblyMainWindow", NQLog::Fatal) << "\e[1;31m-------------------------------------------------------------------------------------------------------\e[0m";
+        return 1;
+    }
     // ----------------------
 }

--- a/assembly/assembly/assembly.cc
+++ b/assembly/assembly/assembly.cc
@@ -84,14 +84,39 @@ int main(int argc, char** argv)
       relative_config_path = "/assembly/assembly_glass.cfg";
     }
 
-    // log output -----------
-    ApplicationConfig* config = ApplicationConfig::instance(std::string(Config::CMSTkModLabBasePath)+relative_config_path, "main");
+    // log output - default -----------
+    NQLog::LogLevel nqloglevel_stdout  = NQLog::Message;
 
-    const NQLog::LogLevel nqloglevel_stdout  = ((NQLog::LogLevel) config->getDefaultValue<int>("main", "LogLevel_stdout" , 2));
+    try{
+      NQLogger::instance()->addActiveModule("*");
+      NQLogger::instance()->addDestiniation(stdout, nqloglevel_stdout, "stdout");
+    } catch(NQLogger::InvalidLoggerException& exc){
+        std::cerr << "Initialization error. Message: " << exc.what() << std::endl;
+    }
+
+    ApplicationConfig* config;
+    try{
+      config = ApplicationConfig::instance(std::string(Config::CMSTkModLabBasePath)+relative_config_path, "main");
+    } catch (ApplicationConfig::InvalidConfigFileException& exc) {
+      NQLog("AssemblyMainWindow", NQLog::Fatal) << "\e[1;31m-------------------------------------------------------------------------------------------------------\e[0m";
+      NQLog("AssemblyMainWindow", NQLog::Fatal) << "\e[1;31mInitialization error: ApplicationConfig::append(\"main\") is invalid ! Abort !\e[0m";
+      NQLog("AssemblyMainWindow", NQLog::Fatal) << "\e[1;31mMessage: " << exc.what() << "\e[0m";
+      NQLog("AssemblyMainWindow", NQLog::Fatal) << "\e[1;31m-------------------------------------------------------------------------------------------------------\e[0m";
+      return 1;
+    }
+
+    // log output - set correct parameters -----------
+    nqloglevel_stdout = ((NQLog::LogLevel) config->getDefaultValue<int>("main", "LogLevel_stdout" , 2));
+    try{
+      NQLogger::instance()->setLogLevel("stdout", nqloglevel_stdout);
+    } catch(NQLogger::InvalidLoggerException& exc){
+        NQLog("AssemblyMainWindow", NQLog::Fatal) << "\e[1;31m-------------------------------------------------------------------------------------------------------\e[0m";
+        NQLog("AssemblyMainWindow", NQLog::Fatal) << "\e[1;31mInitialization error: " << exc.what() << "\e[0m";
+        NQLog("AssemblyMainWindow", NQLog::Fatal) << "\e[1;31m-------------------------------------------------------------------------------------------------------\e[0m";
+        return 1;
+    }
+
     const NQLog::LogLevel nqloglevel_logfile = ((NQLog::LogLevel) config->getDefaultValue<int>("main", "LogLevel_logfile", 2));
-
-    NQLogger::instance()->addActiveModule("*");
-    NQLogger::instance()->addDestiniation(stdout, nqloglevel_stdout);
 
     const QString timestamp = QDateTime::currentDateTime().toString("yyyyMMdd_hhmmss");
 
@@ -119,7 +144,14 @@ int main(int argc, char** argv)
     QFile* logfile = new QFile(logfile_path);
     if(logfile->open(QIODevice::WriteOnly | QIODevice::Truncate | QIODevice::Text))
     {
-      NQLogger::instance()->addDestiniation(logfile, nqloglevel_logfile);
+      try{
+        NQLogger::instance()->addDestiniation(logfile, nqloglevel_logfile, "logfile");
+      } catch(NQLogger::InvalidLoggerException& exc){
+        NQLog("AssemblyMainWindow", NQLog::Fatal) << "\e[1;31m-------------------------------------------------------------------------------------------------------\e[0m";
+        NQLog("AssemblyMainWindow", NQLog::Fatal) << "\e[1;31mInitialization error: " << exc.what() << "\e[0m";
+        NQLog("AssemblyMainWindow", NQLog::Fatal) << "\e[1;31m-------------------------------------------------------------------------------------------------------\e[0m";
+        return 1;
+      }
     }
     // ----------------------
 

--- a/assembly/assembly_SiDummyPS.cfg
+++ b/assembly/assembly_SiDummyPS.cfg
@@ -37,7 +37,7 @@ assembly_sequence                              2
 skip_dipping                                   0
 
 # AssemblyParameters (format: path relative to directory where binary is executed)
-AssemblyParameters_file_path                   ../assembly/assembly/parameters/SiDummyPS.cfg
+AssemblyParameters_file_path                   assembly/assembly/parameters/SiDummyPS.cfg
 
 # LStepExpressMotionManager
 #-- Physical bounds of the motion stage (absolute, in mm)

--- a/assembly/assembly_glass.cfg
+++ b/assembly/assembly_glass.cfg
@@ -37,7 +37,7 @@ assembly_sequence                              2
 skip_dipping                                   0
 
 # AssemblyParameters (format: path relative to directory where binary is executed)
-AssemblyParameters_file_path                   ../assembly/assembly/parameters/glass.cfg
+AssemblyParameters_file_path                   assembly/assembly/parameters/glass.cfg
 
 # LStepExpressMotionManager
 #-- Physical bounds of the motion stage (absolute, in mm)

--- a/common/ApplicationConfig.h.in
+++ b/common/ApplicationConfig.h.in
@@ -37,7 +37,16 @@ class ApplicationConfig : public QObject
 {
   Q_OBJECT
 public:
-  
+
+    class InvalidConfigFileException : public std::exception
+    {
+    private:
+      std::string message;
+    public:
+      InvalidConfigFileException(std::string msg) : message(std::move(msg)) {}
+      const char * what () {return message.c_str();}
+    };
+
   struct FullKey {
     std::string filename;
     std::string alias;

--- a/common/ApplicationConfigReader.cc
+++ b/common/ApplicationConfigReader.cc
@@ -44,7 +44,7 @@ void ApplicationConfigReader::fill(ApplicationConfig::storage_t &keyvalueMap)
         QMessageBox::Abort
     );
 
-    throw; // must abort
+    throw ApplicationConfig::InvalidConfigFileException(" [ApplicationConfigReader::openAndCheckFile] ** ERROR: failed to open file: " + filename_ + "."); // throw exception
   }
 
   std::string Key;

--- a/common/nqlogger.cc
+++ b/common/nqlogger.cc
@@ -115,14 +115,32 @@ void NQLogger::addActiveModule(const QString& module)
   activeModules_.insert(std::pair<QString,bool>(module,false));
 }
 
-void NQLogger::addDestiniation(QIODevice * device, NQLog::LogLevel level)
+void NQLogger::addDestiniation(QIODevice * device, NQLog::LogLevel level, std::string dest_name)
 {
+  if(hasDestination(dest_name)){
+    throw(InvalidLoggerException("Logger already has a destination with name \"" + dest_name + "\". Please assign another destination name."));
+  }
   QTextStream* stream = new QTextStream(device);
-  destinations_.push_back(std::pair<NQLog::LogLevel,QTextStream*>(level,stream));
+  destinations_.push_back(std::tuple<NQLog::LogLevel,QTextStream*,std::string>(level,stream,dest_name));
 }
 
-void NQLogger::addDestiniation(FILE * fileHandle, NQLog::LogLevel level)
+void NQLogger::addDestiniation(FILE * fileHandle, NQLog::LogLevel level, std::string dest_name)
 {
+  if(hasDestination(dest_name)){
+    throw(InvalidLoggerException("Logger already has a destination with name \"" + dest_name + "\". Please assign another destination name."));
+  }
   QTextStream* stream = new QTextStream(fileHandle);
-  destinations_.push_back(std::pair<NQLog::LogLevel,QTextStream*>(level,stream));
+  destinations_.push_back(std::tuple<NQLog::LogLevel,QTextStream*,std::string>(level,stream,dest_name));
+}
+
+bool NQLogger::hasDestination(std::string dest_name)
+{
+  for(auto& dest_tuple : destinations_)
+  {
+    if(std::get<2>(dest_tuple) == dest_name)
+    {
+      return true;
+    }
+  }
+  return false;
 }

--- a/common/nqlogger.cc
+++ b/common/nqlogger.cc
@@ -117,7 +117,7 @@ void NQLogger::addActiveModule(const QString& module)
 
 void NQLogger::addDestiniation(QIODevice * device, NQLog::LogLevel level, std::string dest_name)
 {
-  if(hasDestination(dest_name)){
+  if(dest_name != "" && hasDestination(dest_name)){
     throw(InvalidLoggerException("Logger already has a destination with name \"" + dest_name + "\". Please assign another destination name."));
   }
   QTextStream* stream = new QTextStream(device);
@@ -126,7 +126,7 @@ void NQLogger::addDestiniation(QIODevice * device, NQLog::LogLevel level, std::s
 
 void NQLogger::addDestiniation(FILE * fileHandle, NQLog::LogLevel level, std::string dest_name)
 {
-  if(hasDestination(dest_name)){
+  if(dest_name != "" && hasDestination(dest_name)){
     throw(InvalidLoggerException("Logger already has a destination with name \"" + dest_name + "\". Please assign another destination name."));
   }
   QTextStream* stream = new QTextStream(fileHandle);

--- a/common/nqlogger.cc
+++ b/common/nqlogger.cc
@@ -95,9 +95,9 @@ void NQLogger::write(const QString& module, NQLog::LogLevel level, const QString
   message += buffer;
   message += "\n";
 
-  for (std::pair<NQLog::LogLevel,QTextStream*> v : destinations_) {
-    if (level>=v.first) {
-      QTextStream* stream = v.second;
+  for (std::tuple<NQLog::LogLevel,QTextStream*,std::string> v : destinations_) {
+    if (level>=std::get<0>(v)) {
+      QTextStream* stream = std::get<1>(v);
       QMutexLocker locker(&mutex_);
       stream->operator <<(message);
       stream->flush();

--- a/common/nqlogger.cc
+++ b/common/nqlogger.cc
@@ -133,6 +133,23 @@ void NQLogger::addDestiniation(FILE * fileHandle, NQLog::LogLevel level, std::st
   destinations_.push_back(std::tuple<NQLog::LogLevel,QTextStream*,std::string>(level,stream,dest_name));
 }
 
+void NQLogger::setLogLevel(std::string dest_name, NQLog::LogLevel level)
+{
+  if(dest_name == "") {
+    throw(InvalidLoggerException("Cannot alter loglevel with empty destination name. Please assign another destination name."));
+  }
+  for(auto& dest_tuple : destinations_)
+  {
+    if(std::get<2>(dest_tuple) == dest_name)
+    {
+      std::get<0>(dest_tuple) = level;
+      std::cout << "Altered log level to " << level << std::endl;
+      return;
+    }
+  }
+  throw(InvalidLoggerException("Logger has no destination with name \"" + dest_name + "\". Cannot alter log level of this destination."));
+}
+
 bool NQLogger::hasDestination(std::string dest_name)
 {
   for(auto& dest_tuple : destinations_)

--- a/common/nqlogger.h
+++ b/common/nqlogger.h
@@ -24,6 +24,7 @@
 #include <vector>
 #include <set>
 #include <string>
+#include <tuple>
 
 #include <QObject>
 #include <QIODevice>
@@ -140,14 +141,25 @@ class NQLogger : public QObject
     Q_OBJECT
 public:
 
+    class InvalidLoggerException : public std::exception
+    {
+    private:
+      std::string message;
+    public:
+      InvalidLoggerException(std::string msg) : message(std::move(msg)) {}
+      const char * what () {return message.c_str();}
+    };
+
     static NQLogger* instance(QObject *parent = 0);
 
     void write(const QString& module, NQLog::LogLevel level, const QString&buffer);
 
     void addActiveModule(const QString& module);
 
-    void addDestiniation(QIODevice * device, NQLog::LogLevel level = NQLog::Message);
-    void addDestiniation(FILE * fileHandle, NQLog::LogLevel level = NQLog::Message);
+    void addDestiniation(QIODevice * device, NQLog::LogLevel level = NQLog::Message, std::string dest_name = "");
+    void addDestiniation(FILE * fileHandle, NQLog::LogLevel level = NQLog::Message, std::string dest_name = "");
+
+    bool hasDestination(std::string dest_name);
 
 protected:
 
@@ -157,7 +169,7 @@ protected:
     QMutex mutex_;
 
     std::set<std::pair<QString,bool> > activeModules_;
-    std::vector<std::pair<NQLog::LogLevel,QTextStream*> > destinations_;
+    std::vector<std::tuple<NQLog::LogLevel,QTextStream*,std::string> > destinations_;
 };
 
 /** @} */

--- a/common/nqlogger.h
+++ b/common/nqlogger.h
@@ -159,6 +159,8 @@ public:
     void addDestiniation(QIODevice * device, NQLog::LogLevel level = NQLog::Message, std::string dest_name = "");
     void addDestiniation(FILE * fileHandle, NQLog::LogLevel level = NQLog::Message, std::string dest_name = "");
 
+    void setLogLevel(std::string dest_name, NQLog::LogLevel level);
+
     bool hasDestination(std::string dest_name);
 
 protected:


### PR DESCRIPTION
In this merge request, the handling of configuration files (and especially their absence) was improved. Along with that, the logger was made more flexible and now allows to change the log level at runtime.
The following changes were made:
 * The parameter file provided via the main config file can now be a relative **or** an absolute path. In the former case, the relative path is interpreted as relative to the `cmstkmodlab` base directory and the absolute path is compiled from that.
 * An exception is thrown for config files not found. For the parameter and main files they are caught properly and the application is shut down.
 * In the logger, each destination can now have a unique name, with which it is possible to alter the log level at runtime. This was necessary since in the assembly code we need to instantiate the logger before we know the targeted log level.
   * Adding logger destinations with the same name or changing the log level of an unknown log level cause an exception.

One could implement a functionality to change these via the GUI as well, but this can be a future MR.