### PR TITLE
Add stopwatch to toolbar

### DIFF
--- a/assembly/assembly/AssemblyMainWindow.cc
+++ b/assembly/assembly/AssemblyMainWindow.cc
@@ -93,6 +93,8 @@ AssemblyMainWindow::AssemblyMainWindow(const QString& outputdir_path, const QStr
   DBLog_ctrl_(nullptr),
   DBLog_view_(nullptr),
 
+  stopwatch_wid_(nullptr),
+
   button_mainEmergencyStop_(nullptr),
   button_info_(nullptr),
   autofocus_checkbox_(nullptr),
@@ -537,6 +539,13 @@ AssemblyMainWindow::AssemblyMainWindow(const QString& outputdir_path, const QStr
     QWidget *spacer = new QWidget();
     spacer->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     toolBar_->addWidget(spacer);
+
+    stopwatch_wid_ = new AssemblyStopwatchWidget();
+    toolBar_->addWidget(stopwatch_wid_);
+
+    QWidget *spacer2 = new QWidget();
+    spacer2->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    toolBar_->addWidget(spacer2);
 
     QWidget *vac_wid = new QWidget();
 

--- a/assembly/assembly/AssemblyMainWindow.h
+++ b/assembly/assembly/AssemblyMainWindow.h
@@ -44,6 +44,7 @@ typedef AssemblyUEyeModel AssemblyUEyeModel_t;
 #include <AssemblySmartMotionManager.h>
 #include <AssemblyParametersView.h>
 #include <AssemblyHardwareControlView.h>
+#include <AssemblyStopwatchWidget.h>
 #include <LStepExpressModel.h>
 #include <LStepExpressMotionManager.h>
 #include <LStepExpressMotionView.h>
@@ -233,6 +234,8 @@ class AssemblyMainWindow : public QMainWindow
   AssemblyDBLoggerModel* DBLog_model_;
   AssemblyDBLoggerController* DBLog_ctrl_;
   AssemblyDBLoggerView* DBLog_view_;
+
+  AssemblyStopwatchWidget* stopwatch_wid_;
 
   QPushButton* button_mainEmergencyStop_;
   QPushButton* button_info_;

--- a/assembly/assemblyCommon/AssemblyStopwatchWidget.cc
+++ b/assembly/assemblyCommon/AssemblyStopwatchWidget.cc
@@ -1,0 +1,78 @@
+/////////////////////////////////////////////////////////////////////////////////
+//                                                                             //
+//               Copyright (C) 2011-2017 - The DESY CMS Group                  //
+//                           All rights reserved                               //
+//                                                                             //
+//      The CMStkModLab source code is licensed under the GNU GPL v3.0.        //
+//      You have the right to modify and/or redistribute this source code      //
+//      under the terms specified in the license, which may be found online    //
+//      at http://www.gnu.org/licenses or at License.txt.                      //
+//                                                                             //
+/////////////////////////////////////////////////////////////////////////////////
+
+#include <nqlogger.h>
+#include <ApplicationConfig.h>
+
+#include <AssemblyStopwatchWidget.h>
+#include <AssemblyUtilities.h>
+
+#include <QTime>
+
+AssemblyStopwatchWidget::AssemblyStopwatchWidget(QWidget* parent) : QWidget(parent)
+{
+  layout_ = new QHBoxLayout(this);
+  this->setLayout(layout_);
+
+  elapsed_timer_ = new QElapsedTimer();
+
+  update_timer_ = new QTimer();
+
+  button_layout_ = new QVBoxLayout();
+
+  start_ = new QPushButton("Start", this);
+  stop_ = new QPushButton("Stop", this);
+  reset_ = new QPushButton("Reset", this);
+
+  button_layout_->addWidget(start_);
+  button_layout_->addWidget(stop_);
+  button_layout_->addWidget(reset_);
+
+  layout_->addLayout(button_layout_);
+
+  connect(start_, SIGNAL(clicked()), this, SLOT(startStopwatch()));
+  connect(stop_, SIGNAL(clicked()), this, SLOT(stopStopwatch()));
+  connect(reset_, SIGNAL(clicked()), this, SLOT(resetStopwatch()));
+
+  QTime time_elapsed = QTime(0, 0, 0, elapsed_timer_->elapsed());
+  elapsedTimeLabel_ = new QLabel(time_elapsed.toString("mm:ss"));
+  layout_->addWidget(elapsedTimeLabel_);
+
+  connect(update_timer_, &QTimer::timeout, this, &AssemblyStopwatchWidget::updateStopwatch);
+
+  NQLog("AssemblyStopwatchWidget", NQLog::Message) << "constructed";
+}
+
+void AssemblyStopwatchWidget::startStopwatch(){
+  NQLog("AssemblyStopwatchWidget", NQLog::Message) << ": Starting stopwatch";
+  elapsed_timer_->start();
+  update_timer_->start(500);
+}
+
+void AssemblyStopwatchWidget::stopStopwatch(){
+  NQLog("AssemblyStopwatchWidget", NQLog::Message) << ": Stopping stopwatch";
+
+  elapsed_timer_->invalidate();
+  update_timer_->stop();
+}
+
+void AssemblyStopwatchWidget::resetStopwatch(){
+  NQLog("AssemblyStopwatchWidget", NQLog::Message) << ": Resetting stopwatch";
+}
+
+void AssemblyStopwatchWidget::updateStopwatch(){
+  NQLog("AssemblyStopwatchWidget", NQLog::Message) << ": Updating stopwatch";
+
+  QTime time_elapsed = QTime(0, 0, 0, elapsed_timer_->elapsed());
+  elapsedTimeLabel_ = new QLabel(time_elapsed.toString("mm:ss"));
+  NQLog("AssemblyStopwatchWidget", NQLog::Message) << ": Time: " << time_elapsed.toString("mm:ss");
+}

--- a/assembly/assemblyCommon/AssemblyStopwatchWidget.h
+++ b/assembly/assemblyCommon/AssemblyStopwatchWidget.h
@@ -20,7 +20,7 @@
 #include <QPushButton>
 #include <QLabel>
 #include <QTimer>
-#include <QElapsedTimer>
+#include <QTime>
 
 #include <RelayCardManager.h>
 
@@ -46,7 +46,7 @@ class AssemblyStopwatchWidget : public QWidget
   double seconds_;
 
   QTimer* update_timer_;
-  QElapsedTimer* elapsed_timer_;
+  QTime reference_time_;
 
   QLabel* elapsedTimeLabel_;
 

--- a/assembly/assemblyCommon/AssemblyStopwatchWidget.h
+++ b/assembly/assemblyCommon/AssemblyStopwatchWidget.h
@@ -1,0 +1,63 @@
+/////////////////////////////////////////////////////////////////////////////////
+//                                                                             //
+//               Copyright (C) 2011-2017 - The DESY CMS Group                  //
+//                           All rights reserved                               //
+//                                                                             //
+//      The CMStkModLab source code is licensed under the GNU GPL v3.0.        //
+//      You have the right to modify and/or redistribute this source code      //
+//      under the terms specified in the license, which may be found online    //
+//      at http://www.gnu.org/licenses or at License.txt.                      //
+//                                                                             //
+/////////////////////////////////////////////////////////////////////////////////
+
+#ifndef ASSEMBLYSTOPWATCHWIDGET_H
+#define ASSEMBLYSTOPWATCHWIDGET_H
+
+#include <QWidget>
+#include <QString>
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QPushButton>
+#include <QLabel>
+#include <QTimer>
+#include <QElapsedTimer>
+
+#include <RelayCardManager.h>
+
+#include <map>
+
+class AssemblyStopwatchWidget : public QWidget
+{
+ Q_OBJECT
+
+ public:
+
+  explicit AssemblyStopwatchWidget(QWidget* parent=nullptr);
+  virtual ~AssemblyStopwatchWidget() {}
+
+ protected:
+
+  QVBoxLayout* button_layout_;
+  QHBoxLayout* layout_;
+  QPushButton* start_;
+  QPushButton* stop_;
+  QPushButton* reset_;
+
+  double seconds_;
+
+  QTimer* update_timer_;
+  QElapsedTimer* elapsed_timer_;
+
+  QLabel* elapsedTimeLabel_;
+
+ public slots:
+
+  void startStopwatch();
+  void stopStopwatch();
+  void resetStopwatch();
+
+  void updateStopwatch();
+
+};
+
+#endif // ASSEMBLYSTOPWATCHWIDGET_H

--- a/assembly/assemblyCommon/CMakeLists.txt
+++ b/assembly/assemblyCommon/CMakeLists.txt
@@ -65,6 +65,7 @@ add_library(AssemblyCommon SHARED
         AssemblyDBLoggerController.cc
         AssemblyDBLoggerModel.cc
         AssemblyDBLoggerView.cc
+        AssemblyStopwatchWidget.cc
 )
 
 if(CMSTKMODLAB_FAKEUEYE)


### PR DESCRIPTION
This adds a stopwatch to the toolbar. The color scheme is adjusted to the guidelines for using EA 3430:
 * < 1 min: red, keep mixing
 * < 20 min: orange, curing
 * \> 20 min: green, continue assembly

![image](https://github.com/user-attachments/assets/f9d44cae-bdb9-4e48-88c2-0a4a4f77ce1d)