### PR TITLE
Make Thermo2 CMake ready

### DIFF
--- a/common/MattermostBot.cc
+++ b/common/MattermostBot.cc
@@ -16,7 +16,6 @@
 #include <curl/curl.h>
 
 #include <nqlogger.h>
-#include <ApplicationConfig.h>
 
 #include "MattermostBot.h"
 
@@ -27,7 +26,7 @@ MattermostBot::MattermostBot(std::string config_alias, QObject *parent)
     webhook_(),
     config_alias_(config_alias)
 {
-
+    config_ = ApplicationConfig::instance();
 }
 
 MattermostBot::MattermostBot(QString channel, std::string config_alias, QObject *parent)
@@ -35,7 +34,7 @@ MattermostBot::MattermostBot(QString channel, std::string config_alias, QObject 
     channel_(channel),
     config_alias_(config_alias)
 {
-
+    config_ = ApplicationConfig::instance();
 }
 
 MattermostBot::MattermostBot(QString channel, QString username, std::string config_alias, QObject *parent)
@@ -44,7 +43,7 @@ MattermostBot::MattermostBot(QString channel, QString username, std::string conf
     username_(username),
     config_alias_(config_alias)
 {
-
+    config_ = ApplicationConfig::instance();
 }
 
 MattermostBot::MattermostBot(QString channel, QString username, QString webhook, std::string config_alias, QObject *parent)

--- a/common/MattermostBot.h
+++ b/common/MattermostBot.h
@@ -16,6 +16,7 @@
 #include <QObject>
 #include <QMutex>
 #include <QString>
+#include <ApplicationConfig.h>
 
 /** @addtogroup common
  *  @{

--- a/thermo/thermo2/thermo2Common/CMakeLists.txt
+++ b/thermo/thermo2/thermo2Common/CMakeLists.txt
@@ -12,3 +12,10 @@ target_link_libraries(Thermo2Common_test
 	PRIVATE Thermo2Common
 	PRIVATE PkgConfig::GSL)
 set_target_properties(Thermo2Common_test PROPERTIES OUTPUT_NAME test)
+
+INSTALL(
+  TARGETS Thermo2Common
+  EXPORT Thermo
+  RUNTIME DESTINATION bin
+  ARCHIVE DESTINATION lib
+)

--- a/thermo/thermo2/thermoControl2/CMakeLists.txt
+++ b/thermo/thermo2/thermoControl2/CMakeLists.txt
@@ -41,6 +41,7 @@ set(CMAKE_CXX_FLAGS "${Qt5Svg_EXECUTABLE_COMPILE_FLAGS}")
 set(CMAKE_CXX_FLAGS "${Qt5Network_EXECUTABLE_COMPILE_FLAGS}")
 
 INCLUDE_DIRECTORIES(${CMAKE_SOURCE_DIR}/common)
+INCLUDE_DIRECTORIES(${CMAKE_BINARY_DIR}/common)
 
 target_link_libraries(thermoControl2
         PRIVATE Qt5::Core
@@ -49,4 +50,11 @@ target_link_libraries(thermoControl2
         PRIVATE Qt5::Svg
         PRIVATE Qt5::Network
         PRIVATE Common
+)
+
+INSTALL(
+  TARGETS thermoControl2
+  EXPORT Thermo
+  RUNTIME DESTINATION bin
+  ARCHIVE DESTINATION lib
 )


### PR DESCRIPTION
The Thermo2 part does not seem ready to be configured via CMake. This is fixed here by setting the corresponding include directories and installing the corresponding libraries.

As a side product, a small issue was found in the `MattermostBot`.