### PR TITLE
Implement different schemes for different assembly centers

### DIFF
--- a/assembly/assembly/AssemblyMainWindow.cc
+++ b/assembly/assembly/AssemblyMainWindow.cc
@@ -156,7 +156,8 @@ AssemblyMainWindow::AssemblyMainWindow(const QString& outputdir_path, const QStr
     /// -------------------
 
     /// Camera
-    camera_model_ = new AssemblyUEyeModel_t(10);
+    auto camera_config_interval = config->getDefaultValue<int>("main", "camera_config_interval", 10);
+    camera_model_ = new AssemblyUEyeModel_t(camera_config_interval);
     camera_model_->updateInformation();
 
     camera_thread_ = new AssemblyUEyeCameraThread(camera_model_, this);

--- a/assembly/assembly/AssemblyMainWindow.cc
+++ b/assembly/assembly/AssemblyMainWindow.cc
@@ -322,10 +322,6 @@ AssemblyMainWindow::AssemblyMainWindow(const QString& outputdir_path, const QStr
 
       NQLog("AssemblyMainWindow", NQLog::Message) << "added view " << tabname_Assembly
          << " (assembly_sequence = " << assembly_sequence << ")";
-
-      if (assemblyV2_->IsSkipDipping()) {
-          NQLog("AssemblyMainWindow", NQLog::Message) << "skipping dipping of PSs-Spacers at stage 3";
-      }
     }
     else
     {
@@ -501,9 +497,6 @@ AssemblyMainWindow::AssemblyMainWindow(const QString& outputdir_path, const QStr
     }
     else if(assembly_sequence == 2) {
         emit DBLogMessage("== Using modified assembly sequence == (MaPSA glued to baseplate first)");
-        if (assemblyV2_->IsSkipDipping()) {
-            emit DBLogMessage("== Skipping spacer dipping at stage 3 == (Glue dispenser is used for PSs-to-MaPSA)");
-        }
     }
 
     controls_tab->addTab(DBLog_view_, tabname_DBLog);

--- a/assembly/assembly/AssemblyMainWindow.cc
+++ b/assembly/assembly/AssemblyMainWindow.cc
@@ -1346,6 +1346,13 @@ void AssemblyMainWindow::update_vacuum_information(const int channel, const Swit
     to_be_updated->setStyleSheet("QLabel { color : gray ; font: bold }");
     to_be_updated->setAlignment(Qt::AlignCenter);
   }
+  
+void AssemblyMainWindow::warn_on_stage_limits(const double target_pos, const char axis, const double limit_pos_lower, const double limit_pos_upper)
+{
+    QMessageBox::warning(0, QString("[AssemblyMainWindow]"),
+    QString("Attempting to move %1-axis to %2 . This is beyond the limit of this stage: [ %3 , %4 ]").arg(axis).arg(target_pos).arg(limit_pos_lower).arg(limit_pos_upper),
+        QMessageBox::Ok
+    );
 }
 
 void AssemblyMainWindow::warn_on_stage_limits(const double target_pos, const char axis, const double limit_pos_lower, const double limit_pos_upper)

--- a/assembly/assembly/AssemblyMainWindow.cc
+++ b/assembly/assembly/AssemblyMainWindow.cc
@@ -661,14 +661,6 @@ AssemblyMainWindow::AssemblyMainWindow(const QString& outputdir_path, const QStr
       this->enable_images();
     }
 
-    if(config->hasKey("main", "camera_exposure_time") && camera_ != nullptr)
-    {
-        connect(this, SIGNAL(changeExposureTime(double)), camera_, SLOT(setExposureTime(double)));
-        auto camera_exposure_time = config->getValue<double>("main", "camera_exposure_time");
-        NQLog("AssemblyMainWindow", NQLog::Message) << QString("Setting camera exposure time to %1 ms").arg(camera_exposure_time);
-        emit changeExposureTime(camera_exposure_time);
-        disconnect(this, SIGNAL(changeExposureTime(double)), camera_, SLOT(setExposureTime(double)));
-    }
     // ------------------------
 }
 
@@ -728,6 +720,15 @@ void AssemblyMainWindow::enable_images()
      << ": emitting signal \"images_ON\"";
 
   emit images_ON();
+
+  if(ApplicationConfig::instance()->hasKey("main", "camera_exposure_time") && camera_ != nullptr)
+  {
+      connect(this, SIGNAL(changeExposureTime(double)), camera_, SLOT(setExposureTime(double)));
+      auto camera_exposure_time = ApplicationConfig::instance()->getValue<double>("main", "camera_exposure_time");
+      NQLog("AssemblyMainWindow", NQLog::Message) << QString("Setting camera exposure time to %1 ms").arg(camera_exposure_time);
+      emit changeExposureTime(camera_exposure_time);
+      disconnect(this, SIGNAL(changeExposureTime(double)), camera_, SLOT(setExposureTime(double)));
+  }
 }
 
 void AssemblyMainWindow::disable_images()

--- a/assembly/assembly/AssemblyMainWindow.cc
+++ b/assembly/assembly/AssemblyMainWindow.cc
@@ -29,7 +29,7 @@
 
 #include <opencv2/opencv.hpp>
 
-AssemblyMainWindow::AssemblyMainWindow(const QString& outputdir_path, const QString& logfile_path, const QString& DBlogfile_path, const unsigned int camera_ID, QWidget* parent) :
+AssemblyMainWindow::AssemblyMainWindow(const QString& outputdir_path, const QString& logfile_path, const QString& DBlogfile_path, QWidget* parent) :
   QMainWindow(parent),
 
   // Low-Level Controllers (Motion, Camera, Vacuum)
