### PR TITLE
Subassembly pickup platform

### DIFF
--- a/assembly/assembly/AssemblyMainWindow.cc
+++ b/assembly/assembly/AssemblyMainWindow.cc
@@ -46,9 +46,11 @@ AssemblyMainWindow::AssemblyMainWindow(const QString& outputdir_path, const QStr
   PU_status_(nullptr),
   SP_status_(nullptr),
   BP_status_(nullptr),
+  SUB_status_(nullptr),
   vacuum_pickup_(0),
   vacuum_spacer_(0),
   vacuum_basepl_(0),
+  vacuum_sub_(0),
 
   camera_model_(nullptr),
   camera_thread_(nullptr),
@@ -548,36 +550,44 @@ AssemblyMainWindow::AssemblyMainWindow(const QString& outputdir_path, const QStr
     QLabel* PU_label = new QLabel("PU");
     QLabel* SP_label = new QLabel("SP");
     QLabel* BP_label = new QLabel("BP");
+    QLabel* SUB_label = new QLabel("SUB");
 
     vac_lay->addWidget(PU_label, 0, 1, Qt::AlignCenter);
     vac_lay->addWidget(SP_label, 0, 2, Qt::AlignCenter);
     vac_lay->addWidget(BP_label, 0, 3, Qt::AlignCenter);
+    vac_lay->addWidget(SUB_label, 0, 4, Qt::AlignCenter);
 
     QString filename(Config::CMSTkModLabBasePath.c_str());
 
     vacuum_pickup_ = config->getValue<int>("main", "Vacuum_PickupTool");
     vacuum_spacer_ = config->getValue<int>("main", "Vacuum_Spacers");
     vacuum_basepl_ = config->getValue<int>("main", "Vacuum_Baseplate");
+    vacuum_sub_ = config->getValue<int>("main", "Vacuum_Subassembly");
 
     PU_status_ = new QLabel();
     SP_status_ = new QLabel();
     BP_status_ = new QLabel();
+    SUB_status_ = new QLabel();
 
     PU_status_->setMinimumWidth(30);
     SP_status_->setMinimumWidth(30);
     BP_status_->setMinimumWidth(30);
+    SUB_status_->setMinimumWidth(30);
 
     PU_status_->setText("OFF");
     SP_status_->setText("OFF");
     BP_status_->setText("OFF");
+    SUB_status_->setText("OFF");
 
     PU_status_->setStyleSheet("QLabel { color : green ; font: bold }");
     SP_status_->setStyleSheet("QLabel { color : green ; font: bold }");
     BP_status_->setStyleSheet("QLabel { color : green ; font: bold }");
+    SUB_status_->setStyleSheet("QLabel { color : green ; font: bold }");
 
     vac_lay->addWidget(PU_status_, 1, 1, Qt::AlignCenter);
     vac_lay->addWidget(SP_status_, 1, 2, Qt::AlignCenter);
     vac_lay->addWidget(BP_status_, 1, 3, Qt::AlignCenter);
+    vac_lay->addWidget(SUB_status_, 1, 4, Qt::AlignCenter);
 
     vac_wid->setLayout(vac_lay);
 
@@ -1364,6 +1374,9 @@ void AssemblyMainWindow::update_vacuum_information(const int channel, const Swit
   } else if(channel == vacuum_basepl_)
   {
     to_be_updated = BP_status_;
+  } else if(channel == vacuum_sub_)
+  {
+    to_be_updated = SUB_status_;
   } else {
     NQLog("AssemblyMainWindow", NQLog::Fatal) << "Vacuum channel " << channel << " not known!";
     return;

--- a/assembly/assembly/AssemblyMainWindow.h
+++ b/assembly/assembly/AssemblyMainWindow.h
@@ -184,9 +184,11 @@ class AssemblyMainWindow : public QMainWindow
   int vacuum_basepl_;
   int vacuum_pickup_;
   int vacuum_spacer_;
+  int vacuum_sub_;
   QLabel* PU_status_;
   QLabel* SP_status_;
   QLabel* BP_status_;
+  QLabel* SUB_status_;
 
   AssemblyUEyeModel_t*      camera_model_;
   AssemblyUEyeCameraThread* camera_thread_;

--- a/assembly/assembly/parameters/SiDummyPS.cfg
+++ b/assembly/assembly/parameters/SiDummyPS.cfg
@@ -17,6 +17,7 @@ Thickness_MPA         0.420 #From zfocus on MPA
 Thickness_Spacer      3.200 #May check with caliper or zfocus
 Depth_SpacerSlots     0.350
 Thickness_GlueLayer   0.020
+Thickness_SubassemblyJig 1.500
 
 ####################################
 ### POSITIONS ######################

--- a/assembly/assembly/parameters/glass.cfg
+++ b/assembly/assembly/parameters/glass.cfg
@@ -17,6 +17,7 @@ Thickness_MPA         0.000
 Thickness_Spacer      3.250
 Depth_SpacerSlots     0.350
 Thickness_GlueLayer   0.100
+Thickness_SubassemblyJig 1.500
 
 ####################################
 ### POSITIONS ######################

--- a/assembly/assemblyCommon/AssemblyAssembly.cc
+++ b/assembly/assemblyCommon/AssemblyAssembly.cc
@@ -31,6 +31,7 @@ AssemblyAssembly::AssemblyAssembly(const LStepExpressMotionManager* const motion
  , vacuum_pickup_(0)
  , vacuum_spacer_(0)
  , vacuum_basepl_(0)
+ , vacuum_sub_(0)
 
  , pickup1_Z_(0.)
  , pickup2_Z_(0.)
@@ -61,6 +62,7 @@ AssemblyAssembly::AssemblyAssembly(const LStepExpressMotionManager* const motion
   vacuum_pickup_ = config_->getValue<int>("main", "Vacuum_PickupTool");
   vacuum_spacer_ = config_->getValue<int>("main", "Vacuum_Spacers");
   vacuum_basepl_ = config_->getValue<int>("main", "Vacuum_Baseplate");
+  vacuum_sub_ = config_->getValue<int>("main", "Vacuum_Subassembly");
 
   // absolute Z-position of motion stage for pickup of object after gluing
   // (1: PSs to Spacers, 2: PSs+Spacers to MaPSA)
@@ -469,6 +471,104 @@ void AssemblyAssembly::DisableVacuumBaseplate_finish()
      << ": assembly-step completed";
 
   emit DBLogMessage("== Assembly step completed : [Disable baseplate vacuum]");
+}
+// ----------------------------------------------------------------------------------------------------
+
+// ----------------------------------------------------------------------------------------------------
+// EnableVacuumSubassembly ------------------------------------------------------------------------------
+// ----------------------------------------------------------------------------------------------------
+void AssemblyAssembly::EnableVacuumSubassembly_start()
+{
+  if(in_action_){
+
+    NQLog("AssemblyAssembly", NQLog::Warning) << "EnableVacuumSubassembly_start"
+       << ": logic error, an assembly step is still in progress, will not take further action";
+
+    return;
+  }
+
+  connect(this, SIGNAL(vacuum_ON_request(int)), this->vacuum(), SLOT(enableVacuum(int)));
+
+  connect(this->vacuum(), SIGNAL(vacuum_enabled()), this, SLOT(EnableVacuumSubassembly_finish()));
+  connect(this->vacuum(), SIGNAL(vacuum_toggled()), this, SLOT(EnableVacuumSubassembly_finish()));
+  connect(this->vacuum(), SIGNAL(vacuum_error  ()), this, SLOT(EnableVacuumSubassembly_finish()));
+
+  in_action_ = true;
+
+  NQLog("AssemblyAssembly", NQLog::Spam) << "EnableVacuumSubassembly_start"
+     << ": emitting signal \"vacuum_ON_request(" << vacuum_sub_ << ")\"";
+
+  emit vacuum_ON_request(vacuum_sub_);
+}
+
+void AssemblyAssembly::EnableVacuumSubassembly_finish()
+{
+  disconnect(this, SIGNAL(vacuum_ON_request(int)), this->vacuum(), SLOT(enableVacuum(int)));
+
+  disconnect(this->vacuum(), SIGNAL(vacuum_enabled()), this, SLOT(EnableVacuumSubassembly_finish()));
+  disconnect(this->vacuum(), SIGNAL(vacuum_toggled()), this, SLOT(EnableVacuumSubassembly_finish()));
+  disconnect(this->vacuum(), SIGNAL(vacuum_error  ()), this, SLOT(EnableVacuumSubassembly_finish()));
+
+  if(in_action_){ in_action_ = false; }
+
+  NQLog("AssemblyAssembly", NQLog::Spam) << "EnableVacuumSubassembly_finish"
+     << ": emitting signal \"EnableVacuumSubassembly_finished\"";
+
+  emit EnableVacuumSubassembly_finished();
+
+  NQLog("AssemblyAssembly", NQLog::Message) << "EnableVacuumSubassembly_finish"
+     << ": assembly-step completed";
+
+  emit DBLogMessage("== Assembly step completed : [Enable subassembly vacuum]");
+}
+// ----------------------------------------------------------------------------------------------------
+
+// ----------------------------------------------------------------------------------------------------
+// DisableVacuumSubassembly -----------------------------------------------------------------------------
+// ----------------------------------------------------------------------------------------------------
+void AssemblyAssembly::DisableVacuumSubassembly_start()
+{
+  if(in_action_){
+
+    NQLog("AssemblyAssembly", NQLog::Warning) << "DisableVacuumSubassembly_start"
+       << ": logic error, an assembly step is still in progress, will not take further action";
+
+    return;
+  }
+
+  connect(this, SIGNAL(vacuum_OFF_request(int)), this->vacuum(), SLOT(disableVacuum(int)));
+
+  connect(this->vacuum(), SIGNAL(vacuum_disabled()), this, SLOT(DisableVacuumSubassembly_finish()));
+  connect(this->vacuum(), SIGNAL(vacuum_toggled ()), this, SLOT(DisableVacuumSubassembly_finish()));
+  connect(this->vacuum(), SIGNAL(vacuum_error   ()), this, SLOT(DisableVacuumSubassembly_finish()));
+
+  in_action_ = true;
+
+  NQLog("AssemblyAssembly", NQLog::Spam) << "DisableVacuumSubassembly_start"
+     << ": emitting signal \"vacuum_OFF_request(" << vacuum_sub_ << ")\"";
+
+  emit vacuum_OFF_request(vacuum_sub_);
+}
+
+void AssemblyAssembly::DisableVacuumSubassembly_finish()
+{
+  disconnect(this, SIGNAL(vacuum_OFF_request(int)), this->vacuum(), SLOT(disableVacuum(int)));
+
+  disconnect(this->vacuum(), SIGNAL(vacuum_disabled()), this, SLOT(DisableVacuumSubassembly_finish()));
+  disconnect(this->vacuum(), SIGNAL(vacuum_toggled ()), this, SLOT(DisableVacuumSubassembly_finish()));
+  disconnect(this->vacuum(), SIGNAL(vacuum_error   ()), this, SLOT(DisableVacuumSubassembly_finish()));
+
+  if(in_action_){ in_action_ = false; }
+
+  NQLog("AssemblyAssembly", NQLog::Spam) << "DisableVacuumSubassembly_finish"
+     << ": emitting signal \"DisableVacuumSubassembly_finished\"";
+
+  emit DisableVacuumSubassembly_finished();
+
+  NQLog("AssemblyAssembly", NQLog::Message) << "DisableVacuumSubassembly_finish"
+     << ": assembly-step completed";
+
+  emit DBLogMessage("== Assembly step completed : [Disable subassembly vacuum]");
 }
 // ----------------------------------------------------------------------------------------------------
 

--- a/assembly/assemblyCommon/AssemblyAssembly.h
+++ b/assembly/assemblyCommon/AssemblyAssembly.h
@@ -48,6 +48,7 @@ class AssemblyAssembly : public QObject
   int vacuum_pickup_;
   int vacuum_spacer_;
   int vacuum_basepl_;
+  int vacuum_sub_;
 
   double pickup1_Z_;
   double pickup2_Z_;
@@ -133,7 +134,13 @@ class AssemblyAssembly : public QObject
 
   void DisableVacuumBaseplate_start();
   void DisableVacuumBaseplate_finish();
-  // ---------
+
+  void EnableVacuumSubassembly_start();
+  void EnableVacuumSubassembly_finish();
+
+  void DisableVacuumSubassembly_start();
+  void DisableVacuumSubassembly_finish();
+// ---------
 
   // others
 
@@ -195,6 +202,9 @@ class AssemblyAssembly : public QObject
 
   void EnableVacuumBaseplate_finished();
   void DisableVacuumBaseplate_finished();
+
+  void EnableVacuumSubassembly_finished();
+  void DisableVacuumSubassembly_finished();
 
   void DBLogMessage(const QString);
   // ------

--- a/assembly/assemblyCommon/AssemblyParametersView.cc
+++ b/assembly/assemblyCommon/AssemblyParametersView.cc
@@ -195,6 +195,21 @@ AssemblyParametersView::AssemblyParametersView(QWidget* parent)
     dime_lay->addWidget(this->get(tmp_tag)  , row_index, 6, Qt::AlignRight);
   }
 
+  if(assembly_center == assembly::Center::DESY)
+  {
+    // dimension: thickness of SpacerClamp
+    ++row_index;
+
+    tmp_tag = "Thickness_SubassemblyJig";
+    tmp_des = "Thickness of Subassembly Pickup Jig :";
+
+    map_lineEdit_[tmp_tag] = new QLineEdit(tr(""));
+
+    dime_lay->addWidget(new QLabel(tmp_des) , row_index, 0, Qt::AlignLeft);
+    dime_lay->addWidget(new QLabel(tr("dZ")), row_index, 5, Qt::AlignRight);
+    dime_lay->addWidget(this->get(tmp_tag)  , row_index, 6, Qt::AlignRight);
+  }
+
   //// ---------------------
 
   row_index = -1;

--- a/assembly/assemblyCommon/AssemblySubassemblyPickup.cc
+++ b/assembly/assemblyCommon/AssemblySubassemblyPickup.cc
@@ -156,7 +156,7 @@ void AssemblySubassemblyPickup::GoToSensorMarkerPreAlignment_start()
 
   const double z0 =
      config_->getValue<double>("parameters", "CameraFocusOnAssemblyStage_Z")
-   - config_->getValue<double>("parameters", "Depth_SpacerSlots")
+   + config_->getValue<double>("parameters", "Thickness_SubassemblyJig")
    + config_->getValue<double>("parameters", "Thickness_Spacer")
    + config_->getValue<double>("parameters", "Thickness_GlueLayer")
    + config_->getValue<double>("parameters", "Thickness_PSS");

--- a/assembly/assemblyCommon/AssemblySubassemblyPickup.h
+++ b/assembly/assemblyCommon/AssemblySubassemblyPickup.h
@@ -44,6 +44,7 @@ class AssemblySubassemblyPickup : public QObject
   int vacuum_pickup_;
   int vacuum_spacer_;
   int vacuum_basepl_;
+  int vacuum_sub_;
 
   bool use_smartMove_;
   bool in_action_;
@@ -59,11 +60,14 @@ class AssemblySubassemblyPickup : public QObject
 
   void use_smartMove(const int);
 
+  void EnableVacuumSpacers_start();
+  void EnableVacuumSpacers_finish();
+
   void GoToSensorMarkerPreAlignment_start();
   void GoToSensorMarkerPreAlignment_finish();
 
-  void EnableVacuumSpacers_start();
-  void EnableVacuumSpacers_finish();
+  void EnableVacuumSubassembly_start();
+  void EnableVacuumSubassembly_finish();
 
   void switchToAlignmentTab_PSS();
 
@@ -76,11 +80,14 @@ class AssemblySubassemblyPickup : public QObject
   void LowerPickupToolOntoSubassembly_start();
   void LowerPickupToolOntoSubassembly_finish();
 
-  void DisableVacuumSpacers_start();
-  void DisableVacuumSpacers_finish();
+  void DisableVacuumSubassembly_start();
+  void DisableVacuumSubassembly_finish();
 
   void PickupSubassembly_start();
   void PickupSubassembly_finish();
+
+  void DisableVacuumSpacers_start();
+  void DisableVacuumSpacers_finish();
 
  signals:
 
@@ -101,6 +108,9 @@ class AssemblySubassemblyPickup : public QObject
 
   void EnableVacuumSpacers_finished();
   void DisableVacuumSpacers_finished();
+
+  void EnableVacuumSubassembly_finished();
+  void DisableVacuumSubassembly_finished();
 
   void switchToAlignmentTab_PSS_request();
 

--- a/assembly/assemblyCommon/AssemblySubassemblyPickupWidget.cc
+++ b/assembly/assemblyCommon/AssemblySubassemblyPickupWidget.cc
@@ -61,14 +61,51 @@ AssemblySubassemblyPickupWidget::AssemblySubassemblyPickupWidget(const QObject* 
 
   uint pickup_step_N = 0;
 
+  // step: Place Subassembly Jig on Assembly Platform
+  {
+    ++pickup_step_N;
+
+    AssemblyAssemblyTextWidget* tmp_wid = new AssemblyAssemblyTextWidget;
+    tmp_wid->label()->setText(QString::number(pickup_step_N));
+    tmp_wid->text()->setText("Place Subassembly Pickup Jig on Assembly Platform aligned via pins");
+    sub_pick_lay->addWidget(tmp_wid);
+  }
+  // ----------
+
+  // step: Enable vacuum on spacers to secure the jig
+  {
+    ++pickup_step_N;
+
+    AssemblyAssemblyActionWidget* tmp_wid = new AssemblyAssemblyActionWidget;
+    tmp_wid->label()->setText(QString::number(pickup_step_N));
+    tmp_wid->button()->setText("Enable vacuum on spacer pockets of Assembly Platform to secure the Subassembly Pickup Jig");
+    sub_pick_lay->addWidget(tmp_wid);
+
+    tmp_wid->connect_action(subassembly_pickup, SLOT(EnableVacuumSpacers_start()), SIGNAL(EnableVacuumSpacers_finished()));
+  }
+  // ----------
+
   // step: Place PSS+Spacers Subassembly on Assembly Platform
   {
     ++pickup_step_N;
 
     AssemblyAssemblyTextWidget* tmp_wid = new AssemblyAssemblyTextWidget;
     tmp_wid->label()->setText(QString::number(pickup_step_N));
-    tmp_wid->text()->setText("Place PSS+spacers subassembly on assembly platform with the spacers aligned in their spacer pockets");
+    tmp_wid->text()->setText("Place PSS+spacers subassembly on Subassembly Pickup Jig with the Spacers aligned to the pocket");
     sub_pick_lay->addWidget(tmp_wid);
+  }
+  // ----------
+
+  // step: Enable vacuum on subassembly jig
+  {
+    ++pickup_step_N;
+
+    AssemblyAssemblyActionWidget* tmp_wid = new AssemblyAssemblyActionWidget;
+    tmp_wid->label()->setText(QString::number(pickup_step_N));
+    tmp_wid->button()->setText("Enable vacuum on Subassembly Pickup Jig");
+    sub_pick_lay->addWidget(tmp_wid);
+
+    tmp_wid->connect_action(subassembly_pickup, SLOT(EnableVacuumSubassembly_start()), SIGNAL(EnableVacuumSubassembly_finished()));
   }
   // ----------
 
@@ -78,23 +115,10 @@ AssemblySubassemblyPickupWidget::AssemblySubassemblyPickupWidget(const QObject* 
 
     AssemblyAssemblyActionWidget* tmp_wid = new AssemblyAssemblyActionWidget;
     tmp_wid->label()->setText(QString::number(pickup_step_N));
-    tmp_wid->button()->setText("Go To Measurement Position on PS-s - Spacer height considered");
+    tmp_wid->button()->setText("Go To Measurement Position on PS-s - Spacer \& Jig height considered");
     sub_pick_lay->addWidget(tmp_wid);
 
     tmp_wid->connect_action(subassembly_pickup, SLOT(GoToSensorMarkerPreAlignment_start()), SIGNAL(GoToSensorMarkerPreAlignment_finished()));
-  }
-  // ----------
-
-  // step: Enable vacuum on spacers
-  {
-    ++pickup_step_N;
-
-    AssemblyAssemblyActionWidget* tmp_wid = new AssemblyAssemblyActionWidget;
-    tmp_wid->label()->setText(QString::number(pickup_step_N));
-    tmp_wid->button()->setText("Enable vacuum on spacers");
-    sub_pick_lay->addWidget(tmp_wid);
-
-    tmp_wid->connect_action(subassembly_pickup, SLOT(EnableVacuumSpacers_start()), SIGNAL(EnableVacuumSpacers_finished()));
   }
   // ----------
 
@@ -150,16 +174,16 @@ AssemblySubassemblyPickupWidget::AssemblySubassemblyPickupWidget(const QObject* 
   }
   // ----------
 
-  // step: Disable vacuum on Spacers
+  // step: Disable vacuum on subassembly jig
   {
     ++pickup_step_N;
 
     AssemblyAssemblyActionWidget* tmp_wid = new AssemblyAssemblyActionWidget;
     tmp_wid->label()->setText(QString::number(pickup_step_N));
-    tmp_wid->button()->setText("Disable Vacuum on Spacers");
+    tmp_wid->button()->setText("Disable Vacuum on Subassembly Pickup Jig");
     sub_pick_lay->addWidget(tmp_wid);
 
-    tmp_wid->connect_action(subassembly_pickup, SLOT(DisableVacuumSpacers_start()), SIGNAL(DisableVacuumSpacers_finished()));
+    tmp_wid->connect_action(subassembly_pickup, SLOT(DisableVacuumSubassembly_start()), SIGNAL(DisableVacuumSubassembly_finished()));
   }
   // ----------
 
@@ -173,6 +197,30 @@ AssemblySubassemblyPickupWidget::AssemblySubassemblyPickupWidget(const QObject* 
     sub_pick_lay->addWidget(tmp_wid);
 
     tmp_wid->connect_action(subassembly_pickup, SLOT(PickupSubassembly_start()), SIGNAL(PickupSubassembly_finished()));
+  }
+  // ----------
+
+  // step: Disable vacuum on Spacers to release subassembly pickup jig
+  {
+    ++pickup_step_N;
+
+    AssemblyAssemblyActionWidget* tmp_wid = new AssemblyAssemblyActionWidget;
+    tmp_wid->label()->setText(QString::number(pickup_step_N));
+    tmp_wid->button()->setText("Disable Vacuum on Spacers to release Subassembly Pickup Jig");
+    sub_pick_lay->addWidget(tmp_wid);
+
+    tmp_wid->connect_action(subassembly_pickup, SLOT(DisableVacuumSpacers_start()), SIGNAL(DisableVacuumSpacers_finished()));
+  }
+  // ----------
+
+  // step: Remove Subassembly Jig from Assembly Platform
+  {
+    ++pickup_step_N;
+
+    AssemblyAssemblyTextWidget* tmp_wid = new AssemblyAssemblyTextWidget;
+    tmp_wid->label()->setText(QString::number(pickup_step_N));
+    tmp_wid->text()->setText("Remove Subassembly Pickup Jig from Assembly Platform");
+    sub_pick_lay->addWidget(tmp_wid);
   }
   // ----------
 

--- a/assembly/assemblyCommon/AssemblySubassemblyPickupWidget.cc
+++ b/assembly/assemblyCommon/AssemblySubassemblyPickupWidget.cc
@@ -115,7 +115,7 @@ AssemblySubassemblyPickupWidget::AssemblySubassemblyPickupWidget(const QObject* 
 
     AssemblyAssemblyActionWidget* tmp_wid = new AssemblyAssemblyActionWidget;
     tmp_wid->label()->setText(QString::number(pickup_step_N));
-    tmp_wid->button()->setText("Go To Measurement Position on PS-s - Spacer \& Jig height considered");
+    tmp_wid->button()->setText("Go To Measurement Position on PS-s - Spacer && Jig height considered");
     sub_pick_lay->addWidget(tmp_wid);
 
     tmp_wid->connect_action(subassembly_pickup, SLOT(GoToSensorMarkerPreAlignment_start()), SIGNAL(GoToSensorMarkerPreAlignment_finished()));

--- a/assembly/assemblyCommon/AssemblySubassemblyPickupWidget.h
+++ b/assembly/assemblyCommon/AssemblySubassemblyPickupWidget.h
@@ -36,34 +36,10 @@ class AssemblySubassemblyPickupWidget : public QWidget
   explicit AssemblySubassemblyPickupWidget(const QObject* const, QWidget* parent=nullptr);
   virtual ~AssemblySubassemblyPickupWidget() {}
 
-  QGridLayout* layout() const { return layout_; }
-
  protected:
 
   QCheckBox* smartMove_checkbox_;
 
-  QGridLayout* layout_;
-
-  QPushButton* exe_button_;
-
-  QLabel *     pickup_label_;
-  QLineEdit*   pickup_lineed_;
-  QPushButton* pickup_button_;
-
-  QLabel*      measur_label_;
-  QLineEdit*   measur_lineed_;
-  QPushButton* measur_button_;
-
-  QLabel*      iteraN_label_;
-  QLineEdit*   iteraN_lineed_;
-
- public slots:
-
-
-
- signals:
-
-  //void multipickup_request(const AssemblySubassemblyPickup::Configuration&);
 };
 
 #endif // ASSEMBLYSUBASSEMBLYPICKUPWIDGET_H

--- a/assembly/assemblyCommon/AssemblyVacuumWidget.cc
+++ b/assembly/assemblyCommon/AssemblyVacuumWidget.cc
@@ -76,6 +76,19 @@ AssemblyVacuumWidget::AssemblyVacuumWidget(const QString& label, QWidget* parent
   grid->addWidget(this->get(vacuum_basepl).label_      , 5, 1);
   /// ------------------------------
 
+  /// SUBASSEMBLY
+  const int vacuum_sub = config->getValue<int>("main", "Vacuum_Subassembly");
+
+  valuemap_[vacuum_sub] = Entry();
+
+  this->get(vacuum_sub).radioButton_ = new QRadioButton(tr("Subassembly"));
+  this->get(vacuum_sub).label_ = new QLabel(tr(" UNKNOWN"));
+  this->get(vacuum_sub).label_->setStyleSheet("QLabel { background-color : gray; color : black; }");
+
+  grid->addWidget(this->get(vacuum_sub).radioButton_, 7, 0);
+  grid->addWidget(this->get(vacuum_sub).label_      , 7, 1);
+  /// ------------------------------
+
   layout_->addLayout(grid);
 
   connect(button_, SIGNAL(clicked()), this, SLOT(toggleVacuum()));

--- a/assembly/assembly_SiDummyPS.cfg
+++ b/assembly/assembly_SiDummyPS.cfg
@@ -18,7 +18,8 @@ RelayCardDevice                                Conrad
 # Vacuum
 Vacuum_PickupTool                              1
 Vacuum_Spacers                                 2
-Vacuum_Baseplate                               3
+Vacuum_Baseplate                               4
+Vacuum_Subassembly			       3
 
 # size of pixel unit in mm
 mm_per_pixel_row   0.0012

--- a/assembly/assembly_SiDummyPS.cfg
+++ b/assembly/assembly_SiDummyPS.cfg
@@ -18,8 +18,8 @@ RelayCardDevice                                Conrad
 # Vacuum
 Vacuum_PickupTool                              1
 Vacuum_Spacers                                 2
-Vacuum_Baseplate                               4
-Vacuum_Subassembly			       3
+Vacuum_Baseplate                               3
+Vacuum_Subassembly			       4
 
 # size of pixel unit in mm
 mm_per_pixel_row   0.0012

--- a/assembly/assembly_glass.cfg
+++ b/assembly/assembly_glass.cfg
@@ -18,7 +18,8 @@ RelayCardDevice                                Conrad
 # Vacuum
 Vacuum_PickupTool                              1
 Vacuum_Spacers                                 2
-Vacuum_Baseplate                               3
+Vacuum_Baseplate                               4
+Vacuum_Subassembly			       3
 
 # size of pixel unit in mm
 mm_per_pixel_row   0.0012

--- a/assembly/assembly_glass.cfg
+++ b/assembly/assembly_glass.cfg
@@ -18,8 +18,8 @@ RelayCardDevice                                Conrad
 # Vacuum
 Vacuum_PickupTool                              1
 Vacuum_Spacers                                 2
-Vacuum_Baseplate                               4
-Vacuum_Subassembly			       3
+Vacuum_Baseplate                               3
+Vacuum_Subassembly			       4
 
 # size of pixel unit in mm
 mm_per_pixel_row   0.0012


### PR DESCRIPTION
This PR introduces the usage of a subassembly pickup platform connected to a vacuum relay.

This platform is only used when a PSs+spacers subassembly is to be picked up and does not interfere with the main assembly workflow. It is placed on top of the assembly platform during this workflow, held down by applying vacuum on the spacer pockets, and then itself fixates the subassembly via its own vacuum lines.

This PR can safely be merged in case no subassembly platform is available. In this case, the assembly parameter file should be updated for a zero thickness of this platform and the corresponding steps in the subassembly pickup workflow can be ignored.

Drawings of this platform are available from @Negusbuk .