### PR TITLE
Preparation for Database integration

### DIFF
--- a/assembly/assemblyCommon/AssemblyAssemblyActionWidget.h
+++ b/assembly/assemblyCommon/AssemblyAssemblyActionWidget.h
@@ -33,7 +33,7 @@ class AssemblyAssemblyActionWidget : public QWidget
   QPushButton* button() const { return button_; }
   QCheckBox* checkbox() const { return checkbox_; }
 
-  void connect_action(const QObject*, const char*, const char*);
+  void connect_action(const QObject*, const char*, const char*, const char* = nullptr);
 
  protected:
   QHBoxLayout* layout_;
@@ -45,6 +45,7 @@ class AssemblyAssemblyActionWidget : public QWidget
   const QObject* qobject_;
   const char* start_slot_;
   const char* stop_signal_;
+  const char* abort_signal_;
 
   bool inhibit_dialogue_;
 
@@ -55,6 +56,7 @@ class AssemblyAssemblyActionWidget : public QWidget
   void reset_action();
   void start_action();
   void disable_action();
+  void abort_action();
 
  signals:
   void action_request();

--- a/assembly/assemblyCommon/AssemblyAssemblyV2.cc
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2.cc
@@ -183,6 +183,11 @@ void AssemblyAssemblyV2::ScanMaPSAID_start()
         emit ScanMaPSAID_aborted();
         return;
     } else {
+        if(!database_->is_component_available(MaPSA_ID, "MaPSA"))
+        {
+            emit ScanMaPSAID_aborted();
+            return;
+        }
         MaPSA_ID_ = MaPSA_ID;
         emit MaPSA_ID_updated(MaPSA_ID);
         emit ScanMaPSAID_finished();
@@ -199,6 +204,11 @@ void AssemblyAssemblyV2::ScanPSSID_start()
         emit ScanPSSID_aborted();
         return;
     } else {
+        if(!database_->is_component_available(PSS_ID, "PSs%20Sensor"))
+        {
+            emit ScanPSSID_aborted();
+            return;
+        }
         PSS_ID_ = PSS_ID;
         emit PSS_ID_updated(PSS_ID);
         emit ScanPSSID_finished();
@@ -215,6 +225,11 @@ void AssemblyAssemblyV2::ScanBaseplateID_start()
         emit ScanBaseplateID_aborted();
         return;
     } else {
+        if(!database_->is_component_available(Baseplate_ID, "PS%20Baseplate"))
+        {
+            emit ScanBaseplateID_aborted();
+            return;
+        }
         Baseplate_ID_ = Baseplate_ID;
         emit Baseplate_ID_updated(Baseplate_ID);
         emit ScanBaseplateID_finished();
@@ -231,6 +246,11 @@ void AssemblyAssemblyV2::ScanGlue1ID_start()
         emit ScanGlue1ID_aborted();
         return;
     } else {
+        if(!database_->is_component_available(Glue1_ID, "Glue"))
+        {
+            emit ScanGlue1ID_aborted();
+            return;
+        }
         Glue1_ID_ = Glue1_ID;
         emit Glue1_ID_updated(Glue1_ID);
         emit ScanGlue1ID_finished();
@@ -247,6 +267,11 @@ void AssemblyAssemblyV2::ScanGlue2ID_start()
         emit ScanGlue2ID_aborted();
         return;
     } else {
+        if(!database_->is_component_available(Glue2_ID, "Glue"))
+        {
+            emit ScanGlue2ID_aborted();
+            return;
+        }
         Glue2_ID_ = Glue2_ID;
         emit Glue2_ID_updated(Glue2_ID);
         emit ScanGlue2ID_finished();
@@ -263,6 +288,11 @@ void AssemblyAssemblyV2::ScanGlue3ID_start()
         emit ScanGlue3ID_aborted();
         return;
     } else {
+        if(!database_->is_component_available(Glue3_ID, "Glue"))
+        {
+            emit ScanGlue3ID_aborted();
+            return;
+        }
         Glue3_ID_ = Glue3_ID;
         emit Glue3_ID_updated(Glue3_ID);
         emit ScanGlue3ID_finished();

--- a/assembly/assemblyCommon/AssemblyAssemblyV2.cc
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2.cc
@@ -59,7 +59,9 @@ AssemblyAssemblyV2::AssemblyAssemblyV2(const LStepExpressMotionManager* const mo
  , Baseplate_ID_()
  , MaPSA_ID_()
  , PSS_ID_()
- , Glue_ID_()
+ , Glue1_ID_()
+ , Glue2_ID_()
+ , Glue3_ID_()
  , Module_ID_()
 {
   // validate pointers to controllers
@@ -214,19 +216,51 @@ void AssemblyAssemblyV2::ScanBaseplateID_start()
     }
 }
 
-void AssemblyAssemblyV2::ScanGlueID_start()
+void AssemblyAssemblyV2::ScanGlue1ID_start()
 {
     bool ok = false;
-    QString Glue_ID = QInputDialog::getText(nullptr, tr("Scan Slow Glue ID"),
-                                         tr("Scan Slow Glue ID:"), QLineEdit::Normal,
+    QString Glue1_ID = QInputDialog::getText(nullptr, tr("Scan Slow Glue ID (step 1)"),
+                                         tr("Scan Slow Glue ID (step 1):"), QLineEdit::Normal,
                                          tr(""), &ok);
-    if (!ok || Glue_ID.isEmpty()){
-        emit ScanGlueID_aborted();
+    if (!ok || Glue1_ID.isEmpty()){
+        emit ScanGlue1ID_aborted();
         return;
     } else {
-        Glue_ID_ = Glue_ID;
-        emit Glue_ID_updated(Glue_ID);
-        emit ScanGlueID_finished();
+        Glue1_ID_ = Glue1_ID;
+        emit Glue1_ID_updated(Glue1_ID);
+        emit ScanGlue1ID_finished();
+    }
+}
+
+void AssemblyAssemblyV2::ScanGlue2ID_start()
+{
+    bool ok = false;
+    QString Glue2_ID = QInputDialog::getText(nullptr, tr("Scan Slow Glue ID (step 2)"),
+                                         tr("Scan Slow Glue ID (step 2):"), QLineEdit::Normal,
+                                         Glue1_ID_, &ok);
+    if (!ok || Glue2_ID.isEmpty()){
+        emit ScanGlue2ID_aborted();
+        return;
+    } else {
+        Glue2_ID_ = Glue2_ID;
+        emit Glue2_ID_updated(Glue2_ID);
+        emit ScanGlue2ID_finished();
+    }
+}
+
+void AssemblyAssemblyV2::ScanGlue3ID_start()
+{
+    bool ok = false;
+    QString Glue3_ID = QInputDialog::getText(nullptr, tr("Scan Slow Glue ID (step 3)"),
+                                         tr("Scan Slow Glue ID (step 3):"), QLineEdit::Normal,
+                                         Glue2_ID_, &ok);
+    if (!ok || Glue3_ID.isEmpty()){
+        emit ScanGlue3ID_aborted();
+        return;
+    } else {
+        Glue3_ID_ = Glue3_ID;
+        emit Glue3_ID_updated(Glue3_ID);
+        emit ScanGlue3ID_finished();
     }
 }
 
@@ -248,11 +282,11 @@ void AssemblyAssemblyV2::ScanModuleID_start()
 
 void AssemblyAssemblyV2::PushToDB_start()
 {
-    if(Baseplate_ID_.isEmpty() || MaPSA_ID_.isEmpty() || PSS_ID_.isEmpty() || Module_ID_.isEmpty() || Glue_ID_.isEmpty())
+    if(Baseplate_ID_.isEmpty() || MaPSA_ID_.isEmpty() || PSS_ID_.isEmpty() || Module_ID_.isEmpty() || Glue1_ID_.isEmpty() || Glue2_ID_.isEmpty() || Glue3_ID_.isEmpty())
     {
         QMessageBox msgBox;
         msgBox.setWindowTitle(tr("Information for Database Upload missing"));
-        QString msg = QString("The following IDs are missing:") + (Baseplate_ID_.isEmpty() ? "\n\tBaseplate ID" : "") + (MaPSA_ID_.isEmpty() ? "\n\tMaPSA ID" : "") + (PSS_ID_.isEmpty() ? "\n\tPSS ID" : "") + (Glue_ID_.isEmpty() ? "\n\tGlue ID" : "") + (Module_ID_.isEmpty() ? "\n\tModule ID" : "");
+        QString msg = QString("The following IDs are missing:") + (Baseplate_ID_.isEmpty() ? "\n\tBaseplate ID" : "") + (MaPSA_ID_.isEmpty() ? "\n\tMaPSA ID" : "") + (PSS_ID_.isEmpty() ? "\n\tPSS ID" : "") + (Glue1_ID_.isEmpty() ? "\n\tGlue 1 ID" : "") + (Glue2_ID_.isEmpty() ? "\n\tGlue 2 ID" : "") + (Glue3_ID_.isEmpty() ? "\n\tGlue 3 ID" : "") + (Module_ID_.isEmpty() ? "\n\tModule ID" : "");
         msgBox.setText(msg);
         msgBox.setInformativeText("Please add this information via the toolbar.");
         msgBox.setStandardButtons(QMessageBox::Ok);
@@ -268,7 +302,7 @@ void AssemblyAssemblyV2::PushToDB_start()
     QVBoxLayout* vlay = new QVBoxLayout();
     msgBox->setLayout(vlay);
 
-    QLabel* main_txt = new QLabel(QString("Push the following information to database:\n\tBP:\t%1\n\tMaPSA:\t%2\n\tPS-s:\t%3\n\tGlue:\t%4\n\tModule:\t%5").arg(Baseplate_ID_).arg(MaPSA_ID_).arg(PSS_ID_).arg(Glue_ID_).arg(Module_ID_));
+    QLabel* main_txt = new QLabel(QString("Push the following information to database:\n\tBP:\t%1\n\tMaPSA:\t%2\n\tPS-s:\t%3\n\tGlues:\t%4 %5 %6\n\tModule:\t%7").arg(Baseplate_ID_).arg(MaPSA_ID_).arg(PSS_ID_).arg(Glue1_ID_).arg(Glue2_ID_).arg(Glue3_ID_).arg(Module_ID_));
     vlay->addWidget(main_txt);
 
     QHBoxLayout* comment_lay = new QHBoxLayout();
@@ -306,7 +340,7 @@ void AssemblyAssemblyV2::PushToDB_start()
       case QDialog::Accepted:
         // <--- Insert function to push to database here. --->
         NQLog("AssemblyAssemblyV2", NQLog::Spam) << "PushToDB_start: "
-           << QString("Push the following information to database:\n\tBaseplate:\t%1\n\tMaPSA:\t\t%2\n\tPS-s:\t\t%3\n\tPS-s:\t\t%4\n\tModule:\t\t%5\n\tComment:\t\t%6").arg(Baseplate_ID_).arg(MaPSA_ID_).arg(PSS_ID_).arg(Glue_ID_).arg(Module_ID_).arg(comment_lin->toPlainText()).toStdString();
+           << QString("Push the following information to database:\n\tBaseplate:\t%1\n\tMaPSA:\t\t%2\n\tPS-s:\t\t%3\n\tPS-s:\t\t%4\n\tModule:\t\t%5 %6 %7\n\tComment:\t\t%8").arg(Baseplate_ID_).arg(MaPSA_ID_).arg(PSS_ID_).arg(Glue1_ID_).arg(Glue2_ID_).arg(Glue3_ID_).arg(Module_ID_).arg(comment_lin->toPlainText()).toStdString();
         emit PushToDB_finished();
         break;
       default:

--- a/assembly/assemblyCommon/AssemblyAssemblyV2.cc
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2.cc
@@ -163,7 +163,7 @@ void AssemblyAssemblyV2::use_smartMove(const int state)
 void AssemblyAssemblyV2::ScanMaPSAID_start()
 {
     bool ok = false;
-    QString MaPSA_ID = QInputDialog::getText(nullptr, tr("QInputDialog::getText()"),
+    QString MaPSA_ID = QInputDialog::getText(nullptr, tr("Scan MaPSA ID"),
                                          tr("Scan MaPSA ID:"), QLineEdit::Normal,
                                          tr(""), &ok);
     if (!ok || MaPSA_ID.isEmpty()){
@@ -179,7 +179,7 @@ void AssemblyAssemblyV2::ScanMaPSAID_start()
 void AssemblyAssemblyV2::ScanPSSID_start()
 {
     bool ok = false;
-    QString PSS_ID = QInputDialog::getText(nullptr, tr("QInputDialog::getText()"),
+    QString PSS_ID = QInputDialog::getText(nullptr, tr("Scan PS-s ID"),
                                          tr("Scan PS-s ID:"), QLineEdit::Normal,
                                          tr(""), &ok);
     if (!ok || PSS_ID.isEmpty()){
@@ -195,7 +195,7 @@ void AssemblyAssemblyV2::ScanPSSID_start()
 void AssemblyAssemblyV2::ScanBaseplateID_start()
 {
     bool ok = false;
-    QString Baseplate_ID = QInputDialog::getText(nullptr, tr("QInputDialog::getText()"),
+    QString Baseplate_ID = QInputDialog::getText(nullptr, tr("Scan Baseplate ID"),
                                          tr("Scan Baseplate ID:"), QLineEdit::Normal,
                                          tr(""), &ok);
     if (!ok || Baseplate_ID.isEmpty()){
@@ -211,7 +211,7 @@ void AssemblyAssemblyV2::ScanBaseplateID_start()
 void AssemblyAssemblyV2::ScanModuleID_start()
 {
     bool ok = false;
-    QString Module_ID = QInputDialog::getText(nullptr, tr("QInputDialog::getText()"),
+    QString Module_ID = QInputDialog::getText(nullptr, tr("Scan Module ID"),
                                          tr("Scan Module ID:"), QLineEdit::Normal,
                                          tr(""), &ok);
     if (!ok || Module_ID.isEmpty()){

--- a/assembly/assemblyCommon/AssemblyAssemblyV2.cc
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2.cc
@@ -220,6 +220,29 @@ void AssemblyAssemblyV2::ScanModuleID_start()
     }
 }
 
+void AssemblyAssemblyV2::PushToDB_start()
+{
+    QMessageBox msgBox;
+    msgBox.setWindowTitle(tr("Push Module Information to Database"));
+    msgBox.setText(QString("Push the following information to database:\n\tBaseplate:\t%1\n\tMaPSA:\t%2\n\tPS-s:\t%3\n\tModule:\t%4").arg(Baseplate_ID_).arg(MaPSA_ID_).arg(PSS_ID_).arg(Module_ID_));
+    msgBox.setInformativeText("Do you want to push this information to the Database?");
+    msgBox.setStandardButtons(QMessageBox::No | QMessageBox::Yes);
+    msgBox.setDefaultButton(QMessageBox::Yes);
+    int ret = msgBox.exec();
+
+    switch(ret)
+    {
+      case QMessageBox::No: return; //Exit
+      case QMessageBox::Yes:
+        // Insert function to push to database here.
+        NQLog("AssemblyAssemblyV2", NQLog::Spam) << "PushToDB_start: "
+           << QString("Push the following information to database:\n\tBaseplate:\t%1\n\tMaPSA:\t\t%2\n\tPS-s:\t\t%3\n\tModule:\t\t%4").arg(Baseplate_ID_).arg(MaPSA_ID_).arg(PSS_ID_).arg(Module_ID_).toStdString();
+        emit PushToDB_finished();
+        break; //Continue function execution
+      default: return; //Exit
+    }
+}
+
 // ----------------------------------------------------------------------------------------------------
 // GoToSensorMarkerPreAlignment -----------------------------------------------------------------------
 // ----------------------------------------------------------------------------------------------------

--- a/assembly/assemblyCommon/AssemblyAssemblyV2.cc
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2.cc
@@ -99,8 +99,10 @@ AssemblyAssemblyV2::AssemblyAssemblyV2(const LStepExpressMotionManager* const mo
   std::string assembly_center_str = QString::fromStdString(config_->getValue<std::string>("main", "assembly_center")).toUpper().toStdString();
   if(assembly_center_str == "FNAL") {
       assembly_center_ = assembly::Center::FNAL;
+      database_ = new DatabaseDummy(this);
   } else if(assembly_center_str == "BROWN") {
       assembly_center_ = assembly::Center::BROWN;
+      database_ = new DatabaseDummy(this);
   } else if(assembly_center_str == "DESY") {
       assembly_center_ = assembly::Center::DESY;
       auto base_url = QString::fromStdString(config_->getValue<std::string>("main", "Database_URL"));

--- a/assembly/assemblyCommon/AssemblyAssemblyV2.cc
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2.cc
@@ -50,6 +50,11 @@ AssemblyAssemblyV2::AssemblyAssemblyV2(const LStepExpressMotionManager* const mo
  , PSSPlusSpacersToMaPSAPosition_Y_(0.)
  , PSSPlusSpacersToMaPSAPosition_Z_(0.)
  , PSSPlusSpacersToMaPSAPosition_A_(0.)
+
+ , Baseplate_ID_()
+ , MaPSA_ID_()
+ , PSS_ID_()
+ , Module_ID_()
 {
   // validate pointers to controllers
   this->motion();
@@ -164,7 +169,54 @@ void AssemblyAssemblyV2::ScanMaPSAID_start()
     if (!ok || MaPSA_ID.isEmpty()){
         return;
     } else {
+        MaPSA_ID_ = MaPSA_ID;
+        emit MaPSA_ID_updated(MaPSA_ID);
         emit ScanMaPSAID_finished();
+    }
+}
+
+void AssemblyAssemblyV2::ScanPSSID_start()
+{
+    bool ok = false;
+    QString PSS_ID = QInputDialog::getText(nullptr, tr("QInputDialog::getText()"),
+                                         tr("Scan PS-s ID:"), QLineEdit::Normal,
+                                         tr(""), &ok);
+    if (!ok || PSS_ID.isEmpty()){
+        return;
+    } else {
+        PSS_ID_ = PSS_ID;
+        emit PSS_ID_updated(PSS_ID);
+        emit ScanPSSID_finished();
+    }
+}
+
+void AssemblyAssemblyV2::ScanBaseplateID_start()
+{
+    bool ok = false;
+    QString Baseplate_ID = QInputDialog::getText(nullptr, tr("QInputDialog::getText()"),
+                                         tr("Scan Baseplate ID:"), QLineEdit::Normal,
+                                         tr(""), &ok);
+    if (!ok || Baseplate_ID.isEmpty()){
+        return;
+    } else {
+        Baseplate_ID_ = Baseplate_ID;
+        emit Baseplate_ID_updated(Baseplate_ID);
+        emit ScanBaseplateID_finished();
+    }
+}
+
+void AssemblyAssemblyV2::ScanModuleID_start()
+{
+    bool ok = false;
+    QString Module_ID = QInputDialog::getText(nullptr, tr("QInputDialog::getText()"),
+                                         tr("Scan Module ID:"), QLineEdit::Normal,
+                                         tr(""), &ok);
+    if (!ok || Module_ID.isEmpty()){
+        return;
+    } else {
+        Module_ID_ = Module_ID;
+        emit Module_ID_updated(Module_ID);
+        emit ScanModuleID_finished();
     }
 }
 

--- a/assembly/assemblyCommon/AssemblyAssemblyV2.cc
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2.cc
@@ -63,6 +63,8 @@ AssemblyAssemblyV2::AssemblyAssemblyV2(const LStepExpressMotionManager* const mo
  , Glue2_ID_()
  , Glue3_ID_()
  , Module_ID_()
+
+ , database_()
 {
   // validate pointers to controllers
   this->motion();
@@ -101,6 +103,7 @@ AssemblyAssemblyV2::AssemblyAssemblyV2(const LStepExpressMotionManager* const mo
       assembly_center_ = assembly::Center::BROWN;
   } else if(assembly_center_str == "DESY") {
       assembly_center_ = assembly::Center::DESY;
+      database_ = new DatabaseDESY(this);
   } else {
       NQLog("AssemblyAssemblyV2", NQLog::Warning) << "Invalid assembly center provided: \"" << assembly_center_str << "\". Provide one of the following options: \"FNAL\", \"BROWN\", \"DESY\"";
   }
@@ -407,9 +410,16 @@ void AssemblyAssemblyV2::PushStep1ToDB_start()
         emit PushStep1ToDB_aborted();
         return;
       case QDialog::Accepted:
-        // <--- Insert function to push to database here. --->
         NQLog("AssemblyAssemblyV2", NQLog::Spam) << "PushStep1ToDB_start: "
            << QString("Push the following information to database:\n\tModule:\t\t%1\n\tBaseplate:\t%2\n\tMaPSA:\t\t%3\n\tGlue:\t\t%4\n\tComment:\t%5").arg(Module_ID_).arg(Baseplate_ID_).arg(MaPSA_ID_).arg(Glue1_ID_).arg(comment_lin->toPlainText()).toStdString();
+
+        if(!(database_->MaPSA_to_BP(MaPSA_ID_, Baseplate_ID_, Glue1_ID_, comment_lin->toPlainText())))
+        {
+            NQLog("AssemblyAssemblyV2", NQLog::Spam) << "PushStep1ToDB_start: Something went wrong.";
+            emit PushStep1ToDB_aborted();
+            return;
+        }
+
         emit PushStep1ToDB_finished();
         break;
       default:
@@ -476,9 +486,16 @@ void AssemblyAssemblyV2::PushStep2ToDB_start()
         emit PushStep2ToDB_aborted();
         return;
       case QDialog::Accepted:
-        // <--- Insert function to push to database here. --->
         NQLog("AssemblyAssemblyV2", NQLog::Spam) << "PushStep2ToDB_start: "
            << QString("Push the following information to database:\n\tModule:\t\t%1\n\tPSS:\t\t%2\n\tGlue:\t\t%3\n\tComment:\t%4").arg(Module_ID_).arg(PSS_ID_).arg(Glue2_ID_).arg(comment_lin->toPlainText()).toStdString();
+
+        if(!(database_->PSs_to_spacers(PSS_ID_, Glue2_ID_, comment_lin->toPlainText())))
+        {
+            NQLog("AssemblyAssemblyV2", NQLog::Spam) << "PushStep2ToDB_start: Something went wrong.";
+            emit PushStep2ToDB_aborted();
+            return;
+        }
+
         emit PushStep2ToDB_finished();
         break;
       default:
@@ -545,9 +562,16 @@ void AssemblyAssemblyV2::PushStep3ToDB_start()
         emit PushStep3ToDB_aborted();
         return;
       case QDialog::Accepted:
-        // <--- Insert function to push to database here. --->
         NQLog("AssemblyAssemblyV2", NQLog::Spam) << "PushStep3ToDB_start: "
            << QString("Push the following information to database:\n\tModule:\t\t%1\n\tGlue:\t\t%2\n\tComment:\t%3").arg(Module_ID_).arg(Glue3_ID_).arg(comment_lin->toPlainText()).toStdString();
+
+        if(!(database_->PSs_to_MaPSA(Glue3_ID_, comment_lin->toPlainText())))
+        {
+            NQLog("AssemblyAssemblyV2", NQLog::Spam) << "PushStep3ToDB_start: Something went wrong.";
+            emit PushStep3ToDB_aborted();
+            return;
+        }
+
         emit PushStep3ToDB_finished();
         break;
       default:

--- a/assembly/assemblyCommon/AssemblyAssemblyV2.cc
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2.cc
@@ -283,6 +283,23 @@ void AssemblyAssemblyV2::ScanModuleID_start()
     }
 }
 
+void AssemblyAssemblyV2::RegisterModuleID_start()
+{
+    NQLog("AssemblyAssemblyV2", NQLog::Spam) << "RegisterModuleID_start: "
+    << "Attempting to register module ID in DB";
+
+    if(database_->register_module_name(Module_ID_, "OperatorName"))
+    {
+        NQLog("AssemblyAssemblyV2", NQLog::Spam) << "RegisterModuleID_start: "
+        << "Successfully registered module in DB";
+        emit RegisterModuleID_finished();
+    } else {
+        NQLog("AssemblyAssemblyV2", NQLog::Fatal) << "RegisterModuleID_start: "
+        << "Could not register module in DB";
+        emit RegisterModuleID_aborted();
+    }
+}
+
 void AssemblyAssemblyV2::PushAllToDB_start()
 {
     if(Baseplate_ID_.isEmpty() || MaPSA_ID_.isEmpty() || PSS_ID_.isEmpty() || Module_ID_.isEmpty() || Glue1_ID_.isEmpty() || Glue2_ID_.isEmpty() || Glue3_ID_.isEmpty())

--- a/assembly/assemblyCommon/AssemblyAssemblyV2.cc
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2.cc
@@ -226,6 +226,20 @@ void AssemblyAssemblyV2::ScanModuleID_start()
 
 void AssemblyAssemblyV2::PushToDB_start()
 {
+    if(Baseplate_ID_.isEmpty() || MaPSA_ID_.isEmpty() || PSS_ID_.isEmpty() || Module_ID_.isEmpty())
+    {
+        QMessageBox msgBox;
+        msgBox.setWindowTitle(tr("Information for Database Upload missing"));
+        QString msg = QString("The following IDs are missing:") + (Baseplate_ID_.isEmpty() ? "\n\tBaseplate ID" : "") + (MaPSA_ID_.isEmpty() ? "\n\tMaPSA ID" : "") + (PSS_ID_.isEmpty() ? "\n\tPSS ID" : "") + (Module_ID_.isEmpty() ? "\n\tModule ID" : "");
+        msgBox.setText(msg);
+        msgBox.setInformativeText("Please add this information via the toolbar.");
+        msgBox.setStandardButtons(QMessageBox::Ok);
+        int ret = msgBox.exec();
+
+        emit PushToDB_aborted();
+        return;
+    }
+
     QMessageBox msgBox;
     msgBox.setWindowTitle(tr("Push Module Information to Database"));
     msgBox.setText(QString("Push the following information to database:\n\tBaseplate:\t%1\n\tMaPSA:\t%2\n\tPS-s:\t%3\n\tModule:\t%4").arg(Baseplate_ID_).arg(MaPSA_ID_).arg(PSS_ID_).arg(Module_ID_));

--- a/assembly/assemblyCommon/AssemblyAssemblyV2.cc
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2.cc
@@ -167,6 +167,7 @@ void AssemblyAssemblyV2::ScanMaPSAID_start()
                                          tr("Scan MaPSA ID:"), QLineEdit::Normal,
                                          tr(""), &ok);
     if (!ok || MaPSA_ID.isEmpty()){
+        emit ScanMaPSAID_aborted();
         return;
     } else {
         MaPSA_ID_ = MaPSA_ID;
@@ -182,6 +183,7 @@ void AssemblyAssemblyV2::ScanPSSID_start()
                                          tr("Scan PS-s ID:"), QLineEdit::Normal,
                                          tr(""), &ok);
     if (!ok || PSS_ID.isEmpty()){
+        emit ScanPSSID_aborted();
         return;
     } else {
         PSS_ID_ = PSS_ID;
@@ -197,6 +199,7 @@ void AssemblyAssemblyV2::ScanBaseplateID_start()
                                          tr("Scan Baseplate ID:"), QLineEdit::Normal,
                                          tr(""), &ok);
     if (!ok || Baseplate_ID.isEmpty()){
+        emit ScanBaseplateID_aborted();
         return;
     } else {
         Baseplate_ID_ = Baseplate_ID;
@@ -212,6 +215,7 @@ void AssemblyAssemblyV2::ScanModuleID_start()
                                          tr("Scan Module ID:"), QLineEdit::Normal,
                                          tr(""), &ok);
     if (!ok || Module_ID.isEmpty()){
+        emit ScanModuleID_aborted();
         return;
     } else {
         Module_ID_ = Module_ID;
@@ -232,14 +236,18 @@ void AssemblyAssemblyV2::PushToDB_start()
 
     switch(ret)
     {
-      case QMessageBox::No: return; //Exit
+      case QMessageBox::No:
+        emit PushToDB_aborted();
+        return;
       case QMessageBox::Yes:
-        // Insert function to push to database here.
+        // <--- Insert function to push to database here. --->
         NQLog("AssemblyAssemblyV2", NQLog::Spam) << "PushToDB_start: "
            << QString("Push the following information to database:\n\tBaseplate:\t%1\n\tMaPSA:\t\t%2\n\tPS-s:\t\t%3\n\tModule:\t\t%4").arg(Baseplate_ID_).arg(MaPSA_ID_).arg(PSS_ID_).arg(Module_ID_).toStdString();
         emit PushToDB_finished();
-        break; //Continue function execution
-      default: return; //Exit
+        break;
+      default:
+        emit PushToDB_aborted();
+        return;
     }
 }
 

--- a/assembly/assemblyCommon/AssemblyAssemblyV2.cc
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2.cc
@@ -19,6 +19,7 @@
 #include <unistd.h>
 
 #include <QMessageBox>
+#include <QInputDialog>
 
 AssemblyAssemblyV2::AssemblyAssemblyV2(const LStepExpressMotionManager* const motion, const RelayCardManager* const vacuum, const AssemblySmartMotionManager* const smart_motion, QObject* parent)
  : QObject(parent)
@@ -153,6 +154,19 @@ void AssemblyAssemblyV2::use_smartMove(const int state)
   return;
 }
 // ----------------------------------------------------------------------------------------------------
+
+void AssemblyAssemblyV2::ScanMaPSAID_start()
+{
+    bool ok = false;
+    QString MaPSA_ID = QInputDialog::getText(nullptr, tr("QInputDialog::getText()"),
+                                         tr("Scan MaPSA ID:"), QLineEdit::Normal,
+                                         tr(""), &ok);
+    if (!ok || MaPSA_ID.isEmpty()){
+        return;
+    } else {
+        emit ScanMaPSAID_finished();
+    }
+}
 
 // ----------------------------------------------------------------------------------------------------
 // GoToSensorMarkerPreAlignment -----------------------------------------------------------------------

--- a/assembly/assemblyCommon/AssemblyAssemblyV2.cc
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2.cc
@@ -280,7 +280,7 @@ void AssemblyAssemblyV2::ScanModuleID_start()
     }
 }
 
-void AssemblyAssemblyV2::PushToDB_start()
+void AssemblyAssemblyV2::PushAllToDB_start()
 {
     if(Baseplate_ID_.isEmpty() || MaPSA_ID_.isEmpty() || PSS_ID_.isEmpty() || Module_ID_.isEmpty() || Glue1_ID_.isEmpty() || Glue2_ID_.isEmpty() || Glue3_ID_.isEmpty())
     {
@@ -292,12 +292,12 @@ void AssemblyAssemblyV2::PushToDB_start()
         msgBox.setStandardButtons(QMessageBox::Ok);
         int ret = msgBox.exec();
 
-        emit PushToDB_aborted();
+        emit PushAllToDB_aborted();
         return;
     }
 
     QDialog* msgBox = new QDialog();
-    msgBox->setWindowTitle(tr("Push Module Information to Database"));
+    msgBox->setWindowTitle(tr("Push Full Module Information to Database"));
 
     QVBoxLayout* vlay = new QVBoxLayout();
     msgBox->setLayout(vlay);
@@ -335,16 +335,223 @@ void AssemblyAssemblyV2::PushToDB_start()
     switch(msgBox->result())
     {
       case QDialog::Rejected:
-        emit PushToDB_aborted();
+        emit PushAllToDB_aborted();
         return;
       case QDialog::Accepted:
         // <--- Insert function to push to database here. --->
-        NQLog("AssemblyAssemblyV2", NQLog::Spam) << "PushToDB_start: "
+        NQLog("AssemblyAssemblyV2", NQLog::Spam) << "PushAllToDB_start: "
            << QString("Push the following information to database:\n\tBaseplate:\t%1\n\tMaPSA:\t\t%2\n\tPS-s:\t\t%3\n\tPS-s:\t\t%4\n\tModule:\t\t%5 %6 %7\n\tComment:\t\t%8").arg(Baseplate_ID_).arg(MaPSA_ID_).arg(PSS_ID_).arg(Glue1_ID_).arg(Glue2_ID_).arg(Glue3_ID_).arg(Module_ID_).arg(comment_lin->toPlainText()).toStdString();
-        emit PushToDB_finished();
+        emit PushAllToDB_finished();
         break;
       default:
-        emit PushToDB_aborted();
+        emit PushAllToDB_aborted();
+        return;
+    }
+}
+
+void AssemblyAssemblyV2::PushStep1ToDB_start()
+{
+    if(Module_ID_.isEmpty() || Baseplate_ID_.isEmpty() || MaPSA_ID_.isEmpty() || Glue1_ID_.isEmpty())
+    {
+        QMessageBox msgBox;
+        msgBox.setWindowTitle(tr("Information for Database Upload missing"));
+        QString msg = QString("The following IDs are missing:") + (Module_ID_.isEmpty() ? "\n\tModule ID" : "") + (Baseplate_ID_.isEmpty() ? "\n\tBaseplate ID" : "") + (MaPSA_ID_.isEmpty() ? "\n\tMaPSA ID" : "") + (Glue1_ID_.isEmpty() ? "\n\tGlue 1 ID" : "");
+        msgBox.setText(msg);
+        msgBox.setInformativeText("Please add this information via the toolbar or assembly actions.");
+        msgBox.setStandardButtons(QMessageBox::Ok);
+        int ret = msgBox.exec();
+
+        emit PushStep1ToDB_aborted();
+        return;
+    }
+
+    QDialog* msgBox = new QDialog();
+    msgBox->setWindowTitle(tr("Push Module Information for MaPSA to BP assembly to Database"));
+
+    QVBoxLayout* vlay = new QVBoxLayout();
+    msgBox->setLayout(vlay);
+
+    QLabel* main_txt = new QLabel(QString("Push the following information to database:\n\n\tModule:\t%1\n\tBP:\t%2\n\tMaPSA:\t%3\n\tGlue:\t%4").arg(Module_ID_).arg(Baseplate_ID_).arg(MaPSA_ID_).arg(Glue1_ID_));
+    vlay->addWidget(main_txt);
+
+    QHBoxLayout* comment_lay = new QHBoxLayout();
+
+    QLabel* comment_lab = new QLabel("Comments:");
+    QTextEdit* comment_lin = new QTextEdit("");
+    comment_lin->setTabChangesFocus(true);
+    comment_lin->setFixedHeight(60);
+
+    comment_lay->addWidget(comment_lab);
+    comment_lay->addWidget(comment_lin);
+
+    vlay->addLayout(comment_lay);
+
+    QLabel* info_txt = new QLabel("Do you want to push this information to the Database?");
+    vlay->addWidget(info_txt);
+
+    QDialogButtonBox* button_box = new QDialogButtonBox(Qt::Horizontal);
+    button_box->addButton(QDialogButtonBox::Yes);
+    button_box->addButton(QDialogButtonBox::No);
+    button_box->setCenterButtons(true);
+
+    vlay->addWidget(button_box);
+
+    connect(button_box, SIGNAL(accepted()), msgBox, SLOT(accept()));
+    connect(button_box, SIGNAL(rejected()), msgBox, SLOT(reject()));
+
+    int ret = msgBox->exec();
+
+    switch(msgBox->result())
+    {
+      case QDialog::Rejected:
+        emit PushStep1ToDB_aborted();
+        return;
+      case QDialog::Accepted:
+        // <--- Insert function to push to database here. --->
+        NQLog("AssemblyAssemblyV2", NQLog::Spam) << "PushStep1ToDB_start: "
+           << QString("Push the following information to database:\n\tModule:\t\t%1\n\tBaseplate:\t%2\n\tMaPSA:\t\t%3\n\tGlue:\t\t%4\n\tComment:\t%5").arg(Module_ID_).arg(Baseplate_ID_).arg(MaPSA_ID_).arg(Glue1_ID_).arg(comment_lin->toPlainText()).toStdString();
+        emit PushStep1ToDB_finished();
+        break;
+      default:
+        emit PushStep1ToDB_aborted();
+        return;
+    }
+}
+
+void AssemblyAssemblyV2::PushStep2ToDB_start()
+{
+    if(Module_ID_.isEmpty() || PSS_ID_.isEmpty() || Glue2_ID_.isEmpty())
+    {
+        QMessageBox msgBox;
+        msgBox.setWindowTitle(tr("Information for Database Upload missing"));
+        QString msg = QString("The following IDs are missing:") + (Module_ID_.isEmpty() ? "\n\tModule ID" : "") + (PSS_ID_.isEmpty() ? "\n\tPSS ID" : "") + (Glue2_ID_.isEmpty() ? "\n\tGlue 2 ID" : "");
+        msgBox.setText(msg);
+        msgBox.setInformativeText("Please add this information via the toolbar or assembly actions.");
+        msgBox.setStandardButtons(QMessageBox::Ok);
+        int ret = msgBox.exec();
+
+        emit PushStep2ToDB_aborted();
+        return;
+    }
+
+    QDialog* msgBox = new QDialog();
+    msgBox->setWindowTitle(tr("Push Module Information for PSS to Spacers assembly to Database"));
+
+    QVBoxLayout* vlay = new QVBoxLayout();
+    msgBox->setLayout(vlay);
+
+    QLabel* main_txt = new QLabel(QString("Push the following information to database:\n\n\tModule:\t%1\n\tPSS:\t%2\n\tGlue:\t%3").arg(Module_ID_).arg(PSS_ID_).arg(Glue2_ID_));
+    vlay->addWidget(main_txt);
+
+    QHBoxLayout* comment_lay = new QHBoxLayout();
+
+    QLabel* comment_lab = new QLabel("Comments:");
+    QTextEdit* comment_lin = new QTextEdit("");
+    comment_lin->setTabChangesFocus(true);
+    comment_lin->setFixedHeight(60);
+
+    comment_lay->addWidget(comment_lab);
+    comment_lay->addWidget(comment_lin);
+
+    vlay->addLayout(comment_lay);
+
+    QLabel* info_txt = new QLabel("Do you want to push this information to the Database?");
+    vlay->addWidget(info_txt);
+
+    QDialogButtonBox* button_box = new QDialogButtonBox(Qt::Horizontal);
+    button_box->addButton(QDialogButtonBox::Yes);
+    button_box->addButton(QDialogButtonBox::No);
+    button_box->setCenterButtons(true);
+
+    vlay->addWidget(button_box);
+
+    connect(button_box, SIGNAL(accepted()), msgBox, SLOT(accept()));
+    connect(button_box, SIGNAL(rejected()), msgBox, SLOT(reject()));
+
+    int ret = msgBox->exec();
+
+    switch(msgBox->result())
+    {
+      case QDialog::Rejected:
+        emit PushStep2ToDB_aborted();
+        return;
+      case QDialog::Accepted:
+        // <--- Insert function to push to database here. --->
+        NQLog("AssemblyAssemblyV2", NQLog::Spam) << "PushStep2ToDB_start: "
+           << QString("Push the following information to database:\n\tModule:\t\t%1\n\tPSS:\t\t%2\n\tGlue:\t\t%3\n\tComment:\t%4").arg(Module_ID_).arg(PSS_ID_).arg(Glue2_ID_).arg(comment_lin->toPlainText()).toStdString();
+        emit PushStep2ToDB_finished();
+        break;
+      default:
+        emit PushStep2ToDB_aborted();
+        return;
+    }
+}
+
+void AssemblyAssemblyV2::PushStep3ToDB_start()
+{
+    if(Module_ID_.isEmpty() || Glue3_ID_.isEmpty())
+    {
+        QMessageBox msgBox;
+        msgBox.setWindowTitle(tr("Information for Database Upload missing"));
+        QString msg = QString("The following IDs are missing:") + (Module_ID_.isEmpty() ? "\n\tModule ID" : "") + (Glue3_ID_.isEmpty() ? "\n\tGlue 3 ID" : "");
+        msgBox.setText(msg);
+        msgBox.setInformativeText("Please add this information via the toolbar or assembly actions.");
+        msgBox.setStandardButtons(QMessageBox::Ok);
+        int ret = msgBox.exec();
+
+        emit PushStep3ToDB_aborted();
+        return;
+    }
+
+    QDialog* msgBox = new QDialog();
+    msgBox->setWindowTitle(tr("Push Module Information for PSS to MaPSA assembly to Database"));
+
+    QVBoxLayout* vlay = new QVBoxLayout();
+    msgBox->setLayout(vlay);
+
+    QLabel* main_txt = new QLabel(QString("Push the following information to database:\n\n\tModule:\t%1\n\tGlue:\t%2").arg(Module_ID_).arg(Glue3_ID_));
+    vlay->addWidget(main_txt);
+
+    QHBoxLayout* comment_lay = new QHBoxLayout();
+
+    QLabel* comment_lab = new QLabel("Comments:");
+    QTextEdit* comment_lin = new QTextEdit("");
+    comment_lin->setTabChangesFocus(true);
+    comment_lin->setFixedHeight(60);
+
+    comment_lay->addWidget(comment_lab);
+    comment_lay->addWidget(comment_lin);
+
+    vlay->addLayout(comment_lay);
+
+    QLabel* info_txt = new QLabel("Do you want to push this information to the Database?");
+    vlay->addWidget(info_txt);
+
+    QDialogButtonBox* button_box = new QDialogButtonBox(Qt::Horizontal);
+    button_box->addButton(QDialogButtonBox::Yes);
+    button_box->addButton(QDialogButtonBox::No);
+    button_box->setCenterButtons(true);
+
+    vlay->addWidget(button_box);
+
+    connect(button_box, SIGNAL(accepted()), msgBox, SLOT(accept()));
+    connect(button_box, SIGNAL(rejected()), msgBox, SLOT(reject()));
+
+    int ret = msgBox->exec();
+
+    switch(msgBox->result())
+    {
+      case QDialog::Rejected:
+        emit PushStep3ToDB_aborted();
+        return;
+      case QDialog::Accepted:
+        // <--- Insert function to push to database here. --->
+        NQLog("AssemblyAssemblyV2", NQLog::Spam) << "PushStep3ToDB_start: "
+           << QString("Push the following information to database:\n\tModule:\t\t%1\n\tGlue:\t\t%2\n\tComment:\t%3").arg(Module_ID_).arg(Glue3_ID_).arg(comment_lin->toPlainText()).toStdString();
+        emit PushStep3ToDB_finished();
+        break;
+      default:
+        emit PushStep3ToDB_aborted();
         return;
     }
 }

--- a/assembly/assemblyCommon/AssemblyAssemblyV2.cc
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2.cc
@@ -54,6 +54,7 @@ AssemblyAssemblyV2::AssemblyAssemblyV2(const LStepExpressMotionManager* const mo
  , Baseplate_ID_()
  , MaPSA_ID_()
  , PSS_ID_()
+ , Glue_ID_()
  , Module_ID_()
 {
   // validate pointers to controllers
@@ -208,6 +209,22 @@ void AssemblyAssemblyV2::ScanBaseplateID_start()
     }
 }
 
+void AssemblyAssemblyV2::ScanGlueID_start()
+{
+    bool ok = false;
+    QString Glue_ID = QInputDialog::getText(nullptr, tr("Scan Slow Glue ID"),
+                                         tr("Scan Slow Glue ID:"), QLineEdit::Normal,
+                                         tr(""), &ok);
+    if (!ok || Glue_ID.isEmpty()){
+        emit ScanGlueID_aborted();
+        return;
+    } else {
+        Glue_ID_ = Glue_ID;
+        emit Glue_ID_updated(Glue_ID);
+        emit ScanGlueID_finished();
+    }
+}
+
 void AssemblyAssemblyV2::ScanModuleID_start()
 {
     bool ok = false;
@@ -226,11 +243,11 @@ void AssemblyAssemblyV2::ScanModuleID_start()
 
 void AssemblyAssemblyV2::PushToDB_start()
 {
-    if(Baseplate_ID_.isEmpty() || MaPSA_ID_.isEmpty() || PSS_ID_.isEmpty() || Module_ID_.isEmpty())
+    if(Baseplate_ID_.isEmpty() || MaPSA_ID_.isEmpty() || PSS_ID_.isEmpty() || Module_ID_.isEmpty() || Glue_ID_.isEmpty())
     {
         QMessageBox msgBox;
         msgBox.setWindowTitle(tr("Information for Database Upload missing"));
-        QString msg = QString("The following IDs are missing:") + (Baseplate_ID_.isEmpty() ? "\n\tBaseplate ID" : "") + (MaPSA_ID_.isEmpty() ? "\n\tMaPSA ID" : "") + (PSS_ID_.isEmpty() ? "\n\tPSS ID" : "") + (Module_ID_.isEmpty() ? "\n\tModule ID" : "");
+        QString msg = QString("The following IDs are missing:") + (Baseplate_ID_.isEmpty() ? "\n\tBaseplate ID" : "") + (MaPSA_ID_.isEmpty() ? "\n\tMaPSA ID" : "") + (PSS_ID_.isEmpty() ? "\n\tPSS ID" : "") + (Glue_ID_.isEmpty() ? "\n\tGlue ID" : "") + (Module_ID_.isEmpty() ? "\n\tModule ID" : "");
         msgBox.setText(msg);
         msgBox.setInformativeText("Please add this information via the toolbar.");
         msgBox.setStandardButtons(QMessageBox::Ok);
@@ -242,7 +259,7 @@ void AssemblyAssemblyV2::PushToDB_start()
 
     QMessageBox msgBox;
     msgBox.setWindowTitle(tr("Push Module Information to Database"));
-    msgBox.setText(QString("Push the following information to database:\n\tBaseplate:\t%1\n\tMaPSA:\t%2\n\tPS-s:\t%3\n\tModule:\t%4").arg(Baseplate_ID_).arg(MaPSA_ID_).arg(PSS_ID_).arg(Module_ID_));
+    msgBox.setText(QString("Push the following information to database:\n\tBaseplate:\t%1\n\tMaPSA:\t%2\n\tPS-s:\t%3\n\tGlue:\t%4\n\tModule:\t%5").arg(Baseplate_ID_).arg(MaPSA_ID_).arg(PSS_ID_).arg(Glue_ID_).arg(Module_ID_));
     msgBox.setInformativeText("Do you want to push this information to the Database?");
     msgBox.setStandardButtons(QMessageBox::No | QMessageBox::Yes);
     msgBox.setDefaultButton(QMessageBox::Yes);
@@ -256,7 +273,7 @@ void AssemblyAssemblyV2::PushToDB_start()
       case QMessageBox::Yes:
         // <--- Insert function to push to database here. --->
         NQLog("AssemblyAssemblyV2", NQLog::Spam) << "PushToDB_start: "
-           << QString("Push the following information to database:\n\tBaseplate:\t%1\n\tMaPSA:\t\t%2\n\tPS-s:\t\t%3\n\tModule:\t\t%4").arg(Baseplate_ID_).arg(MaPSA_ID_).arg(PSS_ID_).arg(Module_ID_).toStdString();
+           << QString("Push the following information to database:\n\tBaseplate:\t%1\n\tMaPSA:\t\t%2\n\tPS-s:\t\t%3\n\tPS-s:\t\t%4\n\tModule:\t\t%5").arg(Baseplate_ID_).arg(MaPSA_ID_).arg(PSS_ID_).arg(Glue_ID_).arg(Module_ID_).toStdString();
         emit PushToDB_finished();
         break;
       default:

--- a/assembly/assemblyCommon/AssemblyAssemblyV2.cc
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2.cc
@@ -103,7 +103,9 @@ AssemblyAssemblyV2::AssemblyAssemblyV2(const LStepExpressMotionManager* const mo
       assembly_center_ = assembly::Center::BROWN;
   } else if(assembly_center_str == "DESY") {
       assembly_center_ = assembly::Center::DESY;
-      database_ = new DatabaseDESY(this);
+      auto base_url = QString::fromStdString(config_->getValue<std::string>("main", "Database_URL"));
+      auto token = QString::fromStdString(config_->getValue<std::string>("main", "Database_Token"));
+      database_ = new DatabaseDESY(this, base_url, token);
   } else {
       NQLog("AssemblyAssemblyV2", NQLog::Warning) << "Invalid assembly center provided: \"" << assembly_center_str << "\". Provide one of the following options: \"FNAL\", \"BROWN\", \"DESY\"";
   }

--- a/assembly/assemblyCommon/AssemblyAssemblyV2.h
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2.h
@@ -20,6 +20,7 @@
 #include <AssemblyUtilities.h>
 
 #include <DatabaseDESY.h>
+#include <DatabaseBrown.h>
 #include <DatabaseDummy.h>
 
 #include <AssemblySmartMotionManager.h>

--- a/assembly/assemblyCommon/AssemblyAssemblyV2.h
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2.h
@@ -67,7 +67,7 @@ class AssemblyAssemblyV2 : public QObject
 
   double original_Z_velocity_;
 
-  QString Baseplate_ID_, MaPSA_ID_, PSS_ID_, Glue_ID_, Module_ID_;
+  QString Baseplate_ID_, MaPSA_ID_, PSS_ID_, Glue1_ID_, Glue2_ID_, Glue3_ID_, Module_ID_;
 
   bool alreadyClicked_LowerPickupToolOntoMaPSA, alreadyClicked_LowerPickupToolOntoPSS, alreadyClicked_LowerMaPSAOntoBaseplate, alreadyClicked_LowerPSSOntoSpacers, alreadyClicked_LowerPSSPlusSpacersOntoGluingStage, alreadyClicked_LowerPSSPlusSpacersOntoMaPSA;
 
@@ -175,14 +175,18 @@ class AssemblyAssemblyV2 : public QObject
   void ScanMaPSAID_start();
   void ScanPSSID_start();
   void ScanBaseplateID_start();
-  void ScanGlueID_start();
+  void ScanGlue1ID_start();
+  void ScanGlue2ID_start();
+  void ScanGlue3ID_start();
   void ScanModuleID_start();
   void PushToDB_start();
 
   void Update_Baseplate_ID(QString ID) {Baseplate_ID_ = ID;};
   void Update_MaPSA_ID(QString ID) {MaPSA_ID_ = ID;};
   void Update_PSS_ID(QString ID) {PSS_ID_ = ID;};
-  void Update_Glue_ID(QString ID) {Glue_ID_ = ID;};
+  void Update_Glue1_ID(QString ID) {Glue1_ID_ = ID;};
+  void Update_Glue2_ID(QString ID) {Glue2_ID_ = ID;};
+  void Update_Glue3_ID(QString ID) {Glue3_ID_ = ID;};
   void Update_Module_ID(QString ID) {Module_ID_ = ID;};
 
   void RegisterPSSPlusSpacersToMaPSAPosition_start();
@@ -201,14 +205,18 @@ class AssemblyAssemblyV2 : public QObject
   void ScanMaPSAID_finished();
   void ScanPSSID_finished();
   void ScanBaseplateID_finished();
-  void ScanGlueID_finished();
+  void ScanGlue1ID_finished();
+  void ScanGlue2ID_finished();
+  void ScanGlue3ID_finished();
   void ScanModuleID_finished();
   void PushToDB_finished();
 
   void ScanMaPSAID_aborted();
   void ScanBaseplateID_aborted();
   void ScanPSSID_aborted();
-  void ScanGlueID_aborted();
+  void ScanGlue1ID_aborted();
+  void ScanGlue2ID_aborted();
+  void ScanGlue3ID_aborted();
   void ScanModuleID_aborted();
   void PushToDB_aborted();
 
@@ -269,7 +277,9 @@ class AssemblyAssemblyV2 : public QObject
   void MaPSA_ID_updated(const QString);
   void PSS_ID_updated(const QString);
   void Baseplate_ID_updated(const QString);
-  void Glue_ID_updated(const QString);
+  void Glue1_ID_updated(const QString);
+  void Glue2_ID_updated(const QString);
+  void Glue3_ID_updated(const QString);
   void Module_ID_updated(const QString);
   // ------
 

--- a/assembly/assemblyCommon/AssemblyAssemblyV2.h
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2.h
@@ -202,6 +202,12 @@ class AssemblyAssemblyV2 : public QObject
   void ScanModuleID_finished();
   void PushToDB_finished();
 
+  void ScanMaPSAID_aborted();
+  void ScanBaseplateID_aborted();
+  void ScanPSSID_aborted();
+  void ScanModuleID_aborted();
+  void PushToDB_aborted();
+
   void GoToSensorMarkerPreAlignment_finished();
 
   void GoFromSensorMarkerToPickupXY_finished();

--- a/assembly/assemblyCommon/AssemblyAssemblyV2.h
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2.h
@@ -170,6 +170,8 @@ class AssemblyAssemblyV2 : public QObject
 
   // others
 
+  void ScanMaPSAID_start();
+
   void RegisterPSSPlusSpacersToMaPSAPosition_start();
   void RegisterPSSPlusSpacersToMaPSAPosition_finish();
 
@@ -182,6 +184,8 @@ class AssemblyAssemblyV2 : public QObject
   // motion
   void move_absolute_request(const double, const double, const double, const double);
   void move_relative_request(const double, const double, const double, const double);
+
+  void ScanMaPSAID_finished();
 
   void GoToSensorMarkerPreAlignment_finished();
 

--- a/assembly/assemblyCommon/AssemblyAssemblyV2.h
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2.h
@@ -179,7 +179,10 @@ class AssemblyAssemblyV2 : public QObject
   void ScanGlue2ID_start();
   void ScanGlue3ID_start();
   void ScanModuleID_start();
-  void PushToDB_start();
+  void PushAllToDB_start();
+  void PushStep1ToDB_start();
+  void PushStep2ToDB_start();
+  void PushStep3ToDB_start();
 
   void Update_Baseplate_ID(QString ID) {Baseplate_ID_ = ID;};
   void Update_MaPSA_ID(QString ID) {MaPSA_ID_ = ID;};
@@ -209,7 +212,10 @@ class AssemblyAssemblyV2 : public QObject
   void ScanGlue2ID_finished();
   void ScanGlue3ID_finished();
   void ScanModuleID_finished();
-  void PushToDB_finished();
+  void PushAllToDB_finished();
+  void PushStep1ToDB_finished();
+  void PushStep2ToDB_finished();
+  void PushStep3ToDB_finished();
 
   void ScanMaPSAID_aborted();
   void ScanBaseplateID_aborted();
@@ -218,7 +224,10 @@ class AssemblyAssemblyV2 : public QObject
   void ScanGlue2ID_aborted();
   void ScanGlue3ID_aborted();
   void ScanModuleID_aborted();
-  void PushToDB_aborted();
+  void PushAllToDB_aborted();
+  void PushStep1ToDB_aborted();
+  void PushStep2ToDB_aborted();
+  void PushStep3ToDB_aborted();
 
   void GoToSensorMarkerPreAlignment_finished();
 

--- a/assembly/assemblyCommon/AssemblyAssemblyV2.h
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2.h
@@ -67,7 +67,7 @@ class AssemblyAssemblyV2 : public QObject
 
   double original_Z_velocity_;
 
-  QString Baseplate_ID_, MaPSA_ID_, PSS_ID_, Module_ID_;
+  QString Baseplate_ID_, MaPSA_ID_, PSS_ID_, Glue_ID_, Module_ID_;
 
   bool alreadyClicked_LowerPickupToolOntoMaPSA, alreadyClicked_LowerPickupToolOntoPSS, alreadyClicked_LowerMaPSAOntoBaseplate, alreadyClicked_LowerPSSOntoSpacers, alreadyClicked_LowerPSSPlusSpacersOntoGluingStage, alreadyClicked_LowerPSSPlusSpacersOntoMaPSA;
 
@@ -175,12 +175,14 @@ class AssemblyAssemblyV2 : public QObject
   void ScanMaPSAID_start();
   void ScanPSSID_start();
   void ScanBaseplateID_start();
+  void ScanGlueID_start();
   void ScanModuleID_start();
   void PushToDB_start();
 
   void Update_Baseplate_ID(QString ID) {Baseplate_ID_ = ID;};
   void Update_MaPSA_ID(QString ID) {MaPSA_ID_ = ID;};
   void Update_PSS_ID(QString ID) {PSS_ID_ = ID;};
+  void Update_Glue_ID(QString ID) {Glue_ID_ = ID;};
   void Update_Module_ID(QString ID) {Module_ID_ = ID;};
 
   void RegisterPSSPlusSpacersToMaPSAPosition_start();
@@ -199,12 +201,14 @@ class AssemblyAssemblyV2 : public QObject
   void ScanMaPSAID_finished();
   void ScanPSSID_finished();
   void ScanBaseplateID_finished();
+  void ScanGlueID_finished();
   void ScanModuleID_finished();
   void PushToDB_finished();
 
   void ScanMaPSAID_aborted();
   void ScanBaseplateID_aborted();
   void ScanPSSID_aborted();
+  void ScanGlueID_aborted();
   void ScanModuleID_aborted();
   void PushToDB_aborted();
 
@@ -265,6 +269,7 @@ class AssemblyAssemblyV2 : public QObject
   void MaPSA_ID_updated(const QString);
   void PSS_ID_updated(const QString);
   void Baseplate_ID_updated(const QString);
+  void Glue_ID_updated(const QString);
   void Module_ID_updated(const QString);
   // ------
 

--- a/assembly/assemblyCommon/AssemblyAssemblyV2.h
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2.h
@@ -67,6 +67,8 @@ class AssemblyAssemblyV2 : public QObject
 
   double original_Z_velocity_;
 
+  QString Baseplate_ID_, MaPSA_ID_, PSS_ID_, Module_ID_;
+
   bool alreadyClicked_LowerPickupToolOntoMaPSA, alreadyClicked_LowerPickupToolOntoPSS, alreadyClicked_LowerMaPSAOntoBaseplate, alreadyClicked_LowerPSSOntoSpacers, alreadyClicked_LowerPSSPlusSpacersOntoGluingStage, alreadyClicked_LowerPSSPlusSpacersOntoMaPSA;
 
   assembly::Center assembly_center_;
@@ -171,6 +173,15 @@ class AssemblyAssemblyV2 : public QObject
   // others
 
   void ScanMaPSAID_start();
+  void ScanPSSID_start();
+  void ScanBaseplateID_start();
+  void ScanModuleID_start();
+  void PushToDB_start();
+
+  void Update_Baseplate_ID(QString ID) {Baseplate_ID_ = ID;};
+  void Update_MaPSA_ID(QString ID) {MaPSA_ID_ = ID;};
+  void Update_PSS_ID(QString ID) {PSS_ID_ = ID;};
+  void Update_Module_ID(QString ID) {Module_ID_ = ID;};
 
   void RegisterPSSPlusSpacersToMaPSAPosition_start();
   void RegisterPSSPlusSpacersToMaPSAPosition_finish();
@@ -186,6 +197,10 @@ class AssemblyAssemblyV2 : public QObject
   void move_relative_request(const double, const double, const double, const double);
 
   void ScanMaPSAID_finished();
+  void ScanPSSID_finished();
+  void ScanBaseplateID_finished();
+  void ScanModuleID_finished();
+  void PushToDB_finished();
 
   void GoToSensorMarkerPreAlignment_finished();
 
@@ -240,6 +255,11 @@ class AssemblyAssemblyV2 : public QObject
   void RegisterPSSPlusSpacersToMaPSAPosition_finished();
   void switchToAlignmentTab_PSP_request();
   void switchToAlignmentTab_PSS_request();
+
+  void MaPSA_ID_updated(const QString);
+  void PSS_ID_updated(const QString);
+  void Baseplate_ID_updated(const QString);
+  void Module_ID_updated(const QString);
   // ------
 
 

--- a/assembly/assemblyCommon/AssemblyAssemblyV2.h
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2.h
@@ -19,6 +19,9 @@
 #include <RelayCardManager.h>
 #include <AssemblyUtilities.h>
 
+#include <DatabaseDESY.h>
+#include <DatabaseDummy.h>
+
 #include <AssemblySmartMotionManager.h>
 #include <ApplicationConfig.h>
 
@@ -68,6 +71,8 @@ class AssemblyAssemblyV2 : public QObject
   double original_Z_velocity_;
 
   QString Baseplate_ID_, MaPSA_ID_, PSS_ID_, Glue1_ID_, Glue2_ID_, Glue3_ID_, Module_ID_;
+
+  VDatabase* database_;
 
   bool alreadyClicked_LowerPickupToolOntoMaPSA, alreadyClicked_LowerPickupToolOntoPSS, alreadyClicked_LowerMaPSAOntoBaseplate, alreadyClicked_LowerPSSOntoSpacers, alreadyClicked_LowerPSSPlusSpacersOntoGluingStage, alreadyClicked_LowerPSSPlusSpacersOntoMaPSA;
 

--- a/assembly/assemblyCommon/AssemblyAssemblyV2.h
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2.h
@@ -184,6 +184,8 @@ class AssemblyAssemblyV2 : public QObject
   void ScanGlue2ID_start();
   void ScanGlue3ID_start();
   void ScanModuleID_start();
+
+  void RegisterModuleID_start();
   void PushAllToDB_start();
   void PushStep1ToDB_start();
   void PushStep2ToDB_start();
@@ -217,6 +219,8 @@ class AssemblyAssemblyV2 : public QObject
   void ScanGlue2ID_finished();
   void ScanGlue3ID_finished();
   void ScanModuleID_finished();
+
+  void RegisterModuleID_finished();
   void PushAllToDB_finished();
   void PushStep1ToDB_finished();
   void PushStep2ToDB_finished();
@@ -229,6 +233,8 @@ class AssemblyAssemblyV2 : public QObject
   void ScanGlue2ID_aborted();
   void ScanGlue3ID_aborted();
   void ScanModuleID_aborted();
+
+  void RegisterModuleID_aborted();
   void PushAllToDB_aborted();
   void PushStep1ToDB_aborted();
   void PushStep2ToDB_aborted();

--- a/assembly/assemblyCommon/AssemblyAssemblyV2View.cc
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2View.cc
@@ -170,6 +170,19 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
   }
   // ----------
 
+  // step: Register Module ID in DB
+  {
+    ++assembly_step_N;
+
+    AssemblyAssemblyActionWidget* tmp_wid = new AssemblyAssemblyActionWidget;
+    tmp_wid->label()->setText(QString::number(assembly_step_N));
+    tmp_wid->button()->setText("Register Module ID in DB");
+    PSPToBasep_lay->addWidget(tmp_wid);
+
+    tmp_wid->connect_action(assembly, SLOT(RegisterModuleID_start()), SIGNAL(RegisterModuleID_finished()), SIGNAL(RegisterModuleID_aborted()));
+  }
+  // ----------
+
   // step: Scan MaPSA ID
   {
     ++assembly_step_N;

--- a/assembly/assemblyCommon/AssemblyAssemblyV2View.cc
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2View.cc
@@ -70,7 +70,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
   QLabel* module_id_label = new QLabel("Module ID: ");
   module_id_lineed_ = new QLineEdit("");
   module_id_lineed_->setPlaceholderText("Module ID");
-  module_id_lineed_->setMaximumWidth(200);
+  module_id_lineed_->setMaximumWidth(150);
 
   opts_lay->addWidget(module_id_label);
   opts_lay->addWidget(module_id_lineed_);
@@ -81,7 +81,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
   QLabel* baseplate_id_label = new QLabel("Baseplate ID: ");
   baseplate_id_lineed_ = new QLineEdit("");
   baseplate_id_lineed_->setPlaceholderText("Baseplate ID");
-  baseplate_id_lineed_->setMaximumWidth(200);
+  baseplate_id_lineed_->setMaximumWidth(220);
 
   opts_lay->addWidget(baseplate_id_label);
   opts_lay->addWidget(baseplate_id_lineed_);
@@ -92,7 +92,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
   QLabel* mapsa_id_label = new QLabel("MaPSA ID: ");
   mapsa_id_lineed_ = new QLineEdit("");
   mapsa_id_lineed_->setPlaceholderText("MaPSA ID");
-  mapsa_id_lineed_->setMaximumWidth(150);
+  mapsa_id_lineed_->setMaximumWidth(160);
 
   opts_lay->addWidget(mapsa_id_label);
   opts_lay->addWidget(mapsa_id_lineed_);
@@ -103,7 +103,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
   QLabel* pss_id_label = new QLabel("PS-s Sensor ID: ");
   pss_id_lineed_ = new QLineEdit("");
   pss_id_lineed_->setPlaceholderText("PS-s Sensor ID");
-  pss_id_lineed_->setMaximumWidth(150);
+  pss_id_lineed_->setMaximumWidth(180);
 
   opts_lay->addWidget(pss_id_label);
   opts_lay->addWidget(pss_id_lineed_);
@@ -114,15 +114,15 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
   QLabel* glue_id_label = new QLabel("Slow Glue IDs (steps 1/2/3): ");
   glue1_id_lineed_ = new QLineEdit("");
   glue1_id_lineed_->setPlaceholderText("Glue ID (step 1)");
-  glue1_id_lineed_->setMaximumWidth(80);
+  glue1_id_lineed_->setMaximumWidth(100);
 
   glue2_id_lineed_ = new QLineEdit("");
   glue2_id_lineed_->setPlaceholderText("Glue ID (step 2)");
-  glue2_id_lineed_->setMaximumWidth(80);
+  glue2_id_lineed_->setMaximumWidth(100);
 
   glue3_id_lineed_ = new QLineEdit("");
   glue3_id_lineed_->setPlaceholderText("Glue ID (step 3)");
-  glue3_id_lineed_->setMaximumWidth(80);
+  glue3_id_lineed_->setMaximumWidth(100);
 
   opts_lay->addWidget(glue_id_label);
   opts_lay->addWidget(glue1_id_lineed_);

--- a/assembly/assemblyCommon/AssemblyAssemblyV2View.cc
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2View.cc
@@ -157,31 +157,33 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
   QVBoxLayout* PSPToBasep_lay = new QVBoxLayout;
   wid_PSPToBasep_->setLayout(PSPToBasep_lay);
 
-  // step: Define/Scan Module ID
-  {
-    ++assembly_step_N;
+  if(assembly->GetAssemblyCenter() == assembly::Center::DESY){
+      // step: Define/Scan Module ID
+      {
+        ++assembly_step_N;
 
-    AssemblyAssemblyActionWidget* tmp_wid = new AssemblyAssemblyActionWidget;
-    tmp_wid->label()->setText(QString::number(assembly_step_N));
-    tmp_wid->button()->setText("Define/Scan Module ID");
-    PSPToBasep_lay->addWidget(tmp_wid);
+        AssemblyAssemblyActionWidget* tmp_wid = new AssemblyAssemblyActionWidget;
+        tmp_wid->label()->setText(QString::number(assembly_step_N));
+        tmp_wid->button()->setText("Define/Scan Module ID");
+        PSPToBasep_lay->addWidget(tmp_wid);
 
-    tmp_wid->connect_action(assembly, SLOT(ScanModuleID_start()), SIGNAL(ScanModuleID_finished()), SIGNAL(ScanModuleID_aborted()));
+        tmp_wid->connect_action(assembly, SLOT(ScanModuleID_start()), SIGNAL(ScanModuleID_finished()), SIGNAL(ScanModuleID_aborted()));
+      }
+      // ----------
+
+      // step: Register Module ID in DB
+      {
+        ++assembly_step_N;
+
+        AssemblyAssemblyActionWidget* tmp_wid = new AssemblyAssemblyActionWidget;
+        tmp_wid->label()->setText(QString::number(assembly_step_N));
+        tmp_wid->button()->setText("Register Module ID in DB");
+        PSPToBasep_lay->addWidget(tmp_wid);
+
+        tmp_wid->connect_action(assembly, SLOT(RegisterModuleID_start()), SIGNAL(RegisterModuleID_finished()), SIGNAL(RegisterModuleID_aborted()));
+      }
+      // ----------
   }
-  // ----------
-
-  // step: Register Module ID in DB
-  {
-    ++assembly_step_N;
-
-    AssemblyAssemblyActionWidget* tmp_wid = new AssemblyAssemblyActionWidget;
-    tmp_wid->label()->setText(QString::number(assembly_step_N));
-    tmp_wid->button()->setText("Register Module ID in DB");
-    PSPToBasep_lay->addWidget(tmp_wid);
-
-    tmp_wid->connect_action(assembly, SLOT(RegisterModuleID_start()), SIGNAL(RegisterModuleID_finished()), SIGNAL(RegisterModuleID_aborted()));
-  }
-  // ----------
 
   // step: Scan MaPSA ID
   {
@@ -327,18 +329,20 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
   }
   // ----------
 
-  // step: Scan Glue ID (step 1)
-  {
-    ++assembly_step_N;
+  if(assembly->GetAssemblyCenter() == assembly::Center::DESY){
+      // step: Scan Glue ID (step 1)
+      {
+        ++assembly_step_N;
 
-    AssemblyAssemblyActionWidget* tmp_wid = new AssemblyAssemblyActionWidget;
-    tmp_wid->label()->setText(QString::number(assembly_step_N));
-    tmp_wid->button()->setText("Scan Slow Glue ID");
-    PSPToBasep_lay->addWidget(tmp_wid);
+        AssemblyAssemblyActionWidget* tmp_wid = new AssemblyAssemblyActionWidget;
+        tmp_wid->label()->setText(QString::number(assembly_step_N));
+        tmp_wid->button()->setText("Scan Slow Glue ID");
+        PSPToBasep_lay->addWidget(tmp_wid);
 
-    tmp_wid->connect_action(assembly, SLOT(ScanGlue1ID_start()), SIGNAL(ScanGlue1ID_finished()), SIGNAL(ScanGlue1ID_aborted()));
+        tmp_wid->connect_action(assembly, SLOT(ScanGlue1ID_start()), SIGNAL(ScanGlue1ID_finished()), SIGNAL(ScanGlue1ID_aborted()));
+      }
+      // ----------
   }
-  // ----------
 
   // step: Dispense Glue on Baseplate and Place it on Assembly Platform
   {
@@ -455,7 +459,9 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
   }
   // ----------
 
+
   // step: Push IDs to Database
+  if(assembly->GetAssemblyCenter() == assembly::Center::DESY)
   {
     ++assembly_step_N;
 
@@ -465,6 +471,16 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
     PSPToBasep_lay->addWidget(push_step1_to_db_wid_);
 
     push_step1_to_db_wid_->connect_action(assembly, SLOT(PushStep1ToDB_start()), SIGNAL(PushStep1ToDB_finished()), SIGNAL(PushStep1ToDB_aborted()));
+  } else if(assembly->GetAssemblyCenter() == assembly::Center::BROWN)
+  {
+      ++assembly_step_N;
+
+      push_step1_to_db_wid_ = new AssemblyAssemblyActionWidget;
+      push_step1_to_db_wid_->label()->setText(QString::number(assembly_step_N));
+      push_step1_to_db_wid_->button()->setText("Generate File for Database Input");
+      PSPToBasep_lay->addWidget(push_step1_to_db_wid_);
+
+      push_step1_to_db_wid_->connect_action(assembly, SLOT(PushStep1ToDB_start()), SIGNAL(PushStep1ToDB_finished()), SIGNAL(PushStep1ToDB_aborted()));
   }
   // ----------
 
@@ -696,20 +712,20 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
   }
   // ----------
 
-  // step: Scan Glue ID (step 2)
-  {
-    ++assembly_step_N;
-
-    AssemblyAssemblyActionWidget* tmp_wid = new AssemblyAssemblyActionWidget;
-    tmp_wid->label()->setText(QString::number(assembly_step_N));
-    tmp_wid->button()->setText("Scan Slow Glue ID");
-    PSSToSpacers_lay->addWidget(tmp_wid);
-
-    tmp_wid->connect_action(assembly, SLOT(ScanGlue2ID_start()), SIGNAL(ScanGlue2ID_finished()), SIGNAL(ScanGlue2ID_aborted()));
-  }
-  // ----------
-
   if(assembly->GetAssemblyCenter() == assembly::Center::DESY){
+    // step: Scan Glue ID (step 2)
+    {
+        ++assembly_step_N;
+
+        AssemblyAssemblyActionWidget* tmp_wid = new AssemblyAssemblyActionWidget;
+        tmp_wid->label()->setText(QString::number(assembly_step_N));
+        tmp_wid->button()->setText("Scan Slow Glue ID");
+        PSSToSpacers_lay->addWidget(tmp_wid);
+
+        tmp_wid->connect_action(assembly, SLOT(ScanGlue2ID_start()), SIGNAL(ScanGlue2ID_finished()), SIGNAL(ScanGlue2ID_aborted()));
+    }
+    // ----------
+
     // step: Enable Vacuum on Spacers
     {
       ++assembly_step_N;
@@ -869,6 +885,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
   // ----------
 
   // step: Push IDs to Database
+  if (assembly->GetAssemblyCenter() == assembly::Center::DESY)
   {
     ++assembly_step_N;
 
@@ -878,6 +895,16 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
     PSSToSpacers_lay->addWidget(push_step2_to_db_wid_);
 
     push_step2_to_db_wid_->connect_action(assembly, SLOT(PushStep2ToDB_start()), SIGNAL(PushStep2ToDB_finished()), SIGNAL(PushStep2ToDB_aborted()));
+  } else if (assembly->GetAssemblyCenter() == assembly::Center::BROWN)
+  {
+      ++assembly_step_N;
+
+      push_step2_to_db_wid_ = new AssemblyAssemblyActionWidget;
+      push_step2_to_db_wid_->label()->setText(QString::number(assembly_step_N));
+      push_step2_to_db_wid_->button()->setText("Generate File for Database Input");
+      PSSToSpacers_lay->addWidget(push_step2_to_db_wid_);
+
+      push_step2_to_db_wid_->connect_action(assembly, SLOT(PushStep2ToDB_start()), SIGNAL(PushStep2ToDB_finished()), SIGNAL(PushStep2ToDB_aborted()));
   }
   // ----------
 
@@ -929,19 +956,20 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
   QVBoxLayout* PSSToMaPSA_lay = new QVBoxLayout;
   wid_PSSToMaPSA_->setLayout(PSSToMaPSA_lay);
 
+  if (assembly->GetAssemblyCenter() == assembly::Center::DESY) {
+      // step: Scan Glue ID (step 3)
+      {
+        ++assembly_step_N;
 
-  // step: Scan Glue ID (step 3)
-  {
-    ++assembly_step_N;
+        AssemblyAssemblyActionWidget* tmp_wid = new AssemblyAssemblyActionWidget;
+        tmp_wid->label()->setText(QString::number(assembly_step_N));
+        tmp_wid->button()->setText("Scan Slow Glue ID");
+        PSSToMaPSA_lay->addWidget(tmp_wid);
 
-    AssemblyAssemblyActionWidget* tmp_wid = new AssemblyAssemblyActionWidget;
-    tmp_wid->label()->setText(QString::number(assembly_step_N));
-    tmp_wid->button()->setText("Scan Slow Glue ID");
-    PSSToMaPSA_lay->addWidget(tmp_wid);
-
-    tmp_wid->connect_action(assembly, SLOT(ScanGlue3ID_start()), SIGNAL(ScanGlue3ID_finished()), SIGNAL(ScanGlue3ID_aborted()));
+        tmp_wid->connect_action(assembly, SLOT(ScanGlue3ID_start()), SIGNAL(ScanGlue3ID_finished()), SIGNAL(ScanGlue3ID_aborted()));
+      }
+      // ----------
   }
-  // ----------
 
   // step: Place "MaPSA + Baseplate" on Assembly Platform with Baseplate Pins
   {
@@ -1182,6 +1210,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
   // ----------
 
   // step: Push IDs to Database
+  if (assembly->GetAssemblyCenter() == assembly::Center::DESY)
   {
     ++assembly_step_N;
 
@@ -1191,6 +1220,29 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
     PSSToMaPSA_lay->addWidget(push_step3_to_db_wid_);
 
     push_step3_to_db_wid_->connect_action(assembly, SLOT(PushStep3ToDB_start()), SIGNAL(PushStep3ToDB_finished()), SIGNAL(PushStep3ToDB_aborted()));
+  } else if (assembly->GetAssemblyCenter() == assembly::Center::BROWN)
+  {
+      {
+          ++assembly_step_N;
+
+          AssemblyAssemblyActionWidget* tmp_wid = new AssemblyAssemblyActionWidget;
+          tmp_wid->label()->setText(QString::number(assembly_step_N));
+          tmp_wid->button()->setText("Define/Scan Module ID");
+          PSSToMaPSA_lay->addWidget(tmp_wid);
+
+          tmp_wid->connect_action(assembly, SLOT(ScanModuleID_start()), SIGNAL(ScanModuleID_finished()), SIGNAL(ScanModuleID_aborted()));
+        }
+        // ----------
+        {
+          ++assembly_step_N;
+
+          push_step3_to_db_wid_ = new AssemblyAssemblyActionWidget;
+          push_step3_to_db_wid_->label()->setText(QString::number(assembly_step_N));
+          push_step3_to_db_wid_->button()->setText("Generate File for Database Input");
+          PSSToMaPSA_lay->addWidget(push_step3_to_db_wid_);
+
+          push_step3_to_db_wid_->connect_action(assembly, SLOT(PushStep3ToDB_start()), SIGNAL(PushStep3ToDB_finished()), SIGNAL(PushStep3ToDB_aborted()));
+      }
   }
   // ----------
 

--- a/assembly/assemblyCommon/AssemblyAssemblyV2View.cc
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2View.cc
@@ -30,6 +30,11 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
  , wid_PSPToBasep_(nullptr)
  , wid_PSSToSpacers_(nullptr)
  , wid_PSSToMaPSA_(nullptr)
+ , baseplate_id_lineed_(nullptr)
+ , mapsa_id_lineed_(nullptr)
+ , pss_id_lineed_(nullptr)
+ , module_id_lineed_(nullptr)
+ , push_to_db_button_(nullptr)
 {
   if(assembly == nullptr)
   {
@@ -53,6 +58,45 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
   connect(smartMove_checkbox_, SIGNAL(stateChanged(int)), assembly, SLOT(use_smartMove(int)));
 
   smartMove_checkbox_->setChecked(true);
+  //// -----------------------------------------------
+
+  opts_lay->addStretch();
+
+  QLabel* baseplate_id_label = new QLabel("Baseplate ID: ");
+  baseplate_id_lineed_ = new QLineEdit("");
+  baseplate_id_lineed_->setPlaceholderText("Baseplate ID");
+  baseplate_id_lineed_->setMaximumWidth(200);
+
+  opts_lay->addWidget(baseplate_id_label);
+  opts_lay->addWidget(baseplate_id_lineed_);
+
+  QLabel* mapsa_id_label = new QLabel("MaPSA ID: ");
+  mapsa_id_lineed_ = new QLineEdit("");
+  mapsa_id_lineed_->setPlaceholderText("MaPSA ID");
+  mapsa_id_lineed_->setMaximumWidth(200);
+
+  opts_lay->addWidget(mapsa_id_label);
+  opts_lay->addWidget(mapsa_id_lineed_);
+
+  QLabel* pss_id_label = new QLabel("Strip Sensor ID: ");
+  pss_id_lineed_ = new QLineEdit("");
+  pss_id_lineed_->setPlaceholderText("Strip Sensor ID");
+  pss_id_lineed_->setMaximumWidth(200);
+
+  opts_lay->addWidget(pss_id_label);
+  opts_lay->addWidget(pss_id_lineed_);
+
+  QLabel* module_id_label = new QLabel("Module ID: ");
+  module_id_lineed_ = new QLineEdit("");
+  module_id_lineed_->setPlaceholderText("Module ID");
+  module_id_lineed_->setMaximumWidth(200);
+
+  opts_lay->addWidget(module_id_label);
+  opts_lay->addWidget(module_id_lineed_);
+
+  push_to_db_button_ = new QPushButton("Push to database");
+  opts_lay->addWidget(push_to_db_button_);
+
   //// -----------------------------------------------
 
   QToolBox* toolbox = new QToolBox;

--- a/assembly/assemblyCommon/AssemblyAssemblyV2View.cc
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2View.cc
@@ -459,31 +459,6 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
   }
   // ----------
 
-
-  // step: Push IDs to Database
-  if(assembly->GetAssemblyCenter() == assembly::Center::DESY)
-  {
-    ++assembly_step_N;
-
-    push_step1_to_db_wid_ = new AssemblyAssemblyActionWidget;
-    push_step1_to_db_wid_->label()->setText(QString::number(assembly_step_N));
-    push_step1_to_db_wid_->button()->setText("Push Assembly Information to Database");
-    PSPToBasep_lay->addWidget(push_step1_to_db_wid_);
-
-    push_step1_to_db_wid_->connect_action(assembly, SLOT(PushStep1ToDB_start()), SIGNAL(PushStep1ToDB_finished()), SIGNAL(PushStep1ToDB_aborted()));
-  } else if(assembly->GetAssemblyCenter() == assembly::Center::BROWN)
-  {
-      ++assembly_step_N;
-
-      push_step1_to_db_wid_ = new AssemblyAssemblyActionWidget;
-      push_step1_to_db_wid_->label()->setText(QString::number(assembly_step_N));
-      push_step1_to_db_wid_->button()->setText("Generate File for Database Input");
-      PSPToBasep_lay->addWidget(push_step1_to_db_wid_);
-
-      push_step1_to_db_wid_->connect_action(assembly, SLOT(PushStep1ToDB_start()), SIGNAL(PushStep1ToDB_finished()), SIGNAL(PushStep1ToDB_aborted()));
-  }
-  // ----------
-
   // step: Wait For Glue To Cure
   {
     ++assembly_step_N;
@@ -542,6 +517,30 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
     PSPToBasep_lay->addWidget(tmp_wid);
 
     tmp_wid->connect_action(assembly, SLOT(DisableVacuumBaseplate_start()), SIGNAL(DisableVacuumBaseplate_finished()));
+  }
+  // ----------
+
+  // step: Push IDs to Database
+  if(assembly->GetAssemblyCenter() == assembly::Center::DESY)
+  {
+      ++assembly_step_N;
+
+      push_step1_to_db_wid_ = new AssemblyAssemblyActionWidget;
+      push_step1_to_db_wid_->label()->setText(QString::number(assembly_step_N));
+      push_step1_to_db_wid_->button()->setText("Push Assembly Information to Database");
+      PSPToBasep_lay->addWidget(push_step1_to_db_wid_);
+
+      push_step1_to_db_wid_->connect_action(assembly, SLOT(PushStep1ToDB_start()), SIGNAL(PushStep1ToDB_finished()), SIGNAL(PushStep1ToDB_aborted()));
+  } else if(assembly->GetAssemblyCenter() == assembly::Center::BROWN)
+  {
+      ++assembly_step_N;
+
+      push_step1_to_db_wid_ = new AssemblyAssemblyActionWidget;
+      push_step1_to_db_wid_->label()->setText(QString::number(assembly_step_N));
+      push_step1_to_db_wid_->button()->setText("Generate File for Database Input");
+      PSPToBasep_lay->addWidget(push_step1_to_db_wid_);
+
+      push_step1_to_db_wid_->connect_action(assembly, SLOT(PushStep1ToDB_start()), SIGNAL(PushStep1ToDB_finished()), SIGNAL(PushStep1ToDB_aborted()));
   }
   // ----------
 

--- a/assembly/assemblyCommon/AssemblyAssemblyV2View.cc
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2View.cc
@@ -112,6 +112,19 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
   QVBoxLayout* PSPToBasep_lay = new QVBoxLayout;
   wid_PSPToBasep_->setLayout(PSPToBasep_lay);
 
+  // step: Scan MaPSA ID
+  {
+    ++assembly_step_N;
+
+    AssemblyAssemblyActionWidget* tmp_wid = new AssemblyAssemblyActionWidget;
+    tmp_wid->label()->setText(QString::number(assembly_step_N));
+    tmp_wid->button()->setText("Scan MaPSA ID");
+    PSPToBasep_lay->addWidget(tmp_wid);
+
+    tmp_wid->connect_action(assembly, SLOT(ScanMaPSAID_start()), SIGNAL(ScanMaPSAID_finished()));
+  }
+  // ----------
+
   // step: Place MaPSA on Assembly Platform
   {
     ++assembly_step_N;

--- a/assembly/assemblyCommon/AssemblyAssemblyV2View.cc
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2View.cc
@@ -33,7 +33,9 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
  , baseplate_id_lineed_(nullptr)
  , mapsa_id_lineed_(nullptr)
  , pss_id_lineed_(nullptr)
- , glue_id_lineed_(nullptr)
+ , glue1_id_lineed_(nullptr)
+ , glue2_id_lineed_(nullptr)
+ , glue3_id_lineed_(nullptr)
  , module_id_lineed_(nullptr)
  , push_to_db_button_(nullptr)
 {
@@ -77,7 +79,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
   QLabel* mapsa_id_label = new QLabel("MaPSA ID: ");
   mapsa_id_lineed_ = new QLineEdit("");
   mapsa_id_lineed_->setPlaceholderText("MaPSA ID");
-  mapsa_id_lineed_->setMaximumWidth(200);
+  mapsa_id_lineed_->setMaximumWidth(150);
 
   opts_lay->addWidget(mapsa_id_label);
   opts_lay->addWidget(mapsa_id_lineed_);
@@ -88,7 +90,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
   QLabel* pss_id_label = new QLabel("PS-s Sensor ID: ");
   pss_id_lineed_ = new QLineEdit("");
   pss_id_lineed_->setPlaceholderText("PS-s Sensor ID");
-  pss_id_lineed_->setMaximumWidth(200);
+  pss_id_lineed_->setMaximumWidth(150);
 
   opts_lay->addWidget(pss_id_label);
   opts_lay->addWidget(pss_id_lineed_);
@@ -96,16 +98,30 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
   connect(assembly, SIGNAL(PSS_ID_updated(QString)), pss_id_lineed_, SLOT(setText(QString)));
   connect(pss_id_lineed_, SIGNAL(textEdited(QString)), assembly, SLOT(Update_PSS_ID(QString)));
 
-  QLabel* glue_id_label = new QLabel("Slow Glue ID: ");
-  glue_id_lineed_ = new QLineEdit("");
-  glue_id_lineed_->setPlaceholderText("Slow Glue ID");
-  glue_id_lineed_->setMaximumWidth(200);
+  QLabel* glue_id_label = new QLabel("Slow Glue IDs (steps 1/2/3): ");
+  glue1_id_lineed_ = new QLineEdit("");
+  glue1_id_lineed_->setPlaceholderText("Glue ID (step 1)");
+  glue1_id_lineed_->setMaximumWidth(80);
+
+  glue2_id_lineed_ = new QLineEdit("");
+  glue2_id_lineed_->setPlaceholderText("Glue ID (step 2)");
+  glue2_id_lineed_->setMaximumWidth(80);
+
+  glue3_id_lineed_ = new QLineEdit("");
+  glue3_id_lineed_->setPlaceholderText("Glue ID (step 3)");
+  glue3_id_lineed_->setMaximumWidth(80);
 
   opts_lay->addWidget(glue_id_label);
-  opts_lay->addWidget(glue_id_lineed_);
+  opts_lay->addWidget(glue1_id_lineed_);
+  opts_lay->addWidget(glue2_id_lineed_);
+  opts_lay->addWidget(glue3_id_lineed_);
 
-  connect(assembly, SIGNAL(Glue_ID_updated(QString)), glue_id_lineed_, SLOT(setText(QString)));
-  connect(glue_id_lineed_, SIGNAL(textEdited(QString)), assembly, SLOT(Update_Glue_ID(QString)));
+  connect(assembly, SIGNAL(Glue1_ID_updated(QString)), glue1_id_lineed_, SLOT(setText(QString)));
+  connect(glue1_id_lineed_, SIGNAL(textEdited(QString)), assembly, SLOT(Update_Glue1_ID(QString)));
+  connect(assembly, SIGNAL(Glue2_ID_updated(QString)), glue2_id_lineed_, SLOT(setText(QString)));
+  connect(glue2_id_lineed_, SIGNAL(textEdited(QString)), assembly, SLOT(Update_Glue2_ID(QString)));
+  connect(assembly, SIGNAL(Glue3_ID_updated(QString)), glue3_id_lineed_, SLOT(setText(QString)));
+  connect(glue3_id_lineed_, SIGNAL(textEdited(QString)), assembly, SLOT(Update_Glue3_ID(QString)));
 
   QLabel* module_id_label = new QLabel("Module ID: ");
   module_id_lineed_ = new QLineEdit("");
@@ -283,7 +299,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
   }
   // ----------
 
-  // step: Scan Glue ID
+  // step: Scan Glue ID (step 1)
   {
     ++assembly_step_N;
 
@@ -292,7 +308,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
     tmp_wid->button()->setText("Scan Slow Glue ID");
     PSPToBasep_lay->addWidget(tmp_wid);
 
-    tmp_wid->connect_action(assembly, SLOT(ScanGlueID_start()), SIGNAL(ScanGlueID_finished()), SIGNAL(ScanGlueID_aborted()));
+    tmp_wid->connect_action(assembly, SLOT(ScanGlue1ID_start()), SIGNAL(ScanGlue1ID_finished()), SIGNAL(ScanGlue1ID_aborted()));
   }
   // ----------
 
@@ -639,6 +655,19 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
   }
   // ----------
 
+  // step: Scan Glue ID (step 2)
+  {
+    ++assembly_step_N;
+
+    AssemblyAssemblyActionWidget* tmp_wid = new AssemblyAssemblyActionWidget;
+    tmp_wid->label()->setText(QString::number(assembly_step_N));
+    tmp_wid->button()->setText("Scan Slow Glue ID");
+    PSSToSpacers_lay->addWidget(tmp_wid);
+
+    tmp_wid->connect_action(assembly, SLOT(ScanGlue2ID_start()), SIGNAL(ScanGlue2ID_finished()), SIGNAL(ScanGlue2ID_aborted()));
+  }
+  // ----------
+
   if(assembly->GetAssemblyCenter() == assembly::Center::DESY){
     // step: Enable Vacuum on Spacers
     {
@@ -845,6 +874,20 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
 
   QVBoxLayout* PSSToMaPSA_lay = new QVBoxLayout;
   wid_PSSToMaPSA_->setLayout(PSSToMaPSA_lay);
+
+
+  // step: Scan Glue ID (step 3)
+  {
+    ++assembly_step_N;
+
+    AssemblyAssemblyActionWidget* tmp_wid = new AssemblyAssemblyActionWidget;
+    tmp_wid->label()->setText(QString::number(assembly_step_N));
+    tmp_wid->button()->setText("Scan Slow Glue ID");
+    PSSToMaPSA_lay->addWidget(tmp_wid);
+
+    tmp_wid->connect_action(assembly, SLOT(ScanGlue3ID_start()), SIGNAL(ScanGlue3ID_finished()), SIGNAL(ScanGlue3ID_aborted()));
+  }
+  // ----------
 
   // step: Place "MaPSA + Baseplate" on Assembly Platform with Baseplate Pins
   {
@@ -1185,7 +1228,9 @@ void AssemblyAssemblyV2View::disable_DB()
     mapsa_id_lineed_->setReadOnly(true);
     baseplate_id_lineed_->setReadOnly(true);
     pss_id_lineed_->setReadOnly(true);
-    glue_id_lineed_->setReadOnly(true);
+    glue1_id_lineed_->setReadOnly(true);
+    glue2_id_lineed_->setReadOnly(true);
+    glue3_id_lineed_->setReadOnly(true);
     module_id_lineed_->setReadOnly(true);
 }
 

--- a/assembly/assemblyCommon/AssemblyAssemblyV2View.cc
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2View.cc
@@ -29,7 +29,9 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
  , wid_PSPToBasep_(nullptr)
  , wid_PSSToSpacers_(nullptr)
  , wid_PSSToMaPSA_(nullptr)
- , push_to_db_wid_(nullptr)
+ , push_step1_to_db_wid_(nullptr)
+ , push_step2_to_db_wid_(nullptr)
+ , push_step3_to_db_wid_(nullptr)
  , baseplate_id_lineed_(nullptr)
  , mapsa_id_lineed_(nullptr)
  , pss_id_lineed_(nullptr)
@@ -424,6 +426,19 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
     PSPToBasep_lay->addWidget(tmp_wid);
 
     tmp_wid->connect_action(assembly, SLOT(LowerMaPSAOntoBaseplate_start()), SIGNAL(LowerMaPSAOntoBaseplate_finished()));
+  }
+  // ----------
+
+  // step: Push IDs to Database
+  {
+    ++assembly_step_N;
+
+    push_step1_to_db_wid_ = new AssemblyAssemblyActionWidget;
+    push_step1_to_db_wid_->label()->setText(QString::number(assembly_step_N));
+    push_step1_to_db_wid_->button()->setText("Push Assembly Information to Database");
+    PSPToBasep_lay->addWidget(push_step1_to_db_wid_);
+
+    push_step1_to_db_wid_->connect_action(assembly, SLOT(PushStep1ToDB_start()), SIGNAL(PushStep1ToDB_finished()), SIGNAL(PushStep1ToDB_aborted()));
   }
   // ----------
 
@@ -827,6 +842,19 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
   }
   // ----------
 
+  // step: Push IDs to Database
+  {
+    ++assembly_step_N;
+
+    push_step2_to_db_wid_ = new AssemblyAssemblyActionWidget;
+    push_step2_to_db_wid_->label()->setText(QString::number(assembly_step_N));
+    push_step2_to_db_wid_->button()->setText("Push Assembly Information to Database");
+    PSSToSpacers_lay->addWidget(push_step2_to_db_wid_);
+
+    push_step2_to_db_wid_->connect_action(assembly, SLOT(PushStep2ToDB_start()), SIGNAL(PushStep2ToDB_finished()), SIGNAL(PushStep2ToDB_aborted()));
+  }
+  // ----------
+
   // step: Wait For Glue To Cure
   {
     ++assembly_step_N;
@@ -1127,6 +1155,19 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
   }
   // ----------
 
+  // step: Push IDs to Database
+  {
+    ++assembly_step_N;
+
+    push_step3_to_db_wid_ = new AssemblyAssemblyActionWidget;
+    push_step3_to_db_wid_->label()->setText(QString::number(assembly_step_N));
+    push_step3_to_db_wid_->button()->setText("Push Assembly Information to Database");
+    PSSToMaPSA_lay->addWidget(push_step3_to_db_wid_);
+
+    push_step3_to_db_wid_->connect_action(assembly, SLOT(PushStep3ToDB_start()), SIGNAL(PushStep3ToDB_finished()), SIGNAL(PushStep3ToDB_aborted()));
+  }
+  // ----------
+
   // step: Wait For Glue To Cure
   {
     ++assembly_step_N;
@@ -1190,6 +1231,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
   }
   // ----------
 
+/*
   // step: Push IDs to Database
   {
     ++assembly_step_N;
@@ -1199,9 +1241,10 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
     push_to_db_wid_->button()->setText("Push Assembly Information to Database");
     PSSToMaPSA_lay->addWidget(push_to_db_wid_);
 
-    push_to_db_wid_->connect_action(assembly, SLOT(PushToDB_start()), SIGNAL(PushToDB_finished()), SIGNAL(PushToDB_aborted()));
+    push_to_db_wid_->connect_action(assembly, SLOT(PushAllToDB_start()), SIGNAL(PushAllToDB_finished()), SIGNAL(PushAllToDB_aborted()));
   }
   // ----------
+*/
 
   // step: Remove PS Module from Assembly Platform
   {
@@ -1223,7 +1266,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
 void AssemblyAssemblyV2View::disable_DB()
 {
     //push_to_db_button_->setEnabled(false);
-    push_to_db_wid_->disable_action();
+    //push_to_db_wid_->disable_action();
 
     mapsa_id_lineed_->setReadOnly(true);
     baseplate_id_lineed_->setReadOnly(true);

--- a/assembly/assemblyCommon/AssemblyAssemblyV2View.cc
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2View.cc
@@ -157,6 +157,19 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
   QVBoxLayout* PSPToBasep_lay = new QVBoxLayout;
   wid_PSPToBasep_->setLayout(PSPToBasep_lay);
 
+  // step: Define/Scan Module ID
+  {
+    ++assembly_step_N;
+
+    AssemblyAssemblyActionWidget* tmp_wid = new AssemblyAssemblyActionWidget;
+    tmp_wid->label()->setText(QString::number(assembly_step_N));
+    tmp_wid->button()->setText("Define/Scan Module ID");
+    PSPToBasep_lay->addWidget(tmp_wid);
+
+    tmp_wid->connect_action(assembly, SLOT(ScanModuleID_start()), SIGNAL(ScanModuleID_finished()), SIGNAL(ScanModuleID_aborted()));
+  }
+  // ----------
+
   // step: Scan MaPSA ID
   {
     ++assembly_step_N;
@@ -1215,19 +1228,6 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
     PSSToMaPSA_lay->addWidget(tmp_wid);
 
     tmp_wid->connect_action(assembly, SLOT(DisableVacuumBaseplate_start()), SIGNAL(DisableVacuumBaseplate_finished()));
-  }
-  // ----------
-
-  // step: Scan Module ID
-  {
-    ++assembly_step_N;
-
-    AssemblyAssemblyActionWidget* tmp_wid = new AssemblyAssemblyActionWidget;
-    tmp_wid->label()->setText(QString::number(assembly_step_N));
-    tmp_wid->button()->setText("Scan Module ID");
-    PSSToMaPSA_lay->addWidget(tmp_wid);
-
-    tmp_wid->connect_action(assembly, SLOT(ScanModuleID_start()), SIGNAL(ScanModuleID_finished()), SIGNAL(ScanModuleID_aborted()));
   }
   // ----------
 

--- a/assembly/assemblyCommon/AssemblyAssemblyV2View.cc
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2View.cc
@@ -1156,6 +1156,11 @@ void AssemblyAssemblyV2View::disable_DB()
 {
     push_to_db_button_->setEnabled(false);
     push_to_db_wid_->disable_action();
+
+    mapsa_id_lineed_->setReadOnly(true);
+    baseplate_id_lineed_->setReadOnly(true);
+    pss_id_lineed_->setReadOnly(true);
+    module_id_lineed_->setReadOnly(true);
 }
 
 //-- Information about this tab in GUI

--- a/assembly/assemblyCommon/AssemblyAssemblyV2View.cc
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2View.cc
@@ -37,7 +37,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
  , glue2_id_lineed_(nullptr)
  , glue3_id_lineed_(nullptr)
  , module_id_lineed_(nullptr)
- , push_to_db_button_(nullptr)
+ //, push_to_db_button_(nullptr)
 {
   if(assembly == nullptr)
   {
@@ -64,6 +64,17 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
   //// -----------------------------------------------
 
   opts_lay->addStretch();
+
+  QLabel* module_id_label = new QLabel("Module ID: ");
+  module_id_lineed_ = new QLineEdit("");
+  module_id_lineed_->setPlaceholderText("Module ID");
+  module_id_lineed_->setMaximumWidth(200);
+
+  opts_lay->addWidget(module_id_label);
+  opts_lay->addWidget(module_id_lineed_);
+
+  connect(assembly, SIGNAL(Module_ID_updated(QString)), module_id_lineed_, SLOT(setText(QString)));
+  connect(module_id_lineed_, SIGNAL(textEdited(QString)), assembly, SLOT(Update_Module_ID(QString)));
 
   QLabel* baseplate_id_label = new QLabel("Baseplate ID: ");
   baseplate_id_lineed_ = new QLineEdit("");
@@ -123,22 +134,11 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
   connect(assembly, SIGNAL(Glue3_ID_updated(QString)), glue3_id_lineed_, SLOT(setText(QString)));
   connect(glue3_id_lineed_, SIGNAL(textEdited(QString)), assembly, SLOT(Update_Glue3_ID(QString)));
 
-  QLabel* module_id_label = new QLabel("Module ID: ");
-  module_id_lineed_ = new QLineEdit("");
-  module_id_lineed_->setPlaceholderText("Module ID");
-  module_id_lineed_->setMaximumWidth(200);
+  //push_to_db_button_ = new QPushButton("Push to database");
+  //opts_lay->addWidget(push_to_db_button_);
 
-  opts_lay->addWidget(module_id_label);
-  opts_lay->addWidget(module_id_lineed_);
-
-  connect(assembly, SIGNAL(Module_ID_updated(QString)), module_id_lineed_, SLOT(setText(QString)));
-  connect(module_id_lineed_, SIGNAL(textEdited(QString)), assembly, SLOT(Update_Module_ID(QString)));
-
-  push_to_db_button_ = new QPushButton("Push to database");
-  opts_lay->addWidget(push_to_db_button_);
-
-  connect(push_to_db_button_, SIGNAL(clicked()), assembly, SLOT(PushToDB_start()));
-  connect(assembly, SIGNAL(PushToDB_finished()), this, SLOT(disable_DB()));
+  //connect(push_to_db_button_, SIGNAL(clicked()), assembly, SLOT(PushToDB_start()));
+  //connect(assembly, SIGNAL(PushToDB_finished()), this, SLOT(disable_DB()));
 
   //// -----------------------------------------------
 
@@ -1222,7 +1222,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
 
 void AssemblyAssemblyV2View::disable_DB()
 {
-    push_to_db_button_->setEnabled(false);
+    //push_to_db_button_->setEnabled(false);
     push_to_db_wid_->disable_action();
 
     mapsa_id_lineed_->setReadOnly(true);

--- a/assembly/assemblyCommon/AssemblyAssemblyV2View.cc
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2View.cc
@@ -33,6 +33,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
  , baseplate_id_lineed_(nullptr)
  , mapsa_id_lineed_(nullptr)
  , pss_id_lineed_(nullptr)
+ , glue_id_lineed_(nullptr)
  , module_id_lineed_(nullptr)
  , push_to_db_button_(nullptr)
 {
@@ -94,6 +95,17 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
 
   connect(assembly, SIGNAL(PSS_ID_updated(QString)), pss_id_lineed_, SLOT(setText(QString)));
   connect(pss_id_lineed_, SIGNAL(textEdited(QString)), assembly, SLOT(Update_PSS_ID(QString)));
+
+  QLabel* glue_id_label = new QLabel("Slow Glue ID: ");
+  glue_id_lineed_ = new QLineEdit("");
+  glue_id_lineed_->setPlaceholderText("Slow Glue ID");
+  glue_id_lineed_->setMaximumWidth(200);
+
+  opts_lay->addWidget(glue_id_label);
+  opts_lay->addWidget(glue_id_lineed_);
+
+  connect(assembly, SIGNAL(Glue_ID_updated(QString)), glue_id_lineed_, SLOT(setText(QString)));
+  connect(glue_id_lineed_, SIGNAL(textEdited(QString)), assembly, SLOT(Update_Glue_ID(QString)));
 
   QLabel* module_id_label = new QLabel("Module ID: ");
   module_id_lineed_ = new QLineEdit("");
@@ -268,6 +280,19 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
     PSPToBasep_lay->addWidget(tmp_wid);
 
     tmp_wid->connect_action(assembly, SLOT(ScanBaseplateID_start()), SIGNAL(ScanBaseplateID_finished()), SIGNAL(ScanBaseplateID_aborted()));
+  }
+  // ----------
+
+  // step: Scan Glue ID
+  {
+    ++assembly_step_N;
+
+    AssemblyAssemblyActionWidget* tmp_wid = new AssemblyAssemblyActionWidget;
+    tmp_wid->label()->setText(QString::number(assembly_step_N));
+    tmp_wid->button()->setText("Scan Slow Glue ID");
+    PSPToBasep_lay->addWidget(tmp_wid);
+
+    tmp_wid->connect_action(assembly, SLOT(ScanGlueID_start()), SIGNAL(ScanGlueID_finished()), SIGNAL(ScanGlueID_aborted()));
   }
   // ----------
 
@@ -1160,6 +1185,7 @@ void AssemblyAssemblyV2View::disable_DB()
     mapsa_id_lineed_->setReadOnly(true);
     baseplate_id_lineed_->setReadOnly(true);
     pss_id_lineed_->setReadOnly(true);
+    glue_id_lineed_->setReadOnly(true);
     module_id_lineed_->setReadOnly(true);
 }
 

--- a/assembly/assemblyCommon/AssemblyAssemblyV2View.cc
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2View.cc
@@ -70,6 +70,9 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
   opts_lay->addWidget(baseplate_id_label);
   opts_lay->addWidget(baseplate_id_lineed_);
 
+  connect(assembly, SIGNAL(Baseplate_ID_updated(QString)), baseplate_id_lineed_, SLOT(setText(QString)));
+  connect(baseplate_id_lineed_, SIGNAL(textEdited(QString)), assembly, SLOT(Update_Baseplate_ID(QString)));
+
   QLabel* mapsa_id_label = new QLabel("MaPSA ID: ");
   mapsa_id_lineed_ = new QLineEdit("");
   mapsa_id_lineed_->setPlaceholderText("MaPSA ID");
@@ -78,13 +81,19 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
   opts_lay->addWidget(mapsa_id_label);
   opts_lay->addWidget(mapsa_id_lineed_);
 
-  QLabel* pss_id_label = new QLabel("Strip Sensor ID: ");
+  connect(assembly, SIGNAL(MaPSA_ID_updated(QString)), mapsa_id_lineed_, SLOT(setText(QString)));
+  connect(mapsa_id_lineed_, SIGNAL(textEdited(QString)), assembly, SLOT(Update_MaPSA_ID(QString)));
+
+  QLabel* pss_id_label = new QLabel("PS-s Sensor ID: ");
   pss_id_lineed_ = new QLineEdit("");
-  pss_id_lineed_->setPlaceholderText("Strip Sensor ID");
+  pss_id_lineed_->setPlaceholderText("PS-s Sensor ID");
   pss_id_lineed_->setMaximumWidth(200);
 
   opts_lay->addWidget(pss_id_label);
   opts_lay->addWidget(pss_id_lineed_);
+
+  connect(assembly, SIGNAL(PSS_ID_updated(QString)), pss_id_lineed_, SLOT(setText(QString)));
+  connect(pss_id_lineed_, SIGNAL(textEdited(QString)), assembly, SLOT(Update_PSS_ID(QString)));
 
   QLabel* module_id_label = new QLabel("Module ID: ");
   module_id_lineed_ = new QLineEdit("");
@@ -93,6 +102,9 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
 
   opts_lay->addWidget(module_id_label);
   opts_lay->addWidget(module_id_lineed_);
+
+  connect(assembly, SIGNAL(Module_ID_updated(QString)), module_id_lineed_, SLOT(setText(QString)));
+  connect(module_id_lineed_, SIGNAL(textEdited(QString)), assembly, SLOT(Update_Module_ID(QString)));
 
   push_to_db_button_ = new QPushButton("Push to database");
   opts_lay->addWidget(push_to_db_button_);
@@ -240,6 +252,19 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
     PSPToBasep_lay->addWidget(tmp_wid);
 
     tmp_wid->connect_action(assembly, SLOT(PickupMaPSA_start()), SIGNAL(PickupMaPSA_finished()));
+  }
+  // ----------
+
+  // step: Scan Baseplate ID
+  {
+    ++assembly_step_N;
+
+    AssemblyAssemblyActionWidget* tmp_wid = new AssemblyAssemblyActionWidget;
+    tmp_wid->label()->setText(QString::number(assembly_step_N));
+    tmp_wid->button()->setText("Scan Baseplate ID");
+    PSPToBasep_lay->addWidget(tmp_wid);
+
+    tmp_wid->connect_action(assembly, SLOT(ScanBaseplateID_start()), SIGNAL(ScanBaseplateID_finished()));
   }
   // ----------
 
@@ -441,6 +466,19 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
 
   QVBoxLayout* PSSToSpacers_lay = new QVBoxLayout;
   wid_PSSToSpacers_->setLayout(PSSToSpacers_lay);
+
+  // step: Scan PSS ID
+  {
+    ++assembly_step_N;
+
+    AssemblyAssemblyActionWidget* tmp_wid = new AssemblyAssemblyActionWidget;
+    tmp_wid->label()->setText(QString::number(assembly_step_N));
+    tmp_wid->button()->setText("Scan PS-s ID");
+    PSSToSpacers_lay->addWidget(tmp_wid);
+
+    tmp_wid->connect_action(assembly, SLOT(ScanPSSID_start()), SIGNAL(ScanPSSID_finished()));
+  }
+  // ----------
 
   // step: Place PS-s on Assembly Platform
   {
@@ -1065,6 +1103,19 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
     PSSToMaPSA_lay->addWidget(tmp_wid);
 
     tmp_wid->connect_action(assembly, SLOT(DisableVacuumBaseplate_start()), SIGNAL(DisableVacuumBaseplate_finished()));
+  }
+  // ----------
+
+  // step: Scan Module ID
+  {
+    ++assembly_step_N;
+
+    AssemblyAssemblyActionWidget* tmp_wid = new AssemblyAssemblyActionWidget;
+    tmp_wid->label()->setText(QString::number(assembly_step_N));
+    tmp_wid->button()->setText("Scan Module ID");
+    PSSToMaPSA_lay->addWidget(tmp_wid);
+
+    tmp_wid->connect_action(assembly, SLOT(ScanModuleID_start()), SIGNAL(ScanModuleID_finished()));
   }
   // ----------
 

--- a/assembly/assemblyCommon/AssemblyAssemblyV2View.cc
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2View.cc
@@ -133,7 +133,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
     tmp_wid->button()->setText("Scan MaPSA ID");
     PSPToBasep_lay->addWidget(tmp_wid);
 
-    tmp_wid->connect_action(assembly, SLOT(ScanMaPSAID_start()), SIGNAL(ScanMaPSAID_finished()));
+    tmp_wid->connect_action(assembly, SLOT(ScanMaPSAID_start()), SIGNAL(ScanMaPSAID_finished()), SIGNAL(ScanMaPSAID_aborted()));
   }
   // ----------
 
@@ -264,7 +264,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
     tmp_wid->button()->setText("Scan Baseplate ID");
     PSPToBasep_lay->addWidget(tmp_wid);
 
-    tmp_wid->connect_action(assembly, SLOT(ScanBaseplateID_start()), SIGNAL(ScanBaseplateID_finished()));
+    tmp_wid->connect_action(assembly, SLOT(ScanBaseplateID_start()), SIGNAL(ScanBaseplateID_finished()), SIGNAL(ScanBaseplateID_aborted()));
   }
   // ----------
 
@@ -476,7 +476,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
     tmp_wid->button()->setText("Scan PS-s ID");
     PSSToSpacers_lay->addWidget(tmp_wid);
 
-    tmp_wid->connect_action(assembly, SLOT(ScanPSSID_start()), SIGNAL(ScanPSSID_finished()));
+    tmp_wid->connect_action(assembly, SLOT(ScanPSSID_start()), SIGNAL(ScanPSSID_finished()), SIGNAL(ScanPSSID_aborted()));
   }
   // ----------
 
@@ -1115,7 +1115,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
     tmp_wid->button()->setText("Scan Module ID");
     PSSToMaPSA_lay->addWidget(tmp_wid);
 
-    tmp_wid->connect_action(assembly, SLOT(ScanModuleID_start()), SIGNAL(ScanModuleID_finished()));
+    tmp_wid->connect_action(assembly, SLOT(ScanModuleID_start()), SIGNAL(ScanModuleID_finished()), SIGNAL(ScanModuleID_aborted()));
   }
   // ----------
 
@@ -1128,7 +1128,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
     tmp_wid->button()->setText("Push Assembly Information to Database");
     PSSToMaPSA_lay->addWidget(tmp_wid);
 
-    tmp_wid->connect_action(assembly, SLOT(PushToDB_start()), SIGNAL(PushToDB_finished()));
+    tmp_wid->connect_action(assembly, SLOT(PushToDB_start()), SIGNAL(PushToDB_finished()), SIGNAL(PushToDB_aborted()));
   }
   // ----------
 

--- a/assembly/assemblyCommon/AssemblyAssemblyV2View.cc
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2View.cc
@@ -1119,6 +1119,19 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
   }
   // ----------
 
+  // step: Push IDs to Database
+  {
+    ++assembly_step_N;
+
+    AssemblyAssemblyActionWidget* tmp_wid = new AssemblyAssemblyActionWidget;
+    tmp_wid->label()->setText(QString::number(assembly_step_N));
+    tmp_wid->button()->setText("Push Assembly Information to Database");
+    PSSToMaPSA_lay->addWidget(tmp_wid);
+
+    tmp_wid->connect_action(assembly, SLOT(PushToDB_start()), SIGNAL(PushToDB_finished()));
+  }
+  // ----------
+
   // step: Remove PS Module from Assembly Platform
   {
     ++assembly_step_N;

--- a/assembly/assemblyCommon/AssemblyAssemblyV2View.cc
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2View.cc
@@ -19,7 +19,6 @@
 
 #include <AssemblyAssemblyV2.h>
 #include <AssemblyAssemblyV2View.h>
-#include <AssemblyAssemblyActionWidget.h>
 #include <AssemblyAssemblyTextWidget.h>
 
 #include <AssemblyUtilities.h>
@@ -30,6 +29,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
  , wid_PSPToBasep_(nullptr)
  , wid_PSSToSpacers_(nullptr)
  , wid_PSSToMaPSA_(nullptr)
+ , push_to_db_wid_(nullptr)
  , baseplate_id_lineed_(nullptr)
  , mapsa_id_lineed_(nullptr)
  , pss_id_lineed_(nullptr)
@@ -108,6 +108,9 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
 
   push_to_db_button_ = new QPushButton("Push to database");
   opts_lay->addWidget(push_to_db_button_);
+
+  connect(push_to_db_button_, SIGNAL(clicked()), assembly, SLOT(PushToDB_start()));
+  connect(assembly, SIGNAL(PushToDB_finished()), this, SLOT(disable_DB()));
 
   //// -----------------------------------------------
 
@@ -1123,12 +1126,12 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
   {
     ++assembly_step_N;
 
-    AssemblyAssemblyActionWidget* tmp_wid = new AssemblyAssemblyActionWidget;
-    tmp_wid->label()->setText(QString::number(assembly_step_N));
-    tmp_wid->button()->setText("Push Assembly Information to Database");
-    PSSToMaPSA_lay->addWidget(tmp_wid);
+    push_to_db_wid_ = new AssemblyAssemblyActionWidget;
+    push_to_db_wid_->label()->setText(QString::number(assembly_step_N));
+    push_to_db_wid_->button()->setText("Push Assembly Information to Database");
+    PSSToMaPSA_lay->addWidget(push_to_db_wid_);
 
-    tmp_wid->connect_action(assembly, SLOT(PushToDB_start()), SIGNAL(PushToDB_finished()), SIGNAL(PushToDB_aborted()));
+    push_to_db_wid_->connect_action(assembly, SLOT(PushToDB_start()), SIGNAL(PushToDB_finished()), SIGNAL(PushToDB_aborted()));
   }
   // ----------
 
@@ -1147,6 +1150,12 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
 
   PSSToMaPSA_lay->addStretch(1);
   //// -----------------------------------------------
+}
+
+void AssemblyAssemblyV2View::disable_DB()
+{
+    push_to_db_button_->setEnabled(false);
+    push_to_db_wid_->disable_action();
 }
 
 //-- Information about this tab in GUI

--- a/assembly/assemblyCommon/AssemblyAssemblyV2View.h
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2View.h
@@ -46,7 +46,9 @@ class AssemblyAssemblyV2View : public QWidget
   QLineEdit* baseplate_id_lineed_;
   QLineEdit* mapsa_id_lineed_;
   QLineEdit* pss_id_lineed_;
-  QLineEdit* glue_id_lineed_;
+  QLineEdit* glue1_id_lineed_;
+  QLineEdit* glue2_id_lineed_;
+  QLineEdit* glue3_id_lineed_;
   QLineEdit* module_id_lineed_;
   QPushButton* push_to_db_button_;
 

--- a/assembly/assemblyCommon/AssemblyAssemblyV2View.h
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2View.h
@@ -17,6 +17,8 @@
 #include <QWidget>
 #include <QCheckBox>
 #include <QMessageBox>
+#include <QLineEdit>
+#include <QPushButton>
 
 class AssemblyAssemblyV2View : public QWidget
 {
@@ -35,6 +37,12 @@ class AssemblyAssemblyV2View : public QWidget
   QWidget* wid_PSPToBasep_;
   QWidget* wid_PSSToSpacers_;
   QWidget* wid_PSSToMaPSA_;
+
+  QLineEdit* baseplate_id_lineed_;
+  QLineEdit* mapsa_id_lineed_;
+  QLineEdit* pss_id_lineed_;
+  QLineEdit* module_id_lineed_;
+  QPushButton* push_to_db_button_;
 };
 
 #endif // ASSEMBLYASSEMBLYV2VIEW_H

--- a/assembly/assemblyCommon/AssemblyAssemblyV2View.h
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2View.h
@@ -50,7 +50,7 @@ class AssemblyAssemblyV2View : public QWidget
   QLineEdit* glue2_id_lineed_;
   QLineEdit* glue3_id_lineed_;
   QLineEdit* module_id_lineed_;
-  QPushButton* push_to_db_button_;
+  //QPushButton* push_to_db_button_;
 
 };
 

--- a/assembly/assemblyCommon/AssemblyAssemblyV2View.h
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2View.h
@@ -20,6 +20,8 @@
 #include <QLineEdit>
 #include <QPushButton>
 
+#include <AssemblyAssemblyActionWidget.h>
+
 class AssemblyAssemblyV2View : public QWidget
 {
  Q_OBJECT
@@ -30,6 +32,7 @@ class AssemblyAssemblyV2View : public QWidget
 
  public slots:
   void display_infoTab();
+  void disable_DB();
 
  protected:
   QCheckBox* smartMove_checkbox_;
@@ -38,11 +41,14 @@ class AssemblyAssemblyV2View : public QWidget
   QWidget* wid_PSSToSpacers_;
   QWidget* wid_PSSToMaPSA_;
 
+  AssemblyAssemblyActionWidget* push_to_db_wid_;
+
   QLineEdit* baseplate_id_lineed_;
   QLineEdit* mapsa_id_lineed_;
   QLineEdit* pss_id_lineed_;
   QLineEdit* module_id_lineed_;
   QPushButton* push_to_db_button_;
+
 };
 
 #endif // ASSEMBLYASSEMBLYV2VIEW_H

--- a/assembly/assemblyCommon/AssemblyAssemblyV2View.h
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2View.h
@@ -41,7 +41,9 @@ class AssemblyAssemblyV2View : public QWidget
   QWidget* wid_PSSToSpacers_;
   QWidget* wid_PSSToMaPSA_;
 
-  AssemblyAssemblyActionWidget* push_to_db_wid_;
+  AssemblyAssemblyActionWidget* push_step1_to_db_wid_;
+  AssemblyAssemblyActionWidget* push_step2_to_db_wid_;
+  AssemblyAssemblyActionWidget* push_step3_to_db_wid_;
 
   QLineEdit* baseplate_id_lineed_;
   QLineEdit* mapsa_id_lineed_;

--- a/assembly/assemblyCommon/AssemblyAssemblyV2View.h
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2View.h
@@ -46,6 +46,7 @@ class AssemblyAssemblyV2View : public QWidget
   QLineEdit* baseplate_id_lineed_;
   QLineEdit* mapsa_id_lineed_;
   QLineEdit* pss_id_lineed_;
+  QLineEdit* glue_id_lineed_;
   QLineEdit* module_id_lineed_;
   QPushButton* push_to_db_button_;
 

--- a/assembly/assemblyCommon/CMakeLists.txt
+++ b/assembly/assemblyCommon/CMakeLists.txt
@@ -66,6 +66,8 @@ add_library(AssemblyCommon SHARED
         AssemblyDBLoggerModel.cc
         AssemblyDBLoggerView.cc
         AssemblyStopwatchWidget.cc
+        VDatabase.cc
+        DatabaseDummy.cc
 )
 
 if(CMSTKMODLAB_FAKEUEYE)

--- a/assembly/assemblyCommon/CMakeLists.txt
+++ b/assembly/assemblyCommon/CMakeLists.txt
@@ -67,6 +67,7 @@ add_library(AssemblyCommon SHARED
         AssemblyDBLoggerView.cc
         AssemblyStopwatchWidget.cc
         VDatabase.cc
+        DatabaseDESY.cc
         DatabaseDummy.cc
 )
 
@@ -86,6 +87,7 @@ include_directories(${OPENCV4_INCLUDE_DIRS})
 
 include_directories(${Qt5Core_INCLUDE_DIRS})
 include_directories(${Qt5Widgts_INCLUDE_DIRS})
+include_directories(${Qt5Network_INCLUDE_DIRS})
 include_directories(${Qt5Script_INCLUDE_DIRS})
 include_directories(${Qt5Charts_INCLUDE_DIRS})
 include_directories(${Qt5Svg_INCLUDE_DIRS})
@@ -94,12 +96,14 @@ include_directories(${UEYE_HEADER_DIR})
 
 add_definitions(${Qt5Core_DEFINITIONS})
 add_definitions(${Qt5Widgts_DEFINITIONS})
+add_definitions(${Qt5Network_DEFINITIONS})
 add_definitions(${Qt5Script_DEFINITIONS})
 add_definitions(${Qt5Charts_DEFINITIONS})
 add_definitions(${Qt5Svg_DEFINITIONS})
 
 set(CMAKE_CXX_FLAGS "${Qt5Core_EXECUTABLE_COMPILE_FLAGS}")
 set(CMAKE_CXX_FLAGS "${Qt5Widgts_EXECUTABLE_COMPILE_FLAGS}")
+set(CMAKE_CXX_FLAGS "${Qt5Network_EXECUTABLE_COMPILE_FLAGS}")
 set(CMAKE_CXX_FLAGS "${Qt5Script_EXECUTABLE_COMPILE_FLAGS}")
 set(CMAKE_CXX_FLAGS "${Qt5Charts_EXECUTABLE_COMPILE_FLAGS}")
 set(CMAKE_CXX_FLAGS "${Qt5Svg_EXECUTABLE_COMPILE_FLAGS}")
@@ -115,6 +119,7 @@ INCLUDE_DIRECTORIES(${CMAKE_BINARY_DIR}/common)
 target_link_libraries(AssemblyCommon
         PRIVATE Qt5::Core
         PRIVATE Qt5::Widgets
+        PRIVATE Qt5::Network
         PRIVATE Qt5::Script
         PRIVATE Qt5::Charts
         PRIVATE Qt5::Svg

--- a/assembly/assemblyCommon/CMakeLists.txt
+++ b/assembly/assemblyCommon/CMakeLists.txt
@@ -68,6 +68,7 @@ add_library(AssemblyCommon SHARED
         AssemblyStopwatchWidget.cc
         VDatabase.cc
         DatabaseDESY.cc
+        DatabaseBrown.cc
         DatabaseDummy.cc
 )
 

--- a/assembly/assemblyCommon/DatabaseBrown.cc
+++ b/assembly/assemblyCommon/DatabaseBrown.cc
@@ -1,0 +1,98 @@
+/////////////////////////////////////////////////////////////////////////////////
+//                                                                             //
+//               Copyright (C) 2011-2021 - The DESY CMS Group                  //
+//                           All rights reserved                               //
+//                                                                             //
+//      The CMStkModLab source code is licensed under the GNU GPL v3.0.        //
+//      You have the right to modify and/or redistribute this source code      //
+//      under the terms specified in the license, which may be found online    //
+//      at http://www.gnu.org/licenses or at License.txt.                      //
+//                                                                             //
+/////////////////////////////////////////////////////////////////////////////////
+
+#include <DatabaseBrown.h>
+
+#include <QMessageBox>
+#include <QTextDocumentFragment>
+#include <QFile>
+#include <QTextStream>
+
+#include <nqlogger.h>
+
+DatabaseBrown::DatabaseBrown(QObject *parent, QFileInfo file_path) : VDatabase(parent)
+{
+    m_file_path = file_path;
+    if (!(m_file_path.isDir() && m_file_path.isWritable())){
+        error_message(QString("Path for database file storage is not a writable directory: %1").arg(m_file_path.path()));
+    }
+    error_message(QString("Path for database file storage: %1").arg(m_file_path.canonicalFilePath()));
+}
+
+DatabaseBrown::~DatabaseBrown()
+{
+    // Any connections to close?
+}
+
+
+bool DatabaseBrown::register_module_name(QString module_name, QString operator_name)
+{
+    NQLog("DatabaseBrown", NQLog::Message) << "Could not perform step \"Register module by name\"";
+    error_message(QString("Module %1 already exists in the database (ID: %2). Cannot register another module with this name.").arg(module_name).arg(123));
+    return false;
+}
+
+bool DatabaseBrown::MaPSA_to_BP(QString MaPSA_name, QString BP_name, QString glue_name, QString comment)
+{
+    QFile outfile(m_file_path.canonicalFilePath() + "/PSp.txt");
+    if (!outfile.open(QIODevice::WriteOnly | QIODevice::Text)){
+        error_message(QString("File with name %1 cannot be opened.").arg(outfile.fileName()));
+        return false;
+    }
+
+    QTextStream outstream(&outfile);
+    outstream << MaPSA_name << "\t" << "y" << "\t" << BP_name << "\n";
+
+    outfile.close();
+    return true;
+}
+
+bool DatabaseBrown::PSs_to_spacers(QString PSs_name, QString glue_name, QString comment)
+{
+    QFile outfile(m_file_path.canonicalFilePath() + "/PSs.txt");
+    if (!outfile.open(QIODevice::WriteOnly | QIODevice::Text)){
+        error_message(QString("File with name %1 cannot be opened.").arg(outfile.fileName()));
+        return false;
+    }
+
+    QTextStream outstream(&outfile);
+    outstream << PSs_name << "\t" << "y" << "\n";
+
+    outfile.close();
+    return true;
+}
+
+bool DatabaseBrown::PSs_to_MaPSA(QString module_name, QString MaPSA_name, QString PSs_name, QString glue_name, QString comment)
+{
+    QFile outfile(m_file_path.canonicalFilePath() + "/Module.txt");
+    if (!outfile.open(QIODevice::WriteOnly | QIODevice::Text)){
+        error_message(QString("File with name %1 cannot be opened.").arg(outfile.fileName()));
+        return false;
+    }
+
+    QTextStream outstream(&outfile);
+    outstream << module_name << "\t" << PSs_name << "\t" << MaPSA_name << "\n";
+
+    outfile.close();
+    return true;
+}
+
+void DatabaseBrown::error_message(QString message)
+{
+    NQLog("DatabaseBrown", NQLog::Fatal) << QTextDocumentFragment::fromHtml( message ).toPlainText();
+
+    QMessageBox msgBox;
+    msgBox.setWindowTitle(tr("Warning - Database"));
+    msgBox.setText(message);
+    msgBox.setStandardButtons(QMessageBox::Ok);
+    int ret = msgBox.exec();
+}

--- a/assembly/assemblyCommon/DatabaseBrown.h
+++ b/assembly/assemblyCommon/DatabaseBrown.h
@@ -10,46 +10,36 @@
 //                                                                             //
 /////////////////////////////////////////////////////////////////////////////////
 
-#ifndef VDATABASE_H
-#define VDATABASE_H
+#ifndef DATABASEBROWN_H
+#define DATABASEBROWN_H
 
-#include <unistd.h>
-#include <QObject>
+#include <VDatabase.h>
 
-class VDatabase : public QObject
+#include <QFileInfo>
+
+class DatabaseBrown : public VDatabase
 {
  Q_OBJECT
 
   public:
-      VDatabase(QObject* parent);
-      ~VDatabase();
+      explicit DatabaseBrown(QObject* parent, QFileInfo file_path);
+      ~DatabaseBrown();
 
-      virtual bool register_module_name(QString, QString) = 0;
-      virtual bool MaPSA_to_BP(QString, QString, QString, QString) = 0;
-      virtual bool PSs_to_spacers(QString, QString, QString) = 0;
-      virtual bool PSs_to_MaPSA(QString, QString) = 0;
-      virtual bool PSs_to_MaPSA(QString, QString, QString, QString, QString) = 0;
+      bool register_module_name(QString, QString);
+      bool MaPSA_to_BP(QString, QString, QString="", QString="");
+      bool PSs_to_spacers(QString, QString="", QString="");
+      bool PSs_to_MaPSA(QString, QString, QString, QString="", QString="");
+      bool PSs_to_MaPSA(QString, QString) { return false; };
 
-      virtual bool is_component_available(QString, QString) = 0;
+      bool is_component_available(QString, QString){ return true; };
 
   protected:
 
-      QString module_name_;
-      int module_dbid_;
+      void error_message(QString message);
 
-      QString MaPSA_name_;
-      int MaPSA_dbid_;
+      QFileInfo m_file_path;
 
-      QString PSs_name_;
-      int PSs_dbid_;
-
-      QString BP_name_;
-      int BP_dbid_;
-
-      int Glue1_dbid_;
-      int Glue2_dbid_;
-      int Glue3_dbid_;
 
 };
 
-#endif // VDATABASE_H
+#endif // DATABASEBROWN_H

--- a/assembly/assemblyCommon/DatabaseDESY.cc
+++ b/assembly/assemblyCommon/DatabaseDESY.cc
@@ -51,7 +51,7 @@ bool DatabaseDESY::register_module_name(QString module_name, QString operator_na
     // Check whether module exists in DB - it should not!
     try{
         int return_dbid = get_ID_from_name(module_name, "PS_module");
-        error_message(QString("Module %1 already exists in the database. ID: %2. Cannot register module with this name.").arg(module_name).arg(return_dbid));
+        error_message(QString("Module %1 already exists in the database (ID: %2). Cannot register module with this name.").arg(module_name).arg(return_dbid));
         return false;
     } catch(BadResultException bre){
         error_message("\"register_module_name\" (registering): " + QString::fromUtf8(bre.what()));

--- a/assembly/assemblyCommon/DatabaseDESY.cc
+++ b/assembly/assemblyCommon/DatabaseDESY.cc
@@ -404,10 +404,11 @@ void DatabaseDESY::assign_task(int task_id)
 
     try{
         auto reply_data_assigntask = this->get(request_assigntask);
-        if(reply_data_assigntask.isEmpty()){
-            NQLog("DatabaseDESY", NQLog::Warning) << "Did not receive expected data structure (assign next task).";
+
+        if(!reply_data_assigntask.value("result").toBool()){
             throw BadResultException(QString("\"assign_task\" failed to assign task with ID %1").arg(task_id));
         }
+
         NQLog("DatabaseDESY", NQLog::Message) << "Assigned task with ID " << task_id;
     } catch(BadReplyException bre){
         NQLog("DatabaseDESY", NQLog::Fatal) << "\"assign_task\": " << bre.what();
@@ -425,10 +426,11 @@ void DatabaseDESY::perform_task(int task_id, QJsonObject data_performtask)
 
     try{
         auto reply_data_performtask = this->post(request_performtask, data_performtask);
-        if(reply_data_performtask.isEmpty()){
-            NQLog("DatabaseDESY", NQLog::Warning) << "Did not receive expected data structure (perform task).";
+
+        if(!reply_data_performtask.value("result").toBool()){
             throw BadResultException(QString("\"perform_task\" failed to perform task with ID %1").arg(task_id));
         }
+
         NQLog("DatabaseDESY", NQLog::Message) << "Performed task with ID " << task_id;
     } catch(BadReplyException bre){
         NQLog("DatabaseDESY", NQLog::Fatal) << "\"perform_task\": " << bre.what();

--- a/assembly/assemblyCommon/DatabaseDESY.cc
+++ b/assembly/assemblyCommon/DatabaseDESY.cc
@@ -128,6 +128,18 @@ bool DatabaseDESY::MaPSA_to_BP(QString MaPSA_name, QString BP_name, QString glue
         MaPSA_dbid_ = return_dbid;
         MaPSA_name_ = MaPSA_name;
 
+        // Get BP_dbib_ from BP_name_
+        int return_MaPSA_dbid = get_ID_from_name(BP_name, "PS%20Baseplate");
+        NQLog("DatabaseDESY", NQLog::Message) << "Obtained Baseplate ID (\"Glue MaPSA to Baseplate\"): " << return_MaPSA_dbid;
+        BP_dbid_ = return_MaPSA_dbid;
+        BP_name_ = BP_name;
+
+        // Get Glue1_dbib_ from glue_name
+        auto return_glue_dbid = validate_glue_mixture(glue_name);
+        NQLog("DatabaseDESY", NQLog::Message) << "Obtained Glue ID (\"Glue MaPSA to Baseplate\"): " << return_glue_dbid;
+        Glue1_dbid_ = return_glue_dbid;
+
+
         // // Take MaPSA
         // Get Task ID
         int task_id = get_next_task("take_mapsa");
@@ -146,26 +158,15 @@ bool DatabaseDESY::MaPSA_to_BP(QString MaPSA_name, QString BP_name, QString glue
         NQLog("DatabaseDESY", NQLog::Message) << "Performed task (\"Take MaPSA\") with ID " << task_id;
 
     } catch(BadResultException bre){
-        NQLog("DatabaseDESY", NQLog::Warning) << "Could not perform step \"Take MaPSA\": " << bre.what();
+        error_message("Could not perform step \"Take MaPSA\": " + QString::fromUtf8(bre.what()));
         return false;
     } catch(PartDoesNotExistException pdnee){
-        NQLog("DatabaseDESY", NQLog::Warning) << "Could not perform step \"Take MaPSA\": " << pdnee.what();
+        error_message("Could not perform step \"Take MaPSA\": " + QString::fromUtf8(pdnee.what()));
         return false;
     }
 
     try{
         // // Glue MaPSA to BP
-        // Get BP_dbib_ from BP_name_
-        int return_MaPSA_dbid = get_ID_from_name(BP_name, "PS%20Baseplate");
-        NQLog("DatabaseDESY", NQLog::Message) << "Obtained Baseplate ID (\"Glue MaPSA to Baseplate\"): " << return_MaPSA_dbid;
-        BP_dbid_ = return_MaPSA_dbid;
-        BP_name_ = BP_name;
-
-        // Get Glue1_dbib_ from glue_name
-        auto return_glue_dbid = validate_glue_mixture(glue_name);
-        NQLog("DatabaseDESY", NQLog::Message) << "Obtained Glue ID (\"Glue MaPSA to Baseplate\"): " << return_glue_dbid;
-        Glue1_dbid_ = return_glue_dbid;
-
         // Get Task ID
         int task_id = get_next_task("glue_mapsa_to_baseplate");
         NQLog("DatabaseDESY", NQLog::Message) << "Obtained next task (\"Glue MaPSA to Baseplate\") with ID " << task_id;
@@ -203,6 +204,11 @@ bool DatabaseDESY::PSs_to_spacers(QString PSs_name, QString glue_name, QString c
         PSs_dbid_ = return_dbid;
         PSs_name_ = PSs_name;
 
+        // Get Glue2_dbib_ from glue_name
+        auto return_glue_dbid = validate_glue_mixture(glue_name);
+        NQLog("DatabaseDESY", NQLog::Message) << "Obtained Glue ID (\"Glue PSs to Spacers\"): " << return_glue_dbid;
+        Glue2_dbid_ = return_glue_dbid;
+
         // // Take PSs
         // Get Task ID
         int task_id = get_next_task("take_pss");
@@ -221,20 +227,15 @@ bool DatabaseDESY::PSs_to_spacers(QString PSs_name, QString glue_name, QString c
         NQLog("DatabaseDESY", NQLog::Message) << "Performed task (\"Take PSs\") with ID " << task_id;
 
     } catch(BadResultException bre){
-        NQLog("DatabaseDESY", NQLog::Warning) << "Could not perform step \"Take PSs\": " << bre.what();
+        error_message("Could not perform step \"Take PSs\": " + QString::fromUtf8(bre.what()));
         return false;
     } catch(PartDoesNotExistException pdnee){
-        NQLog("DatabaseDESY", NQLog::Warning) << "Could not perform step \"Take PSs\": " << pdnee.what();
+        error_message("Could not perform step \"Take PSs\": " + QString::fromUtf8(pdnee.what()));
         return false;
     }
 
     try{
         // // Glue PSs to Spacers
-        // Get Glue2_dbib_ from glue_name
-        auto return_glue_dbid = validate_glue_mixture(glue_name);
-        NQLog("DatabaseDESY", NQLog::Message) << "Obtained Glue ID (\"Glue PSs to Spacers\"): " << return_glue_dbid;
-        Glue2_dbid_ = return_glue_dbid;
-
         // Get Task ID
         int task_id = get_next_task("glue_pss_to_spacers");
         NQLog("DatabaseDESY", NQLog::Message) << "Obtained next task (\"Glue PSs to Spacers\") with ID " << task_id;

--- a/assembly/assemblyCommon/DatabaseDESY.cc
+++ b/assembly/assemblyCommon/DatabaseDESY.cc
@@ -361,7 +361,7 @@ int DatabaseDESY::get_next_task()
 {
     QUrl url_gettask = base_url_;
     url_gettask.setPath("/ph2production/api/task/");
-    url_gettask.setQuery(QString("?status=NEW&process=%1").arg(process_dbid_));
+    url_gettask.setQuery(QString("status=NEW&process=%1").arg(process_dbid_));
 
     auto request_gettask = base_request_;
     request_gettask.setUrl(url_gettask);
@@ -429,7 +429,7 @@ int DatabaseDESY::get_ID_from_name(QString part_name)
 {
     QUrl url_getid = base_url_;
     url_getid.setPath("/api/part/");
-    url_getid.setQuery(QString("?name=%1").arg(part_name));
+    url_getid.setQuery(QString("name=%1").arg(part_name));
 
     auto request_getid = base_request_;
     request_getid.setUrl(url_getid);

--- a/assembly/assemblyCommon/DatabaseDESY.cc
+++ b/assembly/assemblyCommon/DatabaseDESY.cc
@@ -177,7 +177,7 @@ bool DatabaseDESY::MaPSA_to_BP(QString MaPSA_name, QString BP_name, QString glue
 
         // Perform Task
         QJsonObject data_perform;
-        data_perform["comment"] = "";
+        data_perform["comment"] = comment;
         data_perform["part"] = QJsonValue(BP_dbid_);
         data_perform["glue"] = QJsonValue(Glue1_dbid_);
 
@@ -246,7 +246,7 @@ bool DatabaseDESY::PSs_to_spacers(QString PSs_name, QString glue_name, QString c
 
         // Perform Task
         QJsonObject data_perform;
-        data_perform["comment"] = "";
+        data_perform["comment"] = comment;
         data_perform["glue"] = QJsonValue(Glue2_dbid_);
 
         perform_task(task_id, data_perform);

--- a/assembly/assemblyCommon/DatabaseDESY.cc
+++ b/assembly/assemblyCommon/DatabaseDESY.cc
@@ -1,0 +1,435 @@
+/////////////////////////////////////////////////////////////////////////////////
+//                                                                             //
+//               Copyright (C) 2011-2021 - The DESY CMS Group                  //
+//                           All rights reserved                               //
+//                                                                             //
+//      The CMStkModLab source code is licensed under the GNU GPL v3.0.        //
+//      You have the right to modify and/or redistribute this source code      //
+//      under the terms specified in the license, which may be found online    //
+//      at http://www.gnu.org/licenses or at License.txt.                      //
+//                                                                             //
+/////////////////////////////////////////////////////////////////////////////////
+
+#include <DatabaseDESY.h>
+
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonValue>
+#include <QJsonArray>
+#include <QByteArray>
+#include <QNetworkReply>
+#include <QEventLoop>
+
+#include <iostream>
+#include <nqlogger.h>
+
+DatabaseDESY::DatabaseDESY(QObject *parent, QString base_url, QString token) : VDatabase(parent)
+{
+    // Initialise stuff!
+    network_access_mgr_ = new QNetworkAccessManager(this);
+
+    network_access_mgr_->setTransferTimeout(5000);
+
+    base_url_ = QUrl(base_url);
+
+    base_request_ = QNetworkRequest();
+    base_request_.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
+    base_request_.setRawHeader("Authorization", ("Token " + token).toUtf8());
+
+    NQLog("DatabaseDESY", NQLog::Debug) << "constructed";
+}
+
+DatabaseDESY::~DatabaseDESY()
+{
+}
+
+
+bool DatabaseDESY::register_module_name(QString module_name, QString operator_name)
+{
+    // Check whether module exists in DB - it should not!
+    try{
+        int return_dbid = get_ID_from_name(module_name);
+        NQLog("DatabaseDESY", NQLog::Message) << "Module " << module_name << " exists in the database. ID: " << return_dbid;
+        return false;
+    } catch(BadResultException bre){
+        NQLog("DatabaseDESY", NQLog::Message) << "Module " << module_name << " does not exist in the database (usually good!).";
+    }
+
+    // Register Module
+    QUrl url_register = base_url_;
+    url_register.setPath("/api/part/");
+
+    auto request_register = base_request_;
+    request_register.setUrl(url_register);
+
+    QJsonObject data_register;
+    data_register["name"] = module_name;
+    data_register["group"] = "Production";
+    data_register["structure"] = "PS_module";
+    data_register["manufacturer"] = "DESY";
+    data_register["contact"] = operator_name;
+    data_register["date"] = QDateTime::currentDateTime().toString("yyyy-MM-dd hh:mm:ss");
+
+    try{
+        auto reply_data_register = this->post(request_register, data_register);
+
+        if(reply_data_register.isEmpty()){
+            NQLog("DatabaseDESY", NQLog::Warning) << "Did not receive expected data structure (register module).";
+            return false;
+        }
+
+        module_dbid_ = reply_data_register.value("id").toInt();
+        module_name_ = module_name;
+        NQLog("DatabaseDESY", NQLog::Message) << "Registered Module with name " << module_name_ << " and ID " << module_dbid_;
+
+    } catch(BadReplyException bre){
+        NQLog("DatabaseDESY", NQLog::Fatal) << "\"register_module_name\" (registering): " << bre.what();
+        return false;
+    }
+
+    // Start assembly process
+    QUrl url_start = base_url_;
+    url_start.setPath("/ph2production/psmoduleprocess/start");
+
+    auto request_start = base_request_;
+    request_start.setUrl(url_start);
+
+    QJsonObject data_start;
+    data_start["parent_part"] = QJsonValue(module_dbid_);
+
+    try{
+        auto reply_data_start = this->post(request_start, data_start);
+        if(reply_data_start.isEmpty()){
+            NQLog("DatabaseDESY", NQLog::Warning) << "Did not receive expected data structure (start process).";
+            return false;
+        }
+
+        process_dbid_ = reply_data_start.value("process_id").toInt();
+        NQLog("DatabaseDESY", NQLog::Message) << "Started assembly process with ID " << process_dbid_;
+    } catch(BadReplyException bre){
+        NQLog("DatabaseDESY", NQLog::Fatal) << "\"register_module_name\": (start assembly process) " << bre.what();
+        return false;
+    }
+
+    return true;
+}
+
+bool DatabaseDESY::MaPSA_to_BP(QString MaPSA_name, QString BP_name, QString glue_name, QString comment)
+{
+    try{
+        // Get MaPSA_dbib_ from MaPSA_name_
+        int return_dbid = get_ID_from_name(MaPSA_name);
+        NQLog("DatabaseDESY", NQLog::Message) << "Obtained MaPSA ID (\"Take MaPSA\"): " << return_dbid;
+        MaPSA_dbid_ = return_dbid;
+        MaPSA_name_ = MaPSA_name;
+
+        // // Take MaPSA
+        // Get Task ID
+        int task_id = get_next_task();
+        NQLog("DatabaseDESY", NQLog::Message) << "Obtained next task (\"Take MaPSA\") with ID " << task_id;
+
+        // Assign Task
+        assign_task(task_id);
+        NQLog("DatabaseDESY", NQLog::Message) << "Assigned next task (\"Take MaPSA\") with ID " << task_id;
+
+        // Perform Task
+        QJsonObject data_perform;
+        data_perform["comment"] = comment;
+        data_perform["part"] = QJsonValue(MaPSA_dbid_);
+
+        perform_task(task_id, data_perform);
+        NQLog("DatabaseDESY", NQLog::Message) << "Performed task (\"Take MaPSA\") with ID " << task_id;
+
+    } catch(BadResultException bre){
+        NQLog("DatabaseDESY", NQLog::Warning) << "Could not perform step \"Take MaPSA\": " << bre.what();
+        return false;
+    }
+
+    try{
+        // // Glue MaPSA to BP
+        // Get BP_dbib_ from BP_name_
+        int return_MaPSA_dbid = get_ID_from_name(BP_name);
+        NQLog("DatabaseDESY", NQLog::Message) << "Obtained Baseplate ID (\"Glue MaPSA to Baseplate\"): " << return_MaPSA_dbid;
+        BP_dbid_ = return_MaPSA_dbid;
+        BP_name_ = BP_name;
+
+        // Get Glue1_dbib_ from glue_name
+        int return_glue_dbid = get_ID_from_name(glue_name);
+        NQLog("DatabaseDESY", NQLog::Message) << "Obtained Glue ID (\"Glue MaPSA to Baseplate\"): " << return_glue_dbid;
+        Glue1_dbid_ = return_glue_dbid;
+
+        // Get Task ID
+        int task_id = get_next_task();
+        NQLog("DatabaseDESY", NQLog::Message) << "Obtained next task (\"Glue MaPSA to Baseplate\") with ID " << task_id;
+
+        // Assign Task
+        assign_task(task_id);
+        NQLog("DatabaseDESY", NQLog::Message) << "Assigned next task (\"Glue MaPSA to Baseplate\") with ID " << task_id;
+
+        // Perform Task
+        QJsonObject data_perform;
+        data_perform["comment"] = "";
+        data_perform["part"] = QJsonValue(BP_dbid_);
+        data_perform["glue"] = QJsonValue(Glue1_dbid_);
+
+        perform_task(task_id, data_perform);
+        NQLog("DatabaseDESY", NQLog::Message) << "Performed task (\"Glue MaPSA to Baseplate\") with ID " << task_id;
+
+    } catch(BadResultException bre){
+        NQLog("DatabaseDESY", NQLog::Warning) << "Could not perform step \"Glue MaPSA to Baseplate\": " << bre.what();
+        return false;
+    }
+
+    return true;
+}
+
+bool DatabaseDESY::PSs_to_spacers(QString PSs_name, QString glue_name, QString comment)
+{
+    try{
+        // Get PSs_dbib_ from PSs_name_
+        int return_dbid = get_ID_from_name(PSs_name);
+        NQLog("DatabaseDESY", NQLog::Message) << "Obtained PSs ID (\"Take PSs\"): " << return_dbid;
+        PSs_dbid_ = return_dbid;
+        PSs_name_ = PSs_name;
+
+        // // Take PSs
+        // Get Task ID
+        int task_id = get_next_task();
+        NQLog("DatabaseDESY", NQLog::Message) << "Obtained next task (\"Take PSs\") with ID " << task_id;
+
+        // Assign Task
+        assign_task(task_id);
+        NQLog("DatabaseDESY", NQLog::Message) << "Assigned next task (\"Take PSs\") with ID " << task_id;
+
+        // Perform Task
+        QJsonObject data_perform;
+        data_perform["comment"] = comment;
+        data_perform["part"] = QJsonValue(PSs_dbid_);
+
+        perform_task(task_id, data_perform);
+        NQLog("DatabaseDESY", NQLog::Message) << "Performed task (\"Take PSs\") with ID " << task_id;
+
+    } catch(BadResultException bre){
+        NQLog("DatabaseDESY", NQLog::Warning) << "Could not perform step \"Take PSs\": " << bre.what();
+        return false;
+    }
+
+    try{
+        // // Glue PSs to Spacers
+        // Get Glue2_dbib_ from glue_name
+        int return_dbid = get_ID_from_name(glue_name);
+        NQLog("DatabaseDESY", NQLog::Message) << "Obtained Glue ID (\"Glue PSs to Spacers\"): " << return_dbid;
+        Glue2_dbid_ = return_dbid;
+
+        // Get Task ID
+        int task_id = get_next_task();
+        NQLog("DatabaseDESY", NQLog::Message) << "Obtained next task (\"Glue PSs to Spacers\") with ID " << task_id;
+
+        // Assign Task
+        assign_task(task_id);
+        NQLog("DatabaseDESY", NQLog::Message) << "Assigned next task (\"Glue PSs to Spacers\") with ID " << task_id;
+
+        // Perform Task
+        QJsonObject data_perform;
+        data_perform["comment"] = "";
+        data_perform["glue"] = QJsonValue(Glue2_dbid_);
+
+        perform_task(task_id, data_perform);
+        NQLog("DatabaseDESY", NQLog::Message) << "Performed task (\"Glue PSs to Spacers\") with ID " << task_id;
+
+    } catch(BadResultException bre){
+        NQLog("DatabaseDESY", NQLog::Warning) << "Could not perform step \"Glue PSs to Spacers\": " << bre.what();
+        return false;
+    }
+
+    return true;
+}
+
+bool DatabaseDESY::PSs_to_MaPSA(QString glue_name, QString comment)
+{
+    try{
+        // // Glue PSs to MaPSA
+        // Get Glue3_dbib_ from glue_name
+        int return_dbid = get_ID_from_name(glue_name);
+        NQLog("DatabaseDESY", NQLog::Message) << "Obtained Glue ID (\"Glue PSs to MaPSA\"): " << return_dbid;
+        Glue3_dbid_ = return_dbid;
+
+        // Get Task ID
+        int task_id = get_next_task();
+        NQLog("DatabaseDESY", NQLog::Message) << "Obtained next task (\"Glue PSs to MaPSA\") with ID " << task_id;
+
+        // Assign Task
+        assign_task(task_id);
+        NQLog("DatabaseDESY", NQLog::Message) << "Assigned next task (\"Glue PSs to MaPSA\") with ID " << task_id;
+
+        // Perform Task
+        QJsonObject data_perform;
+        data_perform["comment"] = comment;
+        data_perform["glue"] = QJsonValue(Glue3_dbid_);
+
+        perform_task(task_id, data_perform);
+        NQLog("DatabaseDESY", NQLog::Message) << "Performed task (\"Glue PSs to MaPSA\") with ID " << task_id;
+
+    } catch(BadResultException bre){
+        NQLog("DatabaseDESY", NQLog::Warning) << "Could not perform step \"Glue PSs to MaPSA\": " << bre.what();
+        return false;
+    }
+
+    return true;
+}
+
+QJsonObject DatabaseDESY::post(QNetworkRequest request, QJsonObject json_object)
+{
+    QJsonDocument json_doc(json_object);
+    QByteArray bytedata = json_doc.toJson();
+
+    QNetworkReply *reply = network_access_mgr_->post(request, bytedata);
+
+    QEventLoop loop;
+    connect(reply, SIGNAL(finished()), &loop, SLOT(quit()));
+    loop.exec();
+
+    if(reply->error() == QNetworkReply::NoError){
+        auto read_message = reply->readAll();
+
+        QJsonDocument reply_document = QJsonDocument::fromJson(read_message);
+        QJsonObject reply_object = reply_document.object();
+
+        return reply_object;
+    }
+    else{
+        QString err = reply->errorString();
+        QString full_reply = QString::fromUtf8(reply->readAll());
+        NQLog("DatabaseDESY", NQLog::Warning) << "post - returned error message: " << err;
+        NQLog("DatabaseDESY", NQLog::Warning) << "post - replied: " << full_reply;
+
+        throw BadReplyException(err, full_reply);
+    }
+
+    reply->deleteLater();
+    return QJsonObject();
+}
+
+QJsonObject DatabaseDESY::get(QNetworkRequest request)
+{
+    QNetworkReply *reply = network_access_mgr_->get(request);
+
+    QEventLoop loop;
+    connect(reply, SIGNAL(finished()), &loop, SLOT(quit()));
+    loop.exec();
+
+    if(reply->error() == QNetworkReply::NoError){
+        auto read_message = reply->readAll();
+
+        QJsonDocument reply_document = QJsonDocument::fromJson(read_message);
+        QJsonObject reply_object = reply_document.object();
+
+        return reply_object;
+    }
+    else{
+        QString err = reply->errorString();
+        QString full_reply = QString::fromUtf8(reply->readAll());
+        NQLog("DatabaseDESY", NQLog::Warning) << "get - returned error message: " << err;
+        NQLog("DatabaseDESY", NQLog::Warning) << "get - replied: " << full_reply;
+
+        throw BadReplyException(err, full_reply);
+    }
+
+    reply->deleteLater();
+    return QJsonObject();
+}
+
+int DatabaseDESY::get_next_task()
+{
+    QUrl url_gettask = base_url_;
+    url_gettask.setPath("/ph2production/api/task/");
+    url_gettask.setQuery(QString("?status=NEW&process=%1").arg(process_dbid_));
+
+    auto request_gettask = base_request_;
+    request_gettask.setUrl(url_gettask);
+
+    try{
+        auto reply_data_gettask = this->get(request_gettask);
+        if(reply_data_gettask.isEmpty()){
+            NQLog("DatabaseDESY", NQLog::Warning) << "Did not receive expected data structure (get next task).";
+            throw BadResultException("\"get_next_task\" failed to obtain task ID - DB returned empty object.");
+        }
+
+        auto results_object = reply_data_gettask.value("results").toArray().at(0).toObject();
+        int task_id = results_object.value("id").toInt();
+        NQLog("DatabaseDESY", NQLog::Message) << "Obtained task with ID " << task_id;
+        return task_id;
+    } catch(BadReplyException bre){
+        NQLog("DatabaseDESY", NQLog::Fatal) << "\"get_next_task\": " << bre.what();
+        throw BadResultException("\"get_next_task\" failed to obtain task ID - received bad reply from DB.");
+    }
+}
+
+void DatabaseDESY::assign_task(int task_id)
+{
+    QUrl url_assigntask = base_url_;
+    url_assigntask.setPath(QString("/ph2production/task/%1/assign").arg(task_id));
+
+    auto request_assigntask = base_request_;
+    request_assigntask.setUrl(url_assigntask);
+
+    try{
+        auto reply_data_assigntask = this->get(request_assigntask);
+        if(reply_data_assigntask.isEmpty()){
+            NQLog("DatabaseDESY", NQLog::Warning) << "Did not receive expected data structure (assign next task).";
+            throw BadResultException("\"assign_task\" failed to assign task with ID " + std::to_string(task_id));
+        }
+        NQLog("DatabaseDESY", NQLog::Message) << "Assigned task with ID " << task_id;
+    } catch(BadReplyException bre){
+        NQLog("DatabaseDESY", NQLog::Fatal) << "\"assign_task\": " << bre.what();
+        throw BadResultException("\"assign_task\" failed to assign task with ID - received bad reply from DB.");
+    }
+}
+
+void DatabaseDESY::perform_task(int task_id, QJsonObject data_performtask)
+{
+    QUrl url_performtask = base_url_;
+    url_performtask.setPath(QString("/ph2production/task/%1/perform").arg(task_id));
+
+    auto request_performtask = base_request_;
+    request_performtask.setUrl(url_performtask);
+
+    try{
+        auto reply_data_performtask = this->post(request_performtask, data_performtask);
+        if(reply_data_performtask.isEmpty()){
+            NQLog("DatabaseDESY", NQLog::Warning) << "Did not receive expected data structure (perform task).";
+            throw BadResultException("\"perform_task\" failed to perform task with ID " + std::to_string(task_id));
+        }
+        NQLog("DatabaseDESY", NQLog::Message) << "Performed task with ID " << task_id;
+    } catch(BadReplyException bre){
+        NQLog("DatabaseDESY", NQLog::Fatal) << "\"perform_task\": " << bre.what();
+        throw BadResultException("\"perform_task\" failed to perform task with ID - received bad reply from DB.");
+    }
+}
+
+int DatabaseDESY::get_ID_from_name(QString part_name)
+{
+    QUrl url_getid = base_url_;
+    url_getid.setPath("/api/part/");
+    url_getid.setQuery(QString("?name=%1").arg(part_name));
+
+    auto request_getid = base_request_;
+    request_getid.setUrl(url_getid);
+
+    try{
+        auto reply_data_getid = this->get(request_getid);
+        if(reply_data_getid.isEmpty()){
+            NQLog("DatabaseDESY", NQLog::Warning) << "Could not find part with name " << part_name;
+            throw BadResultException("\"get_ID_from_name\" failed to get ID from part " + part_name.toStdString());
+        }
+
+        auto results_object = reply_data_getid.value("results").toArray().at(0).toObject();
+        int part_id = results_object.value("id").toInt();
+        NQLog("DatabaseDESY", NQLog::Message) << "Part " << part_name << " found. ID: " << part_id;
+
+        return part_id;
+    } catch(BadReplyException bre){
+        NQLog("DatabaseDESY", NQLog::Fatal) << "\"get_ID_from_name\": " << bre.what();
+        throw BadResultException("\"get_ID_from_name\" failed get ID from part " + part_name.toStdString() + " - received bad reply from DB.");
+    }
+}

--- a/assembly/assemblyCommon/DatabaseDESY.h
+++ b/assembly/assemblyCommon/DatabaseDESY.h
@@ -68,10 +68,11 @@ class BadReplyException : public std::exception {
 class BadResultException : public std::exception {
   private:
       QString message;
+      std::string return_message;
   public:
-      BadResultException(QString msg) : message(msg) {}
+      BadResultException(QString msg) : message(std::move(msg)) {}
       const char* what () {
-          auto return_message = "Failed to perform DB task: " + message.toStdString();
+          return_message = "Failed to perform DB task: " + message.toStdString();
           return return_message.c_str();
       }
 };
@@ -79,10 +80,11 @@ class BadResultException : public std::exception {
 class PartDoesNotExistException : public std::exception {
   private:
       QString message;
+      std::string return_message;
   public:
-      PartDoesNotExistException(QString msg) : message(msg) {}
+      PartDoesNotExistException(QString msg) : message(std::move(msg)) {}
       const char* what () {
-          auto return_message = "Required part does not exist: " + message.toStdString();
+          return_message = "Required part does not exist: " + message.toStdString();
           return return_message.c_str();
       }
 };

--- a/assembly/assemblyCommon/DatabaseDESY.h
+++ b/assembly/assemblyCommon/DatabaseDESY.h
@@ -41,6 +41,7 @@ class DatabaseDESY : public VDatabase
       void assign_task(int task_id);
       void perform_task(int task_id, QJsonObject data);
       int get_ID_from_name(QString part_name);
+      int validate_glue_mixture(QString glue_name);
 
       QNetworkAccessManager* network_access_mgr_;
 

--- a/assembly/assemblyCommon/DatabaseDESY.h
+++ b/assembly/assemblyCommon/DatabaseDESY.h
@@ -32,6 +32,8 @@ class DatabaseDESY : public VDatabase
       bool PSs_to_spacers(QString, QString, QString="");
       bool PSs_to_MaPSA(QString, QString);
 
+      bool is_component_available(QString, QString="");
+
   protected:
 
       QJsonObject post(QNetworkRequest request, QJsonObject json_object);

--- a/assembly/assemblyCommon/DatabaseDESY.h
+++ b/assembly/assemblyCommon/DatabaseDESY.h
@@ -37,7 +37,7 @@ class DatabaseDESY : public VDatabase
       QJsonObject post(QNetworkRequest request, QJsonObject json_object);
       QJsonObject get(QNetworkRequest request);
 
-      int get_next_task();
+      int get_next_task(QString task_name);
       void assign_task(int task_id);
       void perform_task(int task_id, QJsonObject data);
       int get_ID_from_name(QString part_name, QString structure_name="");

--- a/assembly/assemblyCommon/DatabaseDESY.h
+++ b/assembly/assemblyCommon/DatabaseDESY.h
@@ -1,0 +1,77 @@
+/////////////////////////////////////////////////////////////////////////////////
+//                                                                             //
+//               Copyright (C) 2011-2021 - The DESY CMS Group                  //
+//                           All rights reserved                               //
+//                                                                             //
+//      The CMStkModLab source code is licensed under the GNU GPL v3.0.        //
+//      You have the right to modify and/or redistribute this source code      //
+//      under the terms specified in the license, which may be found online    //
+//      at http://www.gnu.org/licenses or at License.txt.                      //
+//                                                                             //
+/////////////////////////////////////////////////////////////////////////////////
+
+#ifndef DATABASEDESY_H
+#define DATABASEDESY_H
+
+#include <VDatabase.h>
+
+#include <QNetworkAccessManager>
+#include <QNetworkRequest>
+#include <QJsonObject>
+
+class DatabaseDESY : public VDatabase
+{
+ Q_OBJECT
+
+  public:
+      explicit DatabaseDESY(QObject* parent, QString base_url, QString token);
+      ~DatabaseDESY();
+
+      bool register_module_name(QString, QString);
+      bool MaPSA_to_BP(QString, QString, QString, QString="");
+      bool PSs_to_spacers(QString, QString, QString="");
+      bool PSs_to_MaPSA(QString, QString);
+
+  protected:
+
+      QJsonObject post(QNetworkRequest request, QJsonObject json_object);
+      QJsonObject get(QNetworkRequest request);
+
+      int get_next_task();
+      void assign_task(int task_id);
+      void perform_task(int task_id, QJsonObject data);
+      int get_ID_from_name(QString part_name);
+
+      QNetworkAccessManager* network_access_mgr_;
+
+      QUrl base_url_;
+      QNetworkRequest base_request_;
+
+      int process_dbid_;
+
+};
+
+class BadReplyException : public std::exception {
+  private:
+      QString error_message;
+      QString full_reply;
+      std::string return_message;
+  public:
+      BadReplyException(QString msg, QString reply) : error_message(std::move(msg)), full_reply(std::move(reply)) {}
+      const char* what () {
+          return_message = "Bad reply from database.\n\tError: " + error_message.toStdString() + "\n\tFull Reply: " + full_reply.toStdString();
+          return return_message.c_str();
+      }
+};
+
+class BadResultException : public std::exception {
+  private:
+      std::string message;
+  public:
+      BadResultException(std::string msg) : message(msg) {}
+      const char* what () {
+          return ("Failed to perform DB task: " + message).c_str();
+      }
+};
+
+#endif // DATABASEDESY_H

--- a/assembly/assemblyCommon/DatabaseDESY.h
+++ b/assembly/assemblyCommon/DatabaseDESY.h
@@ -66,11 +66,23 @@ class BadReplyException : public std::exception {
 
 class BadResultException : public std::exception {
   private:
-      std::string message;
+      QString message;
   public:
-      BadResultException(std::string msg) : message(msg) {}
+      BadResultException(QString msg) : message(msg) {}
       const char* what () {
-          return ("Failed to perform DB task: " + message).c_str();
+          auto return_message = "Failed to perform DB task: " + message.toStdString();
+          return return_message.c_str();
+      }
+};
+
+class PartDoesNotExistException : public std::exception {
+  private:
+      QString message;
+  public:
+      PartDoesNotExistException(QString msg) : message(msg) {}
+      const char* what () {
+          auto return_message = "Required part does not exist: " + message.toStdString();
+          return return_message.c_str();
       }
 };
 

--- a/assembly/assemblyCommon/DatabaseDESY.h
+++ b/assembly/assemblyCommon/DatabaseDESY.h
@@ -40,7 +40,7 @@ class DatabaseDESY : public VDatabase
       int get_next_task();
       void assign_task(int task_id);
       void perform_task(int task_id, QJsonObject data);
-      int get_ID_from_name(QString part_name);
+      int get_ID_from_name(QString part_name, QString structure_name="");
       int validate_glue_mixture(QString glue_name);
 
       QNetworkAccessManager* network_access_mgr_;
@@ -79,13 +79,14 @@ class BadResultException : public std::exception {
 
 class PartDoesNotExistException : public std::exception {
   private:
-      QString message;
-      std::string return_message;
+      QString part_;
+      QString structure_;
+      std::string return_message_;
   public:
-      PartDoesNotExistException(QString msg) : message(std::move(msg)) {}
+      PartDoesNotExistException(QString part, QString structure="") : part_(std::move(part)), structure_(std::move(structure)) {}
       const char* what () {
-          return_message = "Required part does not exist: " + message.toStdString();
-          return return_message.c_str();
+          return_message_ = "Required part does not exist: " + part_.toStdString() + (structure_.isEmpty() ? "" : (" (structure: " + structure_.toStdString() + ")"));
+          return return_message_.c_str();
       }
 };
 

--- a/assembly/assemblyCommon/DatabaseDESY.h
+++ b/assembly/assemblyCommon/DatabaseDESY.h
@@ -43,6 +43,8 @@ class DatabaseDESY : public VDatabase
       int get_ID_from_name(QString part_name, QString structure_name="");
       int validate_glue_mixture(QString glue_name);
 
+      void error_message(QString message);
+
       QNetworkAccessManager* network_access_mgr_;
 
       QUrl base_url_;

--- a/assembly/assemblyCommon/DatabaseDESY.h
+++ b/assembly/assemblyCommon/DatabaseDESY.h
@@ -31,6 +31,7 @@ class DatabaseDESY : public VDatabase
       bool MaPSA_to_BP(QString, QString, QString, QString="");
       bool PSs_to_spacers(QString, QString, QString="");
       bool PSs_to_MaPSA(QString, QString);
+      bool PSs_to_MaPSA(QString, QString, QString, QString, QString) { return false; };
 
       bool is_component_available(QString, QString="");
 

--- a/assembly/assemblyCommon/DatabaseDummy.cc
+++ b/assembly/assemblyCommon/DatabaseDummy.cc
@@ -1,0 +1,49 @@
+/////////////////////////////////////////////////////////////////////////////////
+//                                                                             //
+//               Copyright (C) 2011-2021 - The DESY CMS Group                  //
+//                           All rights reserved                               //
+//                                                                             //
+//      The CMStkModLab source code is licensed under the GNU GPL v3.0.        //
+//      You have the right to modify and/or redistribute this source code      //
+//      under the terms specified in the license, which may be found online    //
+//      at http://www.gnu.org/licenses or at License.txt.                      //
+//                                                                             //
+/////////////////////////////////////////////////////////////////////////////////
+
+#include <DatabaseDummy.h>
+
+DatabaseDummy::DatabaseDummy(QObject *parent) : VDatabase(parent)
+{
+    // Initialise stuff!
+}
+
+DatabaseDummy::~DatabaseDummy()
+{
+    // Any connections to close?
+}
+
+
+bool DatabaseDummy::check_module_name_exists(std::string module_name)
+{
+    return false;
+}
+
+bool DatabaseDummy::register_module_name(std::string module_name)
+{
+    return false;
+}
+
+bool DatabaseDummy::MaPSA_to_BP_(std::string, std::string, std::string)
+{
+    return false;
+}
+
+bool DatabaseDummy::PSs_to_spacers_(std::string, std::string)
+{
+    return false;
+}
+
+bool DatabaseDummy::PSs_to_MaPSA_(std::string)
+{
+    return false;
+}

--- a/assembly/assemblyCommon/DatabaseDummy.cc
+++ b/assembly/assemblyCommon/DatabaseDummy.cc
@@ -12,6 +12,11 @@
 
 #include <DatabaseDummy.h>
 
+#include <QMessageBox>
+#include <QTextDocumentFragment>
+
+#include <nqlogger.h>
+
 DatabaseDummy::DatabaseDummy(QObject *parent) : VDatabase(parent)
 {
     // Initialise stuff!
@@ -25,20 +30,39 @@ DatabaseDummy::~DatabaseDummy()
 
 bool DatabaseDummy::register_module_name(QString module_name, QString operator_name)
 {
+    NQLog("DatabaseDummy", NQLog::Message) << "Could not perform step \"Register module by name\"";
+    error_message(QString("Module %1 already exists in the database (ID: %2). Cannot register another module with this name.").arg(module_name).arg(123));
     return false;
 }
 
-bool DatabaseDummy::MaPSA_to_BP(QString, QString, QString)
+bool DatabaseDummy::MaPSA_to_BP(QString MaPSA_name, QString BP_name, QString glue_name, QString comment)
+{
+    NQLog("DatabaseDummy", NQLog::Message) << "Performed MaPSA to Baseplate gluing step in DB.";
+    return true;
+}
+
+bool DatabaseDummy::PSs_to_spacers(QString PSs_name, QString glue_name, QString comment)
 {
     return false;
 }
 
-bool DatabaseDummy::PSs_to_spacers(QString, QString)
+bool DatabaseDummy::PSs_to_MaPSA(QString glue_name, QString comment)
 {
     return false;
 }
 
-bool DatabaseDummy::PSs_to_MaPSA(QString)
+bool DatabaseDummy::is_component_available(QString part_name, QString structure_name)
 {
-    return false;
+    return true;
+}
+
+void DatabaseDummy::error_message(QString message)
+{
+    NQLog("DatabaseDummy", NQLog::Fatal) << QTextDocumentFragment::fromHtml( message ).toPlainText();
+
+    QMessageBox msgBox;
+    msgBox.setWindowTitle(tr("Warning - Database"));
+    msgBox.setText(message);
+    msgBox.setStandardButtons(QMessageBox::Ok);
+    int ret = msgBox.exec();
 }

--- a/assembly/assemblyCommon/DatabaseDummy.cc
+++ b/assembly/assemblyCommon/DatabaseDummy.cc
@@ -23,27 +23,22 @@ DatabaseDummy::~DatabaseDummy()
 }
 
 
-bool DatabaseDummy::check_module_name_exists(std::string module_name)
+bool DatabaseDummy::register_module_name(QString module_name, QString operator_name)
 {
     return false;
 }
 
-bool DatabaseDummy::register_module_name(std::string module_name)
+bool DatabaseDummy::MaPSA_to_BP(QString, QString, QString)
 {
     return false;
 }
 
-bool DatabaseDummy::MaPSA_to_BP_(std::string, std::string, std::string)
+bool DatabaseDummy::PSs_to_spacers(QString, QString)
 {
     return false;
 }
 
-bool DatabaseDummy::PSs_to_spacers_(std::string, std::string)
-{
-    return false;
-}
-
-bool DatabaseDummy::PSs_to_MaPSA_(std::string)
+bool DatabaseDummy::PSs_to_MaPSA(QString)
 {
     return false;
 }

--- a/assembly/assemblyCommon/DatabaseDummy.h
+++ b/assembly/assemblyCommon/DatabaseDummy.h
@@ -27,6 +27,7 @@ class DatabaseDummy : public VDatabase
       bool MaPSA_to_BP(QString, QString, QString, QString);
       bool PSs_to_spacers(QString, QString, QString);
       bool PSs_to_MaPSA(QString, QString);
+      bool PSs_to_MaPSA(QString, QString, QString, QString, QString) { return false; };
 
       bool is_component_available(QString, QString);
 

--- a/assembly/assemblyCommon/DatabaseDummy.h
+++ b/assembly/assemblyCommon/DatabaseDummy.h
@@ -23,12 +23,10 @@ class DatabaseDummy : public VDatabase
       explicit DatabaseDummy(QObject* parent);
       ~DatabaseDummy();
 
-      bool check_module_name_exists(std::string);
-      bool register_module_name(std::string);
-
-      bool MaPSA_to_BP_(std::string, std::string, std::string);
-      bool PSs_to_spacers_(std::string, std::string);
-      bool PSs_to_MaPSA_(std::string);
+      bool register_module_name(QString, QString);
+      bool MaPSA_to_BP(QString, QString, QString);
+      bool PSs_to_spacers(QString, QString);
+      bool PSs_to_MaPSA(QString);
 
   protected:
 

--- a/assembly/assemblyCommon/DatabaseDummy.h
+++ b/assembly/assemblyCommon/DatabaseDummy.h
@@ -24,11 +24,15 @@ class DatabaseDummy : public VDatabase
       ~DatabaseDummy();
 
       bool register_module_name(QString, QString);
-      bool MaPSA_to_BP(QString, QString, QString);
-      bool PSs_to_spacers(QString, QString);
-      bool PSs_to_MaPSA(QString);
+      bool MaPSA_to_BP(QString, QString, QString, QString);
+      bool PSs_to_spacers(QString, QString, QString);
+      bool PSs_to_MaPSA(QString, QString);
+
+      bool is_component_available(QString, QString);
 
   protected:
+
+      void error_message(QString message);
 
 
 };

--- a/assembly/assemblyCommon/DatabaseDummy.h
+++ b/assembly/assemblyCommon/DatabaseDummy.h
@@ -1,0 +1,38 @@
+/////////////////////////////////////////////////////////////////////////////////
+//                                                                             //
+//               Copyright (C) 2011-2021 - The DESY CMS Group                  //
+//                           All rights reserved                               //
+//                                                                             //
+//      The CMStkModLab source code is licensed under the GNU GPL v3.0.        //
+//      You have the right to modify and/or redistribute this source code      //
+//      under the terms specified in the license, which may be found online    //
+//      at http://www.gnu.org/licenses or at License.txt.                      //
+//                                                                             //
+/////////////////////////////////////////////////////////////////////////////////
+
+#ifndef DATABASEDUMMY_H
+#define DATABASEDUMMY_H
+
+#include <VDatabase.h>
+
+class DatabaseDummy : public VDatabase
+{
+ Q_OBJECT
+
+  public:
+      explicit DatabaseDummy(QObject* parent);
+      ~DatabaseDummy();
+
+      bool check_module_name_exists(std::string);
+      bool register_module_name(std::string);
+
+      bool MaPSA_to_BP_(std::string, std::string, std::string);
+      bool PSs_to_spacers_(std::string, std::string);
+      bool PSs_to_MaPSA_(std::string);
+
+  protected:
+
+
+};
+
+#endif // DATABASEDUMMY_H

--- a/assembly/assemblyCommon/MetrologyView.cc
+++ b/assembly/assemblyCommon/MetrologyView.cc
@@ -65,6 +65,11 @@ MetrologyView::MetrologyView(QWidget* parent)
  , metro_da_deg_linee_(nullptr)
  , metro_da_urad_linee_(nullptr)
 
+ , metro_dx_corr_(0)
+ , metro_dy_corr_(0)
+ , metro_dz_(0)
+ , metro_da_urad_(0)
+
  , patrecOne_image_ (nullptr)
  , patrecOne_scroll_(nullptr)
 
@@ -763,6 +768,7 @@ void MetrologyView::show_results(const double dx, const double dx_corr, const do
   std::stringstream posi_strs_dx_corr;
   posi_strs_dx_corr << dx_corr;
   metro_dx_corr_linee_->setText(QString::fromStdString(posi_strs_dx_corr.str()));
+  metro_dx_corr_ = dx_corr;
 
   std::stringstream posi_strs_dy;
   posi_strs_dy << dy;
@@ -771,10 +777,12 @@ void MetrologyView::show_results(const double dx, const double dx_corr, const do
   std::stringstream posi_strs_dy_corr;
   posi_strs_dy_corr << dy_corr;
   metro_dy_corr_linee_->setText(QString::fromStdString(posi_strs_dy_corr.str()));
+  metro_dy_corr_ = dy_corr;
 
   std::stringstream posi_strs_dz;
   posi_strs_dz << dz;
   metro_dz_linee_->setText(QString::fromStdString(posi_strs_dz.str()));
+  metro_dz_ = dz;
 
   std::stringstream posi_strs_da_deg;
   posi_strs_da_deg << da_deg;
@@ -783,6 +791,7 @@ void MetrologyView::show_results(const double dx, const double dx_corr, const do
   std::stringstream posi_strs_da_urad;
   posi_strs_da_urad << da_urad;
   metro_da_urad_linee_->setText(QString::fromStdString(posi_strs_da_urad.str()));
+  metro_da_urad_ = da_urad;
 
   button_metrologyClearResults_->setEnabled(true);
 
@@ -858,6 +867,11 @@ void MetrologyView::clearResults()
   metro_dz_linee_->setText("");
   metro_da_deg_linee_->setText("");
   metro_da_urad_linee_->setText("");
+
+  metro_dx_corr_ = 0;
+  metro_dy_corr_ = 0;
+  metro_dz_ = 0;
+  metro_da_urad_ = 0;
 
   button_metrologyClearResults_->setEnabled(false);
 

--- a/assembly/assemblyCommon/MetrologyView.cc
+++ b/assembly/assemblyCommon/MetrologyView.cc
@@ -26,6 +26,7 @@
 #include <QGroupBox>
 #include <QLabel>
 #include <QScriptEngine>
+#include <QDialogButtonBox>
 #include <qnumeric.h>
 
 
@@ -82,6 +83,7 @@ MetrologyView::MetrologyView(QWidget* parent)
  , patrecFour_image_ (nullptr)
  , patrecFour_scroll_(nullptr)
 
+ , button_pushToDatabase_(nullptr)
  , button_metrologyClearResults_(nullptr)
  , button_metrologyEmergencyStop_(nullptr)
 
@@ -423,6 +425,17 @@ MetrologyView::MetrologyView(QWidget* parent)
   metro_da_lay->setStretch(4,  55);
   metro_da_lay->setStretch(5, 101);
 
+  QHBoxLayout* metro_pushDB_lay = new QHBoxLayout;
+  metro_res_lay->addLayout(metro_pushDB_lay);
+
+  button_pushToDatabase_ = new QPushButton(tr("Push results to Database"));
+
+  metro_pushDB_lay->addStretch();
+  metro_pushDB_lay->addWidget(button_pushToDatabase_);
+  metro_pushDB_lay->addStretch();
+
+  button_pushToDatabase_->setEnabled(false);
+  connect(button_pushToDatabase_, SIGNAL(clicked()), this, SLOT(push_results_to_DB()));
 
   // Graphical Results (PatRec Images)
   QGridLayout* metro_img_lay = new QGridLayout;
@@ -794,6 +807,7 @@ void MetrologyView::show_results(const double dx, const double dx_corr, const do
   metro_da_urad_ = da_urad;
 
   button_metrologyClearResults_->setEnabled(true);
+  button_pushToDatabase_->setEnabled(true);
 
   return;
 }
@@ -849,6 +863,57 @@ void MetrologyView::metrology_abort(){
   button_metrologyClearResults_->setEnabled(true);
 }
 
+void MetrologyView::push_results_to_DB()
+{
+    QDialog* msgBox = new QDialog();
+    msgBox->setWindowTitle(tr("Push Metrology Results to Database"));
+
+    QVBoxLayout* vlay = new QVBoxLayout();
+    msgBox->setLayout(vlay);
+
+    QLabel* main_txt = new QLabel(QString("Push the following information to database:\n\tdx [mm]:\t\t%1\n\tdy [mm]:\t\t%2\n\tdz [mm]:\t\t%3\n\tda [urad]:\t%4").arg(metro_dx_corr_).arg(metro_dy_corr_).arg(metro_dz_).arg(metro_da_urad_));
+    vlay->addWidget(main_txt);
+
+    QHBoxLayout* mod_ID_lay = new QHBoxLayout();
+
+    QLabel* mod_ID_lab = new QLabel("Module ID:");
+    QLineEdit* mod_ID_lin = new QLineEdit("");
+    mod_ID_lin->setPlaceholderText("Module ID");
+
+    mod_ID_lay->addWidget(mod_ID_lab);
+    mod_ID_lay->addWidget(mod_ID_lin);
+
+    vlay->addLayout(mod_ID_lay);
+
+    QLabel* info_txt = new QLabel("Do you want to push this information to the Database?");
+    vlay->addWidget(info_txt);
+
+    QDialogButtonBox* button_box = new QDialogButtonBox(Qt::Vertical);
+    button_box->addButton(QDialogButtonBox::No);
+    button_box->addButton(QDialogButtonBox::Yes);
+
+    vlay->addWidget(button_box);
+
+    connect(button_box, SIGNAL(accepted()), msgBox, SLOT(accept()));
+    connect(button_box, SIGNAL(rejected()), msgBox, SLOT(reject()));
+
+    int ret = msgBox->exec();
+
+    switch(msgBox->result())
+    {
+      case QDialog::Rejected:
+        return;
+      case QDialog::Accepted:
+        // <--- Insert function to push to database here. --->
+        NQLog("AssemblyAssemblyV2", NQLog::Spam) << "push_results_to_DB: "
+           << QString("Push the following information to database:\n\tModule ID:\t%1\n\tdx [mm]:\t%2\n\tdy [mm]:\t%3\n\tdz [mm]:\t%4\n\tda [urad]:\t%5").arg(mod_ID_lin->text()).arg(metro_dx_corr_).arg(metro_dy_corr_).arg(metro_dz_).arg(metro_da_urad_);
+        button_pushToDatabase_->setEnabled(false);
+        break;
+      default:
+        return;
+    }
+}
+
 void MetrologyView::clearResults()
 {
   NQLog("MetrologyView", NQLog::Spam) << "clearResults()";
@@ -874,6 +939,7 @@ void MetrologyView::clearResults()
   metro_da_urad_ = 0;
 
   button_metrologyClearResults_->setEnabled(false);
+  button_pushToDatabase_->setEnabled(false);
 
   switch_to_config();
 }

--- a/assembly/assemblyCommon/MetrologyView.cc
+++ b/assembly/assemblyCommon/MetrologyView.cc
@@ -888,9 +888,10 @@ void MetrologyView::push_results_to_DB()
     QLabel* info_txt = new QLabel("Do you want to push this information to the Database?");
     vlay->addWidget(info_txt);
 
-    QDialogButtonBox* button_box = new QDialogButtonBox(Qt::Vertical);
-    button_box->addButton(QDialogButtonBox::No);
+    QDialogButtonBox* button_box = new QDialogButtonBox(Qt::Horizontal);
     button_box->addButton(QDialogButtonBox::Yes);
+    button_box->addButton(QDialogButtonBox::No);
+    button_box->setCenterButtons(true);
 
     vlay->addWidget(button_box);
 
@@ -904,6 +905,17 @@ void MetrologyView::push_results_to_DB()
       case QDialog::Rejected:
         return;
       case QDialog::Accepted:
+        if(mod_ID_lin->text().isEmpty())
+        {
+            QMessageBox* warnBox = new QMessageBox;
+            warnBox->setStyleSheet("QLabel{min-width: 300px;}");
+            warnBox->setInformativeText("No Module ID provided. Please try again.");
+            warnBox->setStandardButtons(QMessageBox::Ok);
+            warnBox->setDefaultButton(QMessageBox::Ok);
+            int ret = warnBox->exec();
+            return;
+        }
+
         // <--- Insert function to push to database here. --->
         NQLog("AssemblyAssemblyV2", NQLog::Spam) << "push_results_to_DB: "
            << QString("Push the following information to database:\n\tModule ID:\t%1\n\tdx [mm]:\t%2\n\tdy [mm]:\t%3\n\tdz [mm]:\t%4\n\tda [urad]:\t%5").arg(mod_ID_lin->text()).arg(metro_dx_corr_).arg(metro_dy_corr_).arg(metro_dz_).arg(metro_da_urad_);

--- a/assembly/assemblyCommon/MetrologyView.h
+++ b/assembly/assemblyCommon/MetrologyView.h
@@ -51,6 +51,7 @@ class MetrologyView : public QWidget
   AssemblyUEyeView* PatRecThree_Image() const { return patrecThree_image_; }
   AssemblyUEyeView* PatRecFour_Image() const { return patrecFour_image_; }
 
+  QPushButton* button_pushToDatabase() const { return button_pushToDatabase_; }
   QPushButton* button_metrologyClearResults() const { return button_metrologyClearResults_; }
   QPushButton* button_metrologyEmergencyStop() const { return button_metrologyEmergencyStop_; }
 
@@ -105,7 +106,8 @@ class MetrologyView : public QWidget
   AssemblyUEyeView* patrecFour_image_;
   QScrollArea*      patrecFour_scroll_;
 
-  QPushButton*  button_metrologyClearResults_;
+  QPushButton* button_pushToDatabase_;
+  QPushButton* button_metrologyClearResults_;
   QPushButton* button_metrologyEmergencyStop_;
 
   bool finder_connected_;
@@ -141,6 +143,8 @@ class MetrologyView : public QWidget
   void go_to_PSP_BL_marker();
 
   void go_to_PSS_BL_marker();
+
+  void push_results_to_DB();
 
   void clearResults();
 

--- a/assembly/assemblyCommon/MetrologyView.h
+++ b/assembly/assemblyCommon/MetrologyView.h
@@ -91,6 +91,8 @@ class MetrologyView : public QWidget
   QLineEdit* metro_da_deg_linee_;
   QLineEdit* metro_da_urad_linee_;
 
+  double metro_dx_corr_, metro_dy_corr_, metro_dz_, metro_da_urad_;
+
   AssemblyUEyeView* patrecOne_image_;
   QScrollArea*      patrecOne_scroll_;
 

--- a/assembly/assemblyCommon/VDatabase.cc
+++ b/assembly/assemblyCommon/VDatabase.cc
@@ -1,0 +1,20 @@
+/////////////////////////////////////////////////////////////////////////////////
+//                                                                             //
+//               Copyright (C) 2011-2021 - The DESY CMS Group                  //
+//                           All rights reserved                               //
+//                                                                             //
+//      The CMStkModLab source code is licensed under the GNU GPL v3.0.        //
+//      You have the right to modify and/or redistribute this source code      //
+//      under the terms specified in the license, which may be found online    //
+//      at http://www.gnu.org/licenses or at License.txt.                      //
+//                                                                             //
+/////////////////////////////////////////////////////////////////////////////////
+
+#include <VDatabase.h>
+
+VDatabase::VDatabase(QObject* parent) :
+  QObject(parent){
+  }
+
+VDatabase::~VDatabase(){
+}

--- a/assembly/assemblyCommon/VDatabase.h
+++ b/assembly/assemblyCommon/VDatabase.h
@@ -28,6 +28,8 @@ class VDatabase : public QObject
       virtual bool MaPSA_to_BP(QString, QString, QString, QString) = 0;
       virtual bool PSs_to_spacers(QString, QString, QString) = 0;
       virtual bool PSs_to_MaPSA(QString, QString) = 0;
+      
+      virtual bool is_component_available(QString, QString) = 0;
 
   protected:
 

--- a/assembly/assemblyCommon/VDatabase.h
+++ b/assembly/assemblyCommon/VDatabase.h
@@ -1,0 +1,51 @@
+/////////////////////////////////////////////////////////////////////////////////
+//                                                                             //
+//               Copyright (C) 2011-2021 - The DESY CMS Group                  //
+//                           All rights reserved                               //
+//                                                                             //
+//      The CMStkModLab source code is licensed under the GNU GPL v3.0.        //
+//      You have the right to modify and/or redistribute this source code      //
+//      under the terms specified in the license, which may be found online    //
+//      at http://www.gnu.org/licenses or at License.txt.                      //
+//                                                                             //
+/////////////////////////////////////////////////////////////////////////////////
+
+#ifndef VDATABASE_H
+#define VDATABASE_H
+
+#include <unistd.h>
+#include <QObject>
+
+class VDatabase : public QObject
+{
+ Q_OBJECT
+
+  public:
+      VDatabase(QObject* parent);
+      ~VDatabase();
+
+      virtual bool check_module_name_exists(std::string) = 0;
+      virtual bool register_module_name(std::string) = 0;
+
+      virtual bool MaPSA_to_BP_(std::string, std::string, std::string) = 0;
+      virtual bool PSs_to_spacers_(std::string, std::string) = 0;
+      virtual bool PSs_to_MaPSA_(std::string) = 0;
+
+  protected:
+
+      std::string MaPSA_name_;
+      unsigned int MaPSA_dbid_;
+
+      std::string PSs_name_;
+      unsigned int PSs_dbid_;
+
+      std::string BP_name_;
+      unsigned int BP_dbid_;
+
+      unsigned int Glue1_dbid_;
+      unsigned int Glue2_dbid_;
+      unsigned int Glue3_dbid_;
+
+};
+
+#endif // VDATABASE_H

--- a/assembly/assemblyCommon/VDatabase.h
+++ b/assembly/assemblyCommon/VDatabase.h
@@ -24,27 +24,28 @@ class VDatabase : public QObject
       VDatabase(QObject* parent);
       ~VDatabase();
 
-      virtual bool check_module_name_exists(std::string) = 0;
-      virtual bool register_module_name(std::string) = 0;
-
-      virtual bool MaPSA_to_BP_(std::string, std::string, std::string) = 0;
-      virtual bool PSs_to_spacers_(std::string, std::string) = 0;
-      virtual bool PSs_to_MaPSA_(std::string) = 0;
+      virtual bool register_module_name(QString, QString) = 0;
+      virtual bool MaPSA_to_BP(QString, QString, QString, QString) = 0;
+      virtual bool PSs_to_spacers(QString, QString, QString) = 0;
+      virtual bool PSs_to_MaPSA(QString, QString) = 0;
 
   protected:
 
-      std::string MaPSA_name_;
-      unsigned int MaPSA_dbid_;
+      QString module_name_;
+      int module_dbid_;
 
-      std::string PSs_name_;
-      unsigned int PSs_dbid_;
+      QString MaPSA_name_;
+      int MaPSA_dbid_;
 
-      std::string BP_name_;
-      unsigned int BP_dbid_;
+      QString PSs_name_;
+      int PSs_dbid_;
 
-      unsigned int Glue1_dbid_;
-      unsigned int Glue2_dbid_;
-      unsigned int Glue3_dbid_;
+      QString BP_name_;
+      int BP_dbid_;
+
+      int Glue1_dbid_;
+      int Glue2_dbid_;
+      int Glue3_dbid_;
 
 };
 


### PR DESCRIPTION
Preparation work for integration of the database

This integrates the registration of component IDs (via barcode scanner or manual entry)  as well as the upload to a database into the assembly sequence.

The registration of component IDs can either be done in the toolbar ... 
![Screenshot from 2024-05-31 09-45-02](https://github.com/DESY-FH-ELab/cmstkmodlab/assets/9463445/fa5605ee-a602-48b7-9522-d4f49fb3ad52)

or in the assembly sequence:
![Screenshot from 2024-05-31 09-44-27](https://github.com/DESY-FH-ELab/cmstkmodlab/assets/9463445/b6009a12-6b7d-45a9-a3c7-793908e5435c)
![Screenshot from 2024-05-31 09-44-50](https://github.com/DESY-FH-ELab/cmstkmodlab/assets/9463445/ec514082-992d-4969-8682-d6e8ac0aee11)

When entering the IDs via the input dialogue, they are nevertheless registered in the toolbar.

The information can then be pushed to the database via the workflow (or the button in the toolbar):
![Screenshot from 2024-05-31 09-47-54](https://github.com/DESY-FH-ELab/cmstkmodlab/assets/9463445/c8c632c1-89c4-4d02-9c73-949a7629591f)

The user is warned about missing information ...
![Screenshot from 2024-05-31 09-47-38](https://github.com/DESY-FH-ELab/cmstkmodlab/assets/9463445/ddf37f0a-4972-4eba-93d5-f72a8b90fded)

... or can verify before uploading the information:
![Screenshot from 2024-05-31 09-49-47](https://github.com/DESY-FH-ELab/cmstkmodlab/assets/9463445/86a1ff37-fa47-4d4a-af77-1e09ab728ab4)


A function to actually upload the information still has to be added and can be varied from assembly center to assembly center.

On the way to this, a functionality was added in the background that makes it possible to abort individual actions, otherwise the user e.g. would have been informed that the information cannot be pushed to the DB, but either the action would be marked as "Done" and disabled or at the next click (due to the way signals are connected in Qt) the popups would appear twice.

This closes #202 