@@ -54,7 +54,7 @@ AssemblyMainWindow::AssemblyMainWindow(const QString& outputdir_path, const QStr
   camera_thread_(nullptr),
 //  camera_widget_(nullptr),
   camera_(nullptr),
-  camera_ID_(camera_ID),
+  camera_ID_(0),
 
   // High-Level Controllers
   image_ctr_(nullptr),
@@ -163,6 +163,7 @@ AssemblyMainWindow::AssemblyMainWindow(const QString& outputdir_path, const QStr
     camera_thread_ = new AssemblyUEyeCameraThread(camera_model_, this);
     camera_thread_->start();
 
+    camera_ID_ = config->getDefaultValue<unsigned int>("main", "camera_ID", 1);
     camera_ = camera_model_->getCameraByID(camera_ID_);
     if(camera_ == nullptr)
     {

--- a/assembly/assembly/AssemblyMainWindow.cc
+++ b/assembly/assembly/AssemblyMainWindow.cc
@@ -345,14 +345,14 @@ AssemblyMainWindow::AssemblyMainWindow(const QString& outputdir_path, const QStr
 
     connect(metrology_view_, SIGNAL(go_to_marker_signal()), metrology_, SLOT(move_to_start()));
     connect(metrology_view_, SIGNAL(enable_vacuum_baseplate(int)), relayCardManager_, SLOT(enableVacuum(int)));
-    connect(relayCardManager_, SIGNAL(vacuumChannelState(int, bool)), metrology_view_, SLOT(updateVacuumChannelState(int, bool)));
+    connect(relayCardManager_, SIGNAL(vacuumChannelState(int, SwitchState)), metrology_view_, SLOT(updateVacuumChannelState(int, SwitchState)));
 
     metrology_view_->PatRecOne_Image()->connectImageProducer(metrology_, SIGNAL(image_PatRecOne(cv::Mat)));
     metrology_view_->PatRecTwo_Image()->connectImageProducer(metrology_, SIGNAL(image_PatRecTwo(cv::Mat)));
     metrology_view_->PatRecThree_Image()->connectImageProducer(metrology_, SIGNAL(image_PatRecThree(cv::Mat)));
     metrology_view_->PatRecFour_Image()->connectImageProducer(metrology_, SIGNAL(image_PatRecFour(cv::Mat)));
 
-    connect(metrology_view_->button_metrologyEmergencyStop(), SIGNAL(clicked()), this, SLOT(disconnect_Metrology()));
+    connect(metrology_view_->button_metrologyEmergencyStop(), SIGNAL(clicked()), this, SLOT(disconnect_metrology()));
     connect(metrology_view_->button_metrologyEmergencyStop(), SIGNAL(clicked()), motion_manager_, SLOT(emergency_stop()));
     connect(metrology_view_->button_metrologyEmergencyStop(), SIGNAL(clicked()), zfocus_finder_ , SLOT(emergencyStop()));
     connect(metrology_view_->button_metrologyClearResults(), SIGNAL(clicked()), metrology_, SLOT(clear_results()));

--- a/assembly/assembly/AssemblyMainWindow.cc
+++ b/assembly/assembly/AssemblyMainWindow.cc
@@ -171,6 +171,16 @@ AssemblyMainWindow::AssemblyMainWindow(const QString& outputdir_path, const QStr
     }
     /// -------------------
 
+    std::string assembly_center_str = QString::fromStdString(config->getValue<std::string>("main", "assembly_center")).toUpper().toStdString();
+    if(!(assembly_center_str == "FNAL" || assembly_center_str == "BROWN" || assembly_center_str == "DESY")) {
+        NQLog("AssemblyAssemblyV2", NQLog::Fatal) << "Invalid assembly center provided: \"" << assembly_center_str << "\". Provide one of the following options: \"FNAL\", \"BROWN\", \"DESY\"";
+        QMessageBox* msgBox = new QMessageBox;
+        msgBox->setInformativeText(QString("Invalid assembly center provided (\"%1\").\nProvide one of the following options: \"FNAL\", \"BROWN\", \"DESY\"").arg(QString::fromStdString(assembly_center_str)));
+        msgBox->setStandardButtons(QMessageBox::Ok);
+        int ret = msgBox->exec();
+        exit(1);
+    }
+
     /// Vacuum Manager
     std::string relayCardDevice = config->getValue<std::string>("main", "RelayCardDevice");
     if (relayCardDevice=="Velleman")

--- a/assembly/assembly/AssemblyMainWindow.cc
+++ b/assembly/assembly/AssemblyMainWindow.cc
@@ -1346,7 +1346,8 @@ void AssemblyMainWindow::update_vacuum_information(const int channel, const Swit
     to_be_updated->setStyleSheet("QLabel { color : gray ; font: bold }");
     to_be_updated->setAlignment(Qt::AlignCenter);
   }
-  
+}
+
 void AssemblyMainWindow::warn_on_stage_limits(const double target_pos, const char axis, const double limit_pos_lower, const double limit_pos_upper)
 {
     QMessageBox::warning(0, QString("[AssemblyMainWindow]"),

--- a/assembly/assembly/AssemblyMainWindow.cc
+++ b/assembly/assembly/AssemblyMainWindow.cc
@@ -660,6 +660,15 @@ AssemblyMainWindow::AssemblyMainWindow(const QString& outputdir_path, const QStr
     {
       this->enable_images();
     }
+
+    if(config->hasKey("main", "camera_exposure_time") && camera_ != nullptr)
+    {
+        connect(this, SIGNAL(changeExposureTime(double)), camera_, SLOT(setExposureTime(double)));
+        auto camera_exposure_time = config->getValue<double>("main", "camera_exposure_time");
+        NQLog("AssemblyMainWindow", NQLog::Message) << QString("Setting camera exposure time to %1 ms").arg(camera_exposure_time);
+        emit changeExposureTime(camera_exposure_time);
+        disconnect(this, SIGNAL(changeExposureTime(double)), camera_, SLOT(setExposureTime(double)));
+    }
     // ------------------------
 }
 

--- a/assembly/assembly/AssemblyMainWindow.cc
+++ b/assembly/assembly/AssemblyMainWindow.cc
@@ -1369,11 +1369,3 @@ void AssemblyMainWindow::warn_on_stage_limits(const double target_pos, const cha
         QMessageBox::Ok
     );
 }
-
-void AssemblyMainWindow::warn_on_stage_limits(const double target_pos, const char axis, const double limit_pos_lower, const double limit_pos_upper)
-{
-    QMessageBox::warning(0, QString("[AssemblyMainWindow]"),
-    QString("Attempting to move %1-axis to %2 . This is beyond the limit of this stage: [ %3 , %4 ]").arg(axis).arg(target_pos).arg(limit_pos_lower).arg(limit_pos_upper),
-        QMessageBox::Ok
-    );
-}

--- a/assembly/assembly/AssemblyMainWindow.h
+++ b/assembly/assembly/AssemblyMainWindow.h
@@ -164,6 +164,8 @@ class AssemblyMainWindow : public QMainWindow
 
   void messageBox_restartMotionStage();
 
+  void restore_autofocus_settings();
+
  protected:
 
   // Low-Level Controllers (Motion, Camera, Vacuum)

--- a/assembly/assembly/AssemblyMainWindow.h
+++ b/assembly/assembly/AssemblyMainWindow.h
@@ -81,7 +81,7 @@ class AssemblyMainWindow : public QMainWindow
 
  public:
 
-  explicit AssemblyMainWindow(const QString& outputdir_path, const QString& logfile_path, const QString& DBlogfile_path, const unsigned int camera_ID=10, QWidget* parent=nullptr);
+  explicit AssemblyMainWindow(const QString& outputdir_path, const QString& logfile_path, const QString& DBlogfile_path, QWidget* parent=nullptr);
   virtual ~AssemblyMainWindow()
   {
       disconnect_otherSlots();

--- a/assembly/assembly/AssemblyMainWindow.h
+++ b/assembly/assembly/AssemblyMainWindow.h
@@ -136,6 +136,8 @@ class AssemblyMainWindow : public QMainWindow
 
   void image_request();
 
+  void changeExposureTime(double);
+
   void updateVacuumChannelsStatus();
 
   void autofocus_ON();

--- a/assembly/assemblyCommon/AssemblyAssemblyV2.cc
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2.cc
@@ -1110,6 +1110,7 @@ void AssemblyAssemblyV2::LowerPSSOntoSpacers_start()
     const double dx0 = 0.0;
     const double dy0 = 0.0;
 
+    bool use_spacer_clamp = GetAssemblyCenter()==assembly::Center::FNAL || GetAssemblyCenter()==assembly::Center::BROWN;
     const double dz0 =
         config_->getValue<double>("parameters", "CameraFocusOnAssemblyStage_Z")
       - config_->getValue<double>("parameters", "Depth_SpacerSlots")
@@ -1117,6 +1118,7 @@ void AssemblyAssemblyV2::LowerPSSOntoSpacers_start()
       + config_->getValue<double>("parameters", "FromCameraBestFocusToPickupHeight_dZ")
       + config_->getValue<double>("parameters", "Thickness_PSS")
       + config_->getValue<double>("parameters", "Thickness_GlueLayer")
+      + (use_spacer_clamp ? config_->getValue<double>("parameters", "Thickness_SpacerClamp") : 0)
       - motion_->get_position_Z();
 
     const double da0 = 0.0;

--- a/assembly/assemblyCommon/AssemblyAssemblyV2.cc
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2.cc
@@ -161,7 +161,8 @@ void AssemblyAssemblyV2::GoToSensorMarkerPreAlignment_start(bool isMapsa)
 
   const double x0 = config_->getValue<double>("parameters", "RefPointSensor_X");
   const double y0 = config_->getValue<double>("parameters", "RefPointSensor_Y");
-  const double z0 = config_->getValue<double>("parameters", "CameraFocusOnAssemblyStage_Z") + (isMapsa ? config_->getValue<double>("parameters", "Thickness_PSP") : config_->getValue<double>("parameters", "Thickness_PSS"));
+  const double z0 = config_->getValue<double>("parameters", "CameraFocusOnAssemblyStage_Z")
+   + (isMapsa ? config_->getValue<double>("parameters", "Thickness_PSP") : config_->getValue<double>("parameters", "Thickness_PSS"));
   const double a0 = config_->getValue<double>("parameters", "RefPointSensor_A");
 
   connect(this, SIGNAL(move_absolute_request(double, double, double, double)), motion_, SLOT(moveAbsolute(double, double, double, double)));

--- a/assembly/assemblyCommon/AssemblyAssemblyV2.cc
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2.cc
@@ -72,8 +72,6 @@ AssemblyAssemblyV2::AssemblyAssemblyV2(const LStepExpressMotionManager* const mo
 
   alreadyClicked_LowerPickupToolOntoMaPSA = false; alreadyClicked_LowerPickupToolOntoPSS = false; alreadyClicked_LowerMaPSAOntoBaseplate = false; alreadyClicked_LowerPSSOntoSpacers = false; alreadyClicked_LowerPSSPlusSpacersOntoGluingStage = false; alreadyClicked_LowerPSSPlusSpacersOntoMaPSA = false;
 
-  skip_dipping_ = config_->getDefaultValue<bool>("main", "skip_dipping", false);
-
   std::string assembly_center_str = QString::fromStdString(config_->getValue<std::string>("main", "assembly_center")).toUpper().toStdString();
   if(assembly_center_str == "FNAL") {
       assembly_center_ = assembly::Center::FNAL;
@@ -84,11 +82,6 @@ AssemblyAssemblyV2::AssemblyAssemblyV2(const LStepExpressMotionManager* const mo
   } else {
       NQLog("AssemblyAssemblyV2", NQLog::Warning) << "Invalid assembly center provided: \"" << assembly_center_str << "\". Provide one of the following options: \"FNAL\", \"BROWN\", \"DESY\"";
   }
-}
-
-bool AssemblyAssemblyV2::IsSkipDipping() const
-{
-    return skip_dipping_;
 }
 
 const LStepExpressMotionManager* AssemblyAssemblyV2::motion() const

--- a/assembly/assemblyCommon/AssemblyAssemblyV2.cc
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2.cc
@@ -14,7 +14,6 @@
 #include <ApplicationConfig.h>
 
 #include <AssemblyAssemblyV2.h>
-#include <AssemblyUtilities.h>
 
 #include <string>
 
@@ -75,6 +74,16 @@ AssemblyAssemblyV2::AssemblyAssemblyV2(const LStepExpressMotionManager* const mo
 
   skip_dipping_ = config_->getDefaultValue<bool>("main", "skip_dipping", false);
 
+  std::string assembly_center_str = QString::fromStdString(config_->getValue<std::string>("main", "assembly_center")).toUpper().toStdString();
+  if(assembly_center_str == "FNAL") {
+      assembly_center_ = assembly::Center::FNAL;
+  } else if(assembly_center_str == "BROWN") {
+      assembly_center_ = assembly::Center::BROWN;
+  } else if(assembly_center_str == "DESY") {
+      assembly_center_ = assembly::Center::DESY;
+  } else {
+      NQLog("AssemblyAssemblyV2", NQLog::Warning) << "Invalid assembly center provided: \"" << assembly_center_str << "\". Provide one of the following options: \"FNAL\", \"BROWN\", \"DESY\"";
+  }
 }
 
 bool AssemblyAssemblyV2::IsSkipDipping() const

--- a/assembly/assemblyCommon/AssemblyAssemblyV2.cc
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2.cc
@@ -149,7 +149,7 @@ void AssemblyAssemblyV2::use_smartMove(const int state)
 // ----------------------------------------------------------------------------------------------------
 // GoToSensorMarkerPreAlignment -----------------------------------------------------------------------
 // ----------------------------------------------------------------------------------------------------
-void AssemblyAssemblyV2::GoToSensorMarkerPreAlignment_start()
+void AssemblyAssemblyV2::GoToSensorMarkerPreAlignment_start(bool isMapsa)
 {
   if(in_action_){
 
@@ -161,7 +161,7 @@ void AssemblyAssemblyV2::GoToSensorMarkerPreAlignment_start()
 
   const double x0 = config_->getValue<double>("parameters", "RefPointSensor_X");
   const double y0 = config_->getValue<double>("parameters", "RefPointSensor_Y");
-  const double z0 = config_->getValue<double>("parameters", "RefPointSensor_Z");
+  const double z0 = config_->getValue<double>("parameters", "CameraFocusOnAssemblyStage_Z") + (isMapsa ? config_->getValue<double>("parameters", "Thickness_PSP") : config_->getValue<double>("parameters", "Thickness_PSS"));
   const double a0 = config_->getValue<double>("parameters", "RefPointSensor_A");
 
   connect(this, SIGNAL(move_absolute_request(double, double, double, double)), motion_, SLOT(moveAbsolute(double, double, double, double)));

--- a/assembly/assemblyCommon/AssemblyAssemblyV2.cc
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2.cc
@@ -16,6 +16,7 @@
 #include <AssemblyAssemblyV2.h>
 
 #include <string>
+#include <unistd.h>
 
 #include <QMessageBox>
 
@@ -69,6 +70,8 @@ AssemblyAssemblyV2::AssemblyAssemblyV2(const LStepExpressMotionManager* const mo
   pickup1_Z_ = config_->getValue<double>("main", "AssemblyAssembly_pickup1_Z");
   pickup2_Z_ = config_->getValue<double>("main", "AssemblyAssembly_pickup2_Z");
   makespace_Z_ = config_->getValue<double>("main", "AssemblyAssembly_makespace_Z");
+
+  original_Z_velocity_ = motion_->get_velocity_Z();
 
   alreadyClicked_LowerPickupToolOntoMaPSA = false; alreadyClicked_LowerPickupToolOntoPSS = false; alreadyClicked_LowerMaPSAOntoBaseplate = false; alreadyClicked_LowerPSSOntoSpacers = false; alreadyClicked_LowerPSSPlusSpacersOntoGluingStage = false; alreadyClicked_LowerPSSPlusSpacersOntoMaPSA = false;
 
@@ -1656,6 +1659,92 @@ void AssemblyAssemblyV2::LowerPSSPlusSpacersOntoGluingStage_finish()
   emit DBLogMessage("== Assembly step completed : [Lower {PS-s + spacers} onto gluing stage]");
 }
 // ----------------------------------------------------------------------------------------------------
+
+
+// ----------------------------------------------------------------------------------------------------
+// SlowlyLiftFromGluingStage --------------------------------------------------------------
+// ----------------------------------------------------------------------------------------------------
+void AssemblyAssemblyV2::SlowlyLiftFromGluingStage_start()
+{
+  if(in_action_){
+
+    NQLog("AssemblyAssemblyV2", NQLog::Warning) << "SlowlyLiftFromGluingStage_start"
+       << ": logic error, an assembly step is still in progress, will not take further action";
+
+    return;
+  }
+
+  if(use_smartMove_)
+  {
+
+    original_Z_velocity_ = motion_->get_velocity_Z();
+
+    double slowVelocity = 0.5; // mm/s
+    motion_->set_velocity_Z(slowVelocity);
+
+    while(slowVelocity != motion_->get_velocity_Z())
+    {
+      sleep(1);
+    }
+
+    const double dx0 = 0.;
+    const double dy0 = 0.;
+    const double dz0 = 5.;
+    const double da0 = 0.;
+
+    connect(this, SIGNAL(move_relative_request(double, double, double, double)), smart_motion_, SLOT(move_relative(double, double, double, double)));
+    connect(smart_motion_, SIGNAL(motion_completed()), this, SLOT(SlowlyLiftFromGluingStage_finish()));
+
+    in_action_ = true;
+
+    NQLog("AssemblyAssemblyV2", NQLog::Spam) << "SlowlyLiftFromGluingStage_start"
+       << ": emitting signal \"move_relative_request(" << dx0 << ", " << dy0 << ", " << dz0 << ", " << da0 << ")\"";
+
+    emit move_relative_request(dx0, dy0, dz0, da0);
+  }
+  else
+  {
+    NQLog("AssemblyAssemblyV2", NQLog::Critical) << "SlowlyLiftFromGluingStage_start"
+       << ": please enable \"smartMove\" mode (tick box in top-left corner of Assembly tab), required for this step";
+
+    QMessageBox msgBox;
+    msgBox.setText(tr("AssemblyAssemblyV2::SlowlyLiftFromGluingStage_start -- please enable \"smartMove\" mode (tick box in top-left corner of Assembly tab), required for this step"));
+    msgBox.exec();
+
+    NQLog("AssemblyAssemblyV2", NQLog::Spam) << "SlowlyLiftFromGluingStage_finish"
+       << ": emitting signal \"SlowlyLiftFromGluingStage_finished\"";
+
+    emit SlowlyLiftFromGluingStage_finished();
+
+    return;
+  }
+}
+
+void AssemblyAssemblyV2::SlowlyLiftFromGluingStage_finish()
+{
+  motion_->set_velocity_Z(original_Z_velocity_);
+  while(original_Z_velocity_ != motion_->get_velocity_Z())
+  {
+    sleep(1);
+  }
+
+  disconnect(this, SIGNAL(move_relative_request(double, double, double, double)), smart_motion_, SLOT(move_relative(double, double, double, double)));
+  disconnect(smart_motion_, SIGNAL(motion_completed()), this, SLOT(SlowlyLiftFromGluingStage_finish()));
+
+  if(in_action_){ in_action_ = false; }
+
+  NQLog("AssemblyAssemblyV2", NQLog::Spam) << "SlowlyLiftFromGluingStage_finish"
+     << ": emitting signal \"SlowlyLiftFromGluingStage_finished\"";
+
+  emit SlowlyLiftFromGluingStage_finished();
+
+  NQLog("AssemblyAssemblyV2", NQLog::Message) << "SlowlyLiftFromGluingStage_finish"
+     << ": assembly-step completed";
+
+  emit DBLogMessage("== Assembly step completed : [Slowly lifted PSS + spacers from gluing station]");
+}
+// ----------------------------------------------------------------------------------------------------
+
 
 // ----------------------------------------------------------------------------------------------------
 // ReturnToPSSPlusSpacersToMaPSAPosition --------------------------------------------------------------

--- a/assembly/assemblyCommon/AssemblyAssemblyV2.h
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2.h
@@ -74,7 +74,10 @@ class AssemblyAssemblyV2 : public QObject
   void use_smartMove(const int);
 
   // motion
-  void GoToSensorMarkerPreAlignment_start();
+  void GoToPspSensorMarkerPreAlignment_start() {GoToSensorMarkerPreAlignment_start(true );};
+  void GoToPssSensorMarkerPreAlignment_start() {GoToSensorMarkerPreAlignment_start(false);};
+
+  void GoToSensorMarkerPreAlignment_start(const bool isMapsa);
   void GoToSensorMarkerPreAlignment_finish();
 
   void GoFromSensorMarkerToPickupXY_start();

--- a/assembly/assemblyCommon/AssemblyAssemblyV2.h
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2.h
@@ -62,6 +62,8 @@ class AssemblyAssemblyV2 : public QObject
   double PSSPlusSpacersToMaPSAPosition_Z_;
   double PSSPlusSpacersToMaPSAPosition_A_;
 
+  double original_Z_velocity_;
+
   bool alreadyClicked_LowerPickupToolOntoMaPSA, alreadyClicked_LowerPickupToolOntoPSS, alreadyClicked_LowerMaPSAOntoBaseplate, alreadyClicked_LowerPSSOntoSpacers, alreadyClicked_LowerPSSPlusSpacersOntoGluingStage, alreadyClicked_LowerPSSPlusSpacersOntoMaPSA;
 
   assembly::Center assembly_center_;
@@ -121,6 +123,9 @@ class AssemblyAssemblyV2 : public QObject
 
   void ReturnToPSSPlusSpacersToMaPSAPosition_start();
   void ReturnToPSSPlusSpacersToMaPSAPosition_finish();
+
+  void SlowlyLiftFromGluingStage_start();
+  void SlowlyLiftFromGluingStage_finish();
 
   void LowerPSSPlusSpacersOntoMaPSA_start();
   void LowerPSSPlusSpacersOntoMaPSA_finish();
@@ -203,6 +208,7 @@ class AssemblyAssemblyV2 : public QObject
   void LowerPSSPlusSpacersOntoGluingStage_finished();
   void ReturnToPSSPlusSpacersToMaPSAPosition_finished();
 
+  void SlowlyLiftFromGluingStage_finished();
   void LowerPSSPlusSpacersOntoMaPSA_finished();
   void LiftUpPickupTool_finished();
   // ------

--- a/assembly/assemblyCommon/AssemblyAssemblyV2.h
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2.h
@@ -76,8 +76,8 @@ class AssemblyAssemblyV2 : public QObject
   void use_smartMove(const int);
 
   // motion
-  void GoToPspSensorMarkerPreAlignment_start() {GoToSensorMarkerPreAlignment_start(true );};
-  void GoToPssSensorMarkerPreAlignment_start() {GoToSensorMarkerPreAlignment_start(false);};
+  void GoToPSPSensorMarkerPreAlignment_start() {GoToSensorMarkerPreAlignment_start(true );};
+  void GoToPSSSensorMarkerPreAlignment_start() {GoToSensorMarkerPreAlignment_start(false);};
 
   void GoToSensorMarkerPreAlignment_start(const bool isMapsa);
   void GoToSensorMarkerPreAlignment_finish();

--- a/assembly/assemblyCommon/AssemblyAssemblyV2.h
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2.h
@@ -64,12 +64,10 @@ class AssemblyAssemblyV2 : public QObject
 
   bool alreadyClicked_LowerPickupToolOntoMaPSA, alreadyClicked_LowerPickupToolOntoPSS, alreadyClicked_LowerMaPSAOntoBaseplate, alreadyClicked_LowerPSSOntoSpacers, alreadyClicked_LowerPSSPlusSpacersOntoGluingStage, alreadyClicked_LowerPSSPlusSpacersOntoMaPSA;
 
-  bool skip_dipping_;
-
   assembly::Center assembly_center_;
 
  public:
-  bool IsSkipDipping() const;
+  assembly::Center GetAssemblyCenter() const {return assembly_center_;};
 
  public slots:
 

--- a/assembly/assemblyCommon/AssemblyAssemblyV2.h
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2.h
@@ -17,6 +17,7 @@
 
 #include <LStepExpressMotionManager.h>
 #include <RelayCardManager.h>
+#include <AssemblyUtilities.h>
 
 #include <AssemblySmartMotionManager.h>
 #include <ApplicationConfig.h>
@@ -64,6 +65,8 @@ class AssemblyAssemblyV2 : public QObject
   bool alreadyClicked_LowerPickupToolOntoMaPSA, alreadyClicked_LowerPickupToolOntoPSS, alreadyClicked_LowerMaPSAOntoBaseplate, alreadyClicked_LowerPSSOntoSpacers, alreadyClicked_LowerPSSPlusSpacersOntoGluingStage, alreadyClicked_LowerPSSPlusSpacersOntoMaPSA;
 
   bool skip_dipping_;
+
+  assembly::Center assembly_center_;
 
  public:
   bool IsSkipDipping() const;

--- a/assembly/assemblyCommon/AssemblyAssemblyV2View.cc
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2View.cc
@@ -451,7 +451,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
   }
   // ----------
 
-  if(skip_dipping){
+  if(assembly->GetAssemblyCenter() == assembly::Center::DESY){
     // step: Dispense Slow Glue on Spacers and Place them on Assembly Platform
     {
       ++assembly_step_N;
@@ -579,7 +579,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
 
     AssemblyAssemblyTextWidget* tmp_wid = new AssemblyAssemblyTextWidget;
     tmp_wid->label()->setText(QString::number(assembly_step_N));
-    if(skip_dipping){
+    if(assembly->GetAssemblyCenter() == assembly::Center::DESY){
       tmp_wid->text()->setText("Dispense Slow Glue on \"MaPSA + Baseplate\" and Place on Assembly Platform with Baseplate Pins");
     } else {
       tmp_wid->text()->setText("Place \"MaPSA + Baseplate\" on Assembly Platform with Baseplate Pins");
@@ -667,7 +667,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
   }
   // ----------
 
-  if (skip_dipping)
+  if (assembly->GetAssemblyCenter() == assembly::Center::DESY)
       {
           // step: Make space on the platform by raising the pickup tool
           {

--- a/assembly/assemblyCommon/AssemblyAssemblyV2View.cc
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2View.cc
@@ -22,7 +22,9 @@
 #include <AssemblyAssemblyActionWidget.h>
 #include <AssemblyAssemblyTextWidget.h>
 
-AssemblyAssemblyV2View::AssemblyAssemblyV2View(const QObject* const assembly, QWidget* parent)
+#include <AssemblyUtilities.h>
+
+AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const assembly, QWidget* parent)
  : QWidget(parent)
  , smartMove_checkbox_(nullptr)
  , wid_PSPToBasep_(nullptr)
@@ -32,12 +34,10 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const QObject* const assembly, QW
   if(assembly == nullptr)
   {
     NQLog("AssemblyAssemblyView", NQLog::Fatal) << "AssemblyAssemblyView(" << assembly << ", " << parent << ")"
-       << ": null pointer to QObject --> GUI layout will not be created";
+       << ": null pointer to AssemblyAssemblyV2 --> GUI layout will not be created";
 
     return;
   }
-
-  bool skip_dipping = dynamic_cast<const AssemblyAssemblyV2*>(assembly) -> IsSkipDipping();
 
   QVBoxLayout* layout = new QVBoxLayout;
   this->setLayout(layout);

--- a/assembly/assemblyCommon/AssemblyAssemblyV2View.cc
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2View.cc
@@ -760,6 +760,22 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
       }
       // ----------
 
+      if(assembly->GetAssemblyCenter() == assembly::Center::FNAL || assembly->GetAssemblyCenter() == assembly::Center::BROWN)
+      {
+        // step: Slowly lift from gluing stage
+        {
+          ++assembly_step_N;
+
+          AssemblyAssemblyActionWidget* tmp_wid = new AssemblyAssemblyActionWidget;
+          tmp_wid->label()->setText(QString::number(assembly_step_N));
+          tmp_wid->button()->setText("Slowly lift from gluing stage by 5 mm");
+          PSSToMaPSA_lay->addWidget(tmp_wid);
+
+          tmp_wid->connect_action(assembly, SLOT(SlowlyLiftFromGluingStage_start()), SIGNAL(SlowlyLiftFromGluingStage_finished()));
+        }
+      }
+      // ----------
+
       // step: Return To "PS-s to MaPSA" XYZA Position
       // (step prior to lowering pickup tool; camera height must correspond to best-focus height on PS-p surface)
       {

--- a/assembly/assemblyCommon/AssemblyAssemblyV2View.cc
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2View.cc
@@ -88,7 +88,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
     tmp_wid->button()->setText("Go To Measurement Position on MaPSA");
     PSPToBasep_lay->addWidget(tmp_wid);
 
-    tmp_wid->connect_action(assembly, SLOT(GoToSensorMarkerPreAlignment_start()), SIGNAL(GoToSensorMarkerPreAlignment_finished()));
+    tmp_wid->connect_action(assembly, SLOT(GoToPSPSensorMarkerPreAlignment_start()), SIGNAL(GoToSensorMarkerPreAlignment_finished()));
   }
   // ----------
 
@@ -340,7 +340,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
     tmp_wid->button()->setText("Go To Measurement Position on PS-s");
     PSSToSpacers_lay->addWidget(tmp_wid);
 
-    tmp_wid->connect_action(assembly, SLOT(GoToSensorMarkerPreAlignment_start()), SIGNAL(GoToSensorMarkerPreAlignment_finished()));
+    tmp_wid->connect_action(assembly, SLOT(GoToPSSSensorMarkerPreAlignment_start()), SIGNAL(GoToSensorMarkerPreAlignment_finished()));
   }
   // ----------
 

--- a/assembly/assemblyCommon/AssemblyAssemblyV2View.cc
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2View.cc
@@ -192,7 +192,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
 
     AssemblyAssemblyTextWidget* tmp_wid = new AssemblyAssemblyTextWidget;
     tmp_wid->label()->setText(QString::number(assembly_step_N));
-    tmp_wid->text()->setText("Dispense (Slow+Fast) Glue on Baseplate and Place it on Assembly Platform with Pins");
+    tmp_wid->text()->setText("Dispense Slow Glue on Baseplate and Place it on Assembly Platform with Pins");
     PSPToBasep_lay->addWidget(tmp_wid);
   }
   // ----------
@@ -220,6 +220,17 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
     PSPToBasep_lay->addWidget(tmp_wid);
 
     tmp_wid->connect_action(assembly, SLOT(GoToXYAPositionToGlueMaPSAToBaseplate_start()), SIGNAL(GoToXYAPositionToGlueMaPSAToBaseplate_finished()));
+  }
+  // ----------
+
+  // step: Dispense Fast Glue on Baseplate
+  {
+    ++assembly_step_N;
+
+    AssemblyAssemblyTextWidget* tmp_wid = new AssemblyAssemblyTextWidget;
+    tmp_wid->label()->setText(QString::number(assembly_step_N));
+    tmp_wid->text()->setText("Dispense Fast Glue on Baseplate");
+    PSPToBasep_lay->addWidget(tmp_wid);
   }
   // ----------
 

--- a/assembly/assemblyCommon/AssemblyAssemblyV2View.h
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2View.h
@@ -23,7 +23,7 @@ class AssemblyAssemblyV2View : public QWidget
  Q_OBJECT
 
  public:
-  explicit AssemblyAssemblyV2View(const QObject* const, QWidget* parent=nullptr);
+  explicit AssemblyAssemblyV2View(const AssemblyAssemblyV2* const, QWidget* parent=nullptr);
   virtual ~AssemblyAssemblyV2View() {}
 
  public slots:

--- a/assembly/assemblyCommon/AssemblyParametersView.cc
+++ b/assembly/assemblyCommon/AssemblyParametersView.cc
@@ -41,6 +41,19 @@ AssemblyParametersView::AssemblyParametersView(QWidget* parent)
   QVBoxLayout* layout = new QVBoxLayout;
   this->setLayout(layout);
 
+  // Get information on assembly center to accommodate for different parameters required
+  std::string assembly_center_str = QString::fromStdString(config_->getValue<std::string>("main", "assembly_center")).toUpper().toStdString();
+  assembly::Center assembly_center;
+  if(assembly_center_str == "FNAL") {
+      assembly_center = assembly::Center::FNAL;
+  } else if(assembly_center_str == "BROWN") {
+      assembly_center = assembly::Center::BROWN;
+  } else if(assembly_center_str == "DESY") {
+      assembly_center = assembly::Center::DESY;
+  } else {
+      NQLog("AssemblyAssemblyV2", NQLog::Warning) << "Invalid assembly center provided: \"" << assembly_center_str << "\". Provide one of the following options: \"FNAL\", \"BROWN\", \"DESY\"";
+  }
+
   //// Display parameter filename -------------------
   QHBoxLayout* filename_lay = new QHBoxLayout;
   layout->addLayout(filename_lay);
@@ -167,6 +180,22 @@ AssemblyParametersView::AssemblyParametersView(QWidget* parent)
   dime_lay->addWidget(new QLabel(tmp_des) , row_index, 0, Qt::AlignLeft);
   dime_lay->addWidget(new QLabel(tr("dZ")), row_index, 5, Qt::AlignRight);
   dime_lay->addWidget(this->get(tmp_tag)  , row_index, 6, Qt::AlignRight);
+
+
+  if(assembly_center == assembly::Center::FNAL || assembly_center == assembly::Center::BROWN)
+  {
+    // dimension: thickness of SpacerClamp
+    ++row_index;
+
+    tmp_tag = "Thickness_SpacerClamp";
+    tmp_des = "Thickness of SpacerClamp :";
+
+    map_lineEdit_[tmp_tag] = new QLineEdit(tr(""));
+
+    dime_lay->addWidget(new QLabel(tmp_des) , row_index, 0, Qt::AlignLeft);
+    dime_lay->addWidget(new QLabel(tr("dZ")), row_index, 5, Qt::AlignRight);
+    dime_lay->addWidget(this->get(tmp_tag)  , row_index, 6, Qt::AlignRight);
+  }
 
   //// ---------------------
 

--- a/assembly/assemblyCommon/AssemblyParametersView.cc
+++ b/assembly/assemblyCommon/AssemblyParametersView.cc
@@ -13,7 +13,6 @@
 #include <nqlogger.h>
 
 #include <AssemblyParametersView.h>
-#include <AssemblyUtilities.h>
 
 #include <QVBoxLayout>
 #include <QHBoxLayout>
@@ -43,13 +42,12 @@ AssemblyParametersView::AssemblyParametersView(QWidget* parent)
 
   // Get information on assembly center to accommodate for different parameters required
   std::string assembly_center_str = QString::fromStdString(config_->getValue<std::string>("main", "assembly_center")).toUpper().toStdString();
-  assembly::Center assembly_center;
   if(assembly_center_str == "FNAL") {
-      assembly_center = assembly::Center::FNAL;
+      assembly_center_ = assembly::Center::FNAL;
   } else if(assembly_center_str == "BROWN") {
-      assembly_center = assembly::Center::BROWN;
+      assembly_center_ = assembly::Center::BROWN;
   } else if(assembly_center_str == "DESY") {
-      assembly_center = assembly::Center::DESY;
+      assembly_center_ = assembly::Center::DESY;
   } else {
       NQLog("AssemblyAssemblyV2", NQLog::Warning) << "Invalid assembly center provided: \"" << assembly_center_str << "\". Provide one of the following options: \"FNAL\", \"BROWN\", \"DESY\"";
   }
@@ -182,7 +180,7 @@ AssemblyParametersView::AssemblyParametersView(QWidget* parent)
   dime_lay->addWidget(this->get(tmp_tag)  , row_index, 6, Qt::AlignRight);
 
 
-  if(assembly_center == assembly::Center::FNAL || assembly_center == assembly::Center::BROWN)
+  if(assembly_center_ == assembly::Center::FNAL || assembly_center_ == assembly::Center::BROWN)
   {
     // dimension: thickness of SpacerClamp
     ++row_index;
@@ -282,7 +280,7 @@ AssemblyParametersView::AssemblyParametersView(QWidget* parent)
   posi_lay->addWidget(button_moveAbsRefPos4_, row_index, 9, Qt::AlignRight);
 
 
-  if(assembly_center == assembly::Center::FNAL || assembly_center == assembly::Center::BROWN)
+  if(assembly_center_ == assembly::Center::FNAL || assembly_center_ == assembly::Center::BROWN)
   {
     // position: z-position where camera is focused on Gluing Stage surface
     ++row_index;
@@ -554,8 +552,11 @@ AssemblyParametersView::AssemblyParametersView(QWidget* parent)
   connect(button_moveAbsRefPos1_ , SIGNAL(clicked()), this, SLOT(moveToAbsRefPos1()));
   connect(button_moveAbsRefPos2_ , SIGNAL(clicked()), this, SLOT(moveToAbsRefPos2()));
   connect(button_moveAbsRefPos4_ , SIGNAL(clicked()), this, SLOT(moveToAbsRefPos4()));
-  connect(button_moveAbsRefPos5_ , SIGNAL(clicked()), this, SLOT(moveToAbsRefPos5()));
   connect(this , SIGNAL(click_moveToAbsRefPos(int)), this, SLOT(askConfirmMoveToAbsRefPoint(int)));
+  if(assembly_center_ == assembly::Center::FNAL || assembly_center_ == assembly::Center::BROWN)
+  {
+    connect(button_moveAbsRefPos5_ , SIGNAL(clicked()), this, SLOT(moveToAbsRefPos5()));
+  }
 
   connect(button_moveRelRefDist1_ , SIGNAL(clicked()), this, SLOT(moveByRelRefDist1()));
   connect(button_moveRelRefDist2_ , SIGNAL(clicked()), this, SLOT(moveByRelRefDist2()));
@@ -592,8 +593,11 @@ AssemblyParametersView::~AssemblyParametersView()
     disconnect(button_moveAbsRefPos1_ , SIGNAL(clicked()), this, SLOT(moveToAbsRefPos1()));
     disconnect(button_moveAbsRefPos2_ , SIGNAL(clicked()), this, SLOT(moveToAbsRefPos2()));
     disconnect(button_moveAbsRefPos4_ , SIGNAL(clicked()), this, SLOT(moveToAbsRefPos4()));
-    disconnect(button_moveAbsRefPos5_ , SIGNAL(clicked()), this, SLOT(moveToAbsRefPos5()));
     disconnect(this , SIGNAL(click_moveToAbsRefPos(int)), this, SLOT(askConfirmMoveToAbsRefPoint(int)));
+    if(assembly_center_ == assembly::Center::FNAL || assembly_center_ == assembly::Center::BROWN)
+    {
+      disconnect(button_moveAbsRefPos5_ , SIGNAL(clicked()), this, SLOT(moveToAbsRefPos5()));
+    }
 
     disconnect(button_moveRelRefDist1_ , SIGNAL(clicked()), this, SLOT(moveByRelRefDist1()));
     disconnect(button_moveRelRefDist2_ , SIGNAL(clicked()), this, SLOT(moveByRelRefDist2()));

--- a/assembly/assemblyCommon/AssemblyParametersView.cc
+++ b/assembly/assemblyCommon/AssemblyParametersView.cc
@@ -737,14 +737,19 @@ void AssemblyParametersView::transmit_entries()
 void AssemblyParametersView::copy_values()
 {
   //-- Values read from parameters (<-> calibrations) file
-  for(const auto& i_key : config_->getKeys()) {
+  std::vector<std::string> exceptions;
+  exceptions.push_back("AssemblyObjectAlignerView_PSP_deltaX");
+  exceptions.push_back("AssemblyObjectAlignerView_PSP_deltaX_neg");
+  exceptions.push_back("AssemblyObjectAlignerView_PSS_deltaX");
+  exceptions.push_back("AssemblyObjectAlignerView_PSS_deltaX_neg");
+  exceptions.push_back("AssemblyParameters_file_path");
 
-    if(!(i_key.alias == "parameters"))
-    {
-      continue;
-    }
+  for(const auto& key : map_lineEdit_)
+  {
+    if (std::count(exceptions.begin(), exceptions.end(), key.first))
+        continue;
 
-    this->setText(i_key.key, config_->getValue<double>(i_key));
+    this->setText(key.first, config_->getValue<double>("parameters", key.first));
   }
 
   //-- Values read from config file

--- a/assembly/assemblyCommon/AssemblyParametersView.cc
+++ b/assembly/assemblyCommon/AssemblyParametersView.cc
@@ -281,31 +281,35 @@ AssemblyParametersView::AssemblyParametersView(QWidget* parent)
   button_moveAbsRefPos4_  = new QPushButton(tr("Move To Abs. Position"));
   posi_lay->addWidget(button_moveAbsRefPos4_, row_index, 9, Qt::AlignRight);
 
-  // position: z-position where camera is focused on Gluing Stage surface
-  ++row_index;
 
-  tmp_tag = "CameraFocusOnGluingStage";
-  tmp_des = "Camera Focused on Gluing Stage Surface :";
+  if(assembly_center == assembly::Center::FNAL || assembly_center == assembly::Center::BROWN)
+  {
+    // position: z-position where camera is focused on Gluing Stage surface
+    ++row_index;
 
-  map_lineEdit_[tmp_tag+"_X"] = new QLineEdit(tr(""));
-  map_lineEdit_[tmp_tag+"_Y"] = new QLineEdit(tr(""));
-  map_lineEdit_[tmp_tag+"_Z"] = new QLineEdit(tr(""));
-  map_lineEdit_[tmp_tag+"_A"] = new QLineEdit(tr(""));
+    tmp_tag = "CameraFocusOnGluingStage";
+    tmp_des = "Camera Focused on Gluing Stage Surface :";
 
-  posi_lay->addWidget(new QLabel(tmp_des)    , row_index, 0, Qt::AlignLeft);
-  posi_lay->addWidget(new QLabel(tr("X"))    , row_index, 1, Qt::AlignRight);
-  posi_lay->addWidget(this->get(tmp_tag+"_X"), row_index, 2, Qt::AlignRight);
-  posi_lay->addWidget(new QLabel(tr("Y"))    , row_index, 3, Qt::AlignRight);
-  posi_lay->addWidget(this->get(tmp_tag+"_Y"), row_index, 4, Qt::AlignRight);
-  posi_lay->addWidget(new QLabel(tr("Z"))    , row_index, 5, Qt::AlignRight);
-  posi_lay->addWidget(this->get(tmp_tag+"_Z"), row_index, 6, Qt::AlignRight);
-  posi_lay->addWidget(new QLabel(tr("A"))    , row_index, 7, Qt::AlignRight);
-  posi_lay->addWidget(this->get(tmp_tag+"_A"), row_index, 8, Qt::AlignRight);
+    map_lineEdit_[tmp_tag+"_X"] = new QLineEdit(tr(""));
+    map_lineEdit_[tmp_tag+"_Y"] = new QLineEdit(tr(""));
+    map_lineEdit_[tmp_tag+"_Z"] = new QLineEdit(tr(""));
+    map_lineEdit_[tmp_tag+"_A"] = new QLineEdit(tr(""));
 
-  button_moveAbsRefPos5_  = new QPushButton(tr("Move To Abs. Position")); //NB: make sure that the priority is correctly set between the XYA and Z movements (otherwise the robot arm may crash into the platform...)
-  posi_lay->addWidget(button_moveAbsRefPos5_, row_index, 9, Qt::AlignRight);
+    posi_lay->addWidget(new QLabel(tmp_des)    , row_index, 0, Qt::AlignLeft);
+    posi_lay->addWidget(new QLabel(tr("X"))    , row_index, 1, Qt::AlignRight);
+    posi_lay->addWidget(this->get(tmp_tag+"_X"), row_index, 2, Qt::AlignRight);
+    posi_lay->addWidget(new QLabel(tr("Y"))    , row_index, 3, Qt::AlignRight);
+    posi_lay->addWidget(this->get(tmp_tag+"_Y"), row_index, 4, Qt::AlignRight);
+    posi_lay->addWidget(new QLabel(tr("Z"))    , row_index, 5, Qt::AlignRight);
+    posi_lay->addWidget(this->get(tmp_tag+"_Z"), row_index, 6, Qt::AlignRight);
+    posi_lay->addWidget(new QLabel(tr("A"))    , row_index, 7, Qt::AlignRight);
+    posi_lay->addWidget(this->get(tmp_tag+"_A"), row_index, 8, Qt::AlignRight);
 
-  //// ---------------------
+    button_moveAbsRefPos5_  = new QPushButton(tr("Move To Abs. Position")); //NB: make sure that the priority is correctly set between the XYA and Z movements (otherwise the robot arm may crash into the platform...)
+    posi_lay->addWidget(button_moveAbsRefPos5_, row_index, 9, Qt::AlignRight);
+    //// ---------------------
+
+  }
 
   row_index = -1;
 

--- a/assembly/assemblyCommon/AssemblyParametersView.h
+++ b/assembly/assemblyCommon/AssemblyParametersView.h
@@ -17,6 +17,7 @@
 #include <AssemblyMultiPickupTesterWidget.h>
 #include <AssemblyPositionsRegistryWidget.h>
 #include <ApplicationConfig.h>
+#include <AssemblyUtilities.h>
 
 #include <string>
 #include <map>
@@ -59,6 +60,8 @@ class AssemblyParametersView : public QWidget
   std::map<std::string, QLineEdit*> map_lineEdit_;
 
   ApplicationConfig* config_;
+
+  assembly::Center assembly_center_;
 
  public slots:
 

--- a/assembly/assemblyCommon/AssemblyUEyeCamera.cc
+++ b/assembly/assemblyCommon/AssemblyUEyeCamera.cc
@@ -300,7 +300,7 @@ void AssemblyUEyeCamera::updatePixelClock()
     if (nRet == IS_SUCCESS) {
       nMin = nRange[0];
       nMax = nRange[1];
-      nInc = nRange[2];
+      nInc = nRange[2]!= 0 ? nRange[2] : 1;
     }
 
     NQLog("AssemblyUEyeCamera", NQLog::Debug) << "updatePixelClock"

--- a/assembly/assemblyCommon/AssemblyUtilities.h
+++ b/assembly/assemblyCommon/AssemblyUtilities.h
@@ -54,6 +54,12 @@ namespace assembly {
   // geometry helpers
   void rotation2D_deg(double&, double&, const double, const double, const double);
 
+  enum Center {
+      FNAL = 1,
+      BROWN = 2,
+      DESY = 3
+  };
+
 }
 
 template <class T>

--- a/assembly/assemblyCommon/LStepExpressMotionManager.h
+++ b/assembly/assemblyCommon/LStepExpressMotionManager.h
@@ -41,6 +41,9 @@ class LStepExpressMotionManager : public QObject
     double get_position_Z() const { return this->get_position(2); }
     double get_position_A() const { return this->get_position(3); }
 
+    double   get_velocity_Z() const { return this->model()->getVelocity(2); }
+    void     set_velocity_Z(const double velocity) const { this->model()->setVelocity(2, velocity); }
+
     void myMoveToThread(QThread*);
 
   protected:

--- a/assembly/assemblyCommon/Metrology.cc
+++ b/assembly/assemblyCommon/Metrology.cc
@@ -233,6 +233,30 @@ void Metrology::execute()
   this->run_metrology(0., 0., 0.);
 }
 
+void Metrology::patrec_complete(const int exit_code){
+  QMutexLocker ml(&mutex_);
+
+  if(exit_code != 0)
+  {
+      NQLog("Metrology", NQLog::Critical) << "patrec_complete"
+         << ": pattern recognition terminated with non-zero exit code (" << exit_code << "). Stopping metrology.";
+
+      this->reset();
+
+      QMessageBox* msgBox = new QMessageBox;
+      msgBox->setInformativeText("Metrology routine could not be completed due to to a failed pattern recognition process.");
+
+      msgBox->setStandardButtons(QMessageBox::Ok);
+
+      int ret = msgBox->exec();
+
+      NQLog("Metrology", NQLog::Critical) << "patrec_complete"
+         << ": Emitting signal \"execution_failed\"";
+      emit execution_failed();
+  }
+
+}
+
 void Metrology::run_metrology(const double patrec_dX, const double patrec_dY, const double patrec_angle)
 {
   // Step #0:

--- a/assembly/assemblyCommon/Metrology.cc
+++ b/assembly/assemblyCommon/Metrology.cc
@@ -628,14 +628,14 @@ void Metrology::run_metrology(const double patrec_dX, const double patrec_dY, co
     }
     this->reset();
 
+    emit execution_completed();
+
     QMessageBox* msgBox = new QMessageBox;
     msgBox->setInformativeText("Metrology routine completed successfully!\nSee the results in the Metrology tab.");
 
     msgBox->setStandardButtons(QMessageBox::Ok);
 
     int ret = msgBox->exec();
-
-    emit execution_completed();
   }
 }
 

--- a/assembly/assemblyCommon/Metrology.h
+++ b/assembly/assemblyCommon/Metrology.h
@@ -50,6 +50,8 @@ class Metrology : public QObject
 
   protected:
 
+    mutable QMutex mutex_;
+
     const LStepExpressMotionManager* const motion_manager_;
 
     Configuration configuration_;
@@ -97,6 +99,8 @@ class Metrology : public QObject
 
     void clear_results();
 
+    void patrec_complete(const int);
+
   signals:
 
     void configuration_updated();
@@ -122,6 +126,8 @@ class Metrology : public QObject
     void measured_results(const double, const double, const double, const double, const double, const double, const double);
 
     void execution_completed();
+
+    void execution_failed();
 
     void DBLogMessage(const QString);
 };

--- a/assembly/assemblyCommon/MetrologyView.cc
+++ b/assembly/assemblyCommon/MetrologyView.cc
@@ -548,14 +548,14 @@ void MetrologyView::switch_to_config()
     return;
 }
 
-void MetrologyView::updateVacuumChannelState(int channel, bool state)
+void MetrologyView::updateVacuumChannelState(int channel, SwitchState state)
 {
     const int vacuum_channel_baseplate = config_->getValue<int>("main", "Vacuum_Baseplate");
     if (channel == vacuum_channel_baseplate) {
-        if(state) {
-            metro_enableVacuum_pusbu_->setEnabled(false);
-        } else {
+        if(state==SwitchState::CHANNEL_OFF) {
             metro_enableVacuum_pusbu_->setEnabled(true);
+        } else {
+            metro_enableVacuum_pusbu_->setEnabled(false);
         }
     }
 }

--- a/assembly/assemblyCommon/MetrologyView.cc
+++ b/assembly/assemblyCommon/MetrologyView.cc
@@ -798,6 +798,12 @@ void MetrologyView::updateImage(const int stage, const cv::Mat& img)
   return;
 }
 
+void MetrologyView::metrology_abort(){
+  NQLog("MetrologyView", NQLog::Spam) << "metrology_abort()";
+
+  button_metrologyClearResults_->setEnabled(true);
+}
+
 void MetrologyView::clearResults()
 {
   NQLog("MetrologyView", NQLog::Spam) << "clearResults()";

--- a/assembly/assemblyCommon/MetrologyView.h
+++ b/assembly/assemblyCommon/MetrologyView.h
@@ -17,6 +17,7 @@
 #include <AssemblyObjectFinderPatRecWidget.h>
 #include <ApplicationConfig.h>
 #include <Metrology.h>
+#include <RelayCardManager.h>
 
 #include <QToolBox>
 #include <QWidget>
@@ -132,7 +133,7 @@ class MetrologyView : public QWidget
 
   void clearResults();
 
-  void updateVacuumChannelState(int, bool);
+  void updateVacuumChannelState(int, SwitchState);
 
  signals:
 

--- a/assembly/assemblyCommon/MetrologyView.h
+++ b/assembly/assemblyCommon/MetrologyView.h
@@ -133,6 +133,8 @@ class MetrologyView : public QWidget
 
   void clearResults();
 
+  void metrology_abort();
+
   void updateVacuumChannelState(int, SwitchState);
 
  signals:

--- a/assembly/assembly_SiDummyPS.cfg
+++ b/assembly/assembly_SiDummyPS.cfg
@@ -29,12 +29,15 @@ startup_motion_stage                           1
 
 # switch ON camera automatically (bool)
 startup_camera                                 1
+camera_ID 				       1
+camera_config_interval 			       10
+camera_exposure_time 			       84.58
 
 # assembly sequence (must be 1 or 2)
 assembly_sequence                              2
 
-# omit steps where PSs+spacers are dipped to glue blocks
-skip_dipping                                   0
+# define assembly center: FNAL || BROWN || DESY
+assembly_center 			       FNAL
 
 # AssemblyParameters (format: path relative to directory where binary is executed)
 AssemblyParameters_file_path                   assembly/assembly/parameters/SiDummyPS.cfg

--- a/assembly/assembly_glass.cfg
+++ b/assembly/assembly_glass.cfg
@@ -36,6 +36,7 @@ camera_exposure_time 			       84.58
 # assembly sequence (must be 1 or 2)
 assembly_sequence                              2
 
+# define assembly center: FNAL || BROWN || DESY
 assembly_center 			       FNAL
 
 # AssemblyParameters (format: path relative to directory where binary is executed)

--- a/assembly/assembly_glass.cfg
+++ b/assembly/assembly_glass.cfg
@@ -29,6 +29,7 @@ startup_motion_stage                           1
 
 # switch ON camera automatically (bool)
 startup_camera                                 1
+camera_ID 				       1
 camera_config_interval 			       10
 
 # assembly sequence (must be 1 or 2)

--- a/assembly/assembly_glass.cfg
+++ b/assembly/assembly_glass.cfg
@@ -29,6 +29,7 @@ startup_motion_stage                           1
 
 # switch ON camera automatically (bool)
 startup_camera                                 1
+camera_config_interval 			       10
 
 # assembly sequence (must be 1 or 2)
 assembly_sequence                              2

--- a/assembly/assembly_glass.cfg
+++ b/assembly/assembly_glass.cfg
@@ -33,10 +33,7 @@ startup_camera                                 1
 # assembly sequence (must be 1 or 2)
 assembly_sequence                              2
 
-# omit steps where PSs+spacers are dipped to glue blocks
-skip_dipping                                   0
-
-assembly_center 			       DESY
+assembly_center 			       FNAL
 
 # AssemblyParameters (format: path relative to directory where binary is executed)
 AssemblyParameters_file_path                   assembly/assembly/parameters/glass.cfg

--- a/assembly/assembly_glass.cfg
+++ b/assembly/assembly_glass.cfg
@@ -31,6 +31,7 @@ startup_motion_stage                           1
 startup_camera                                 1
 camera_ID 				       1
 camera_config_interval 			       10
+camera_exposure_time 			       84.58
 
 # assembly sequence (must be 1 or 2)
 assembly_sequence                              2

--- a/assembly/assembly_glass.cfg
+++ b/assembly/assembly_glass.cfg
@@ -36,6 +36,8 @@ assembly_sequence                              2
 # omit steps where PSs+spacers are dipped to glue blocks
 skip_dipping                                   0
 
+assembly_center 			       DESY
+
 # AssemblyParameters (format: path relative to directory where binary is executed)
 AssemblyParameters_file_path                   assembly/assembly/parameters/glass.cfg
 


### PR DESCRIPTION
This implements a parameter `assembly_center` to accommodate differences in assembly schemes/sequences for different assembly centers.

In addition, the following features have been added:

- Remove `skip_dipping` parameter and replace by checking for the new `assembly_center` parameter to be equal to `DESY`
- Make interval at which the camera settings are queried and renewed configurable via `camera_config_interval`, which defaults to `10`, as inspired by #203 
- Make camera ID configurable via `camera_ID` and default to `1`, as inspired by #203 
- Implement different "Go To Sensor Marker" positions for PSp and PSs respectively, copied from #203 
- Default increment of camera pixel clock (read from camera) to 1, copied from #203 
- Make camera exposure time configurable via `camera_exposure_time` - no change by default.
- Add `Thickness_SpacerClamp` to parameter view in case of `FNAL || BROWN`, copied from #203 
- Use `Thickness_SpacerClamp` adding to the spacer height in case of `FNAL || BROWN`, inspired by #203 
- Add option to set/get z velocity from motion stage, copied from #203 
- Implement slow motion upwards to assembly sequence in case of `FNAL || BROWN`, copied from #203 

Hence, the difference between assembly centers is at this moment the skipping of spacer dipping for DESY and the spacer clamp and lift-up velocity for `FNAL || BROWN`.


This requires rebasing before being able to merge