### PR TITLE
Improve motion safety: en-/disable motion tools when stage is moving.

### DIFF
--- a/assembly/assemblyCommon/AssemblyHardwareControlView.cc
+++ b/assembly/assemblyCommon/AssemblyHardwareControlView.cc
@@ -72,8 +72,8 @@ AssemblyHardwareControlView::AssemblyHardwareControlView(const LStepExpressMotio
 
   connect(manager_->model(), SIGNAL(deviceStateChanged(State)), this, SLOT(stateChanged(State)));
 
-//  connect(manager_->model(), SIGNAL(motionStarted ()), this, SLOT(disableMotionTools()));
-//  connect(manager_->model(), SIGNAL(motionFinished()), this, SLOT( enableMotionTools()));
+  connect(manager_->model(), SIGNAL(motionStarted ()), this, SLOT(disableMotionTools()));
+  connect(manager_, SIGNAL(motion_finished()), this, SLOT( enableMotionTools()));
 
   g1->addWidget(box_move, 60);
   /// -------------


### PR DESCRIPTION
These two lines should be used (almost as is).
With these, the start of any motion disables and the finishing of any motion enables the motion tools. Motion tools are the manual interfaces for issuing relative or absolute motions.

This closes #198 