### PR TITLE
Block camera buttons during some actions.

### DIFF
--- a/assembly/assembly/AssemblyMainWindow.cc
+++ b/assembly/assembly/AssemblyMainWindow.cc
@@ -706,7 +706,7 @@ void AssemblyMainWindow::enable_images()
 
   if(image_ctr_ == nullptr)
   {
-    image_ctr_ = new AssemblyImageController(camera_, zfocus_finder_);
+    image_ctr_ = new AssemblyImageController(camera_, zfocus_finder_, this);
   }
 
   connect(this      , SIGNAL(images_ON())      , image_ctr_, SLOT(enable()));

--- a/assembly/assembly/AssemblyMainWindow.cc
+++ b/assembly/assembly/AssemblyMainWindow.cc
@@ -933,6 +933,8 @@ void AssemblyMainWindow::start_objectAligner(const AssemblyObjectAligner::Config
   // if successful, emits signal "configuration_updated()"
   aligner_->update_configuration(conf);
 
+  this->disable_imageButtons(this);
+
   return;
 }
 
@@ -982,6 +984,8 @@ void AssemblyMainWindow::disconnect_objectAligner()
   aligner_view_->Configuration_Widget()->setEnabled(true);
 
   aligner_connected_ = false;
+
+  this->enable_imageButtons(this);
 
   return;
 }

--- a/assembly/assembly/AssemblyMainWindow.cc
+++ b/assembly/assembly/AssemblyMainWindow.cc
@@ -95,6 +95,7 @@ AssemblyMainWindow::AssemblyMainWindow(const QString& outputdir_path, const QStr
 
   button_mainEmergencyStop_(nullptr),
   button_info_(nullptr),
+  button_snapshot_(nullptr),
 
   // flags
   images_enabled_(false),
@@ -510,10 +511,10 @@ AssemblyMainWindow::AssemblyMainWindow(const QString& outputdir_path, const QStr
     spacer1->setMinimumSize(QSize(50,1));
     toolBar_->addWidget(spacer1);
 
-    auto button_snapshot = new QPushButton(tr("Snapshot"));
-    button_snapshot->setStyleSheet("QPushButton { background-color: rgb(0, 170, 0); font: 18px; border-radius: 8px; padding: 7px; } QPushButton:hover { background-color: green; font: bold 18px; border-radius: 8px; padding: 2px; }");
-    toolBar_->addWidget(button_snapshot);
-    connect(button_snapshot, SIGNAL(clicked()), this, SLOT( get_image ()));
+    button_snapshot_ = new QPushButton(tr("Snapshot"));
+    button_snapshot_->setStyleSheet("QPushButton { background-color: rgb(0, 170, 0); font: 18px; border-radius: 8px; padding: 7px; } QPushButton:hover { background-color: green; font: bold 18px; border-radius: 8px; padding: 2px; }");
+    toolBar_->addWidget(button_snapshot_);
+    connect(button_snapshot_, SIGNAL(clicked()), this, SLOT( get_image ()));
 
     QWidget *spacer2 = new QWidget();
     spacer2->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
@@ -1426,11 +1427,7 @@ void AssemblyMainWindow::disable_imageButtons(QObject* sender)
 
     NQLog("AssemblyMainWindow", NQLog::Debug) << "Blocking the camera. (from " << sender->metaObject()->className() << ")";
 
-    for(auto& action : toolBar_->actions()){
-      if(action->text() == "Snapshot"){
-        action->setEnabled(false);
-      }
-    }
+    button_snapshot_->setEnabled(false);
     image_view_->autofocus_button()->setEnabled(false);
     aligner_view_->button_runAlignment()->setEnabled(false);
 }
@@ -1448,12 +1445,8 @@ void AssemblyMainWindow::enable_imageButtons(QObject* sender)
       }
     } else {
       NQLog("AssemblyMainWindow", NQLog::Debug) << "Camera will be released.";
-      for(auto& action : toolBar_->actions()){
-        if(action->text() == "Snapshot"){
-          action->setEnabled(true);
-        }
-      }
+      button_snapshot_->setEnabled(true);
+      image_view_->autofocus_button()->setEnabled(true);
+      aligner_view_->button_runAlignment()->setEnabled(true);
     }
-    image_view_->autofocus_button()->setEnabled(true);
-    aligner_view_->button_runAlignment()->setEnabled(true);
 }

--- a/assembly/assembly/AssemblyMainWindow.cc
+++ b/assembly/assembly/AssemblyMainWindow.cc
@@ -278,7 +278,6 @@ AssemblyMainWindow::AssemblyMainWindow(const QString& outputdir_path, const QStr
     connect(aligner_view_->button_alignerEmergencyStop(), SIGNAL(clicked()), this, SLOT(disconnect_objectAligner()));
     connect(aligner_view_->button_alignerEmergencyStop(), SIGNAL(clicked()), motion_manager_, SLOT(emergency_stop()));
     connect(aligner_view_->button_alignerEmergencyStop(), SIGNAL(clicked()), zfocus_finder_ , SLOT(emergencyStop()));
-    connect(aligner_view_->button_alignerEmergencyStop(), SIGNAL(clicked()), image_ctr_    , SLOT(restore_autofocus_settings()));
 
 
     connect(this, SIGNAL(set_alignmentMode_PSP_request()), aligner_view_, SLOT(set_alignmentMode_PSP()));
@@ -437,7 +436,6 @@ AssemblyMainWindow::AssemblyMainWindow(const QString& outputdir_path, const QStr
     connect(metrology_view_->button_metrologyEmergencyStop(), SIGNAL(clicked()), this, SLOT(disconnect_metrology()));
     connect(metrology_view_->button_metrologyEmergencyStop(), SIGNAL(clicked()), motion_manager_, SLOT(emergency_stop()));
     connect(metrology_view_->button_metrologyEmergencyStop(), SIGNAL(clicked()), zfocus_finder_ , SLOT(emergencyStop()));
-    connect(metrology_view_->button_metrologyEmergencyStop(), SIGNAL(clicked()), image_ctr_ , SLOT(restore_autofocus_settings()));
     connect(metrology_view_->button_metrologyClearResults(), SIGNAL(clicked()), metrology_, SLOT(clear_results()));
 
     NQLog("AssemblyMainWindow", NQLog::Message) << "added view " << tabname_Metrology;
@@ -723,6 +721,10 @@ void AssemblyMainWindow::enable_images()
   connect(this      , SIGNAL(autofocus_ON ())  , image_ctr_, SLOT(enable_autofocus()));
   connect(this      , SIGNAL(autofocus_OFF())  , image_ctr_, SLOT(disable_autofocus()));
   connect(image_view_, SIGNAL(request_image()), image_ctr_, SLOT(acquire_image()));
+
+  connect(button_mainEmergencyStop_, SIGNAL(clicked()), image_ctr_, SLOT(restore_autofocus_settings()));
+  connect(metrology_view_->button_metrologyEmergencyStop(), SIGNAL(clicked()), image_ctr_, SLOT(restore_autofocus_settings()));
+  connect(aligner_view_->button_alignerEmergencyStop(), SIGNAL(clicked()), image_ctr_, SLOT(restore_autofocus_settings()));
 
   NQLog("AssemblyMainWindow", NQLog::Message) << "enable_images"
      << ": connecting AssemblyImageController";

--- a/assembly/assembly/AssemblyMainWindow.cc
+++ b/assembly/assembly/AssemblyMainWindow.cc
@@ -1415,3 +1415,39 @@ void AssemblyMainWindow::closeEvent (QCloseEvent *event)
         }
     }
 }
+
+void AssemblyMainWindow::disable_imageButtons(QObject* sender)
+{
+    camera_blocking_objects_.append(sender);
+
+    NQLog("AssemblyMainWindow", NQLog::Debug) << "Blocking the camera. (from " << sender->metaObject()->className() << ")";
+
+    for(auto& action : toolBar_->actions()){
+      if(action->text() == "Snapshot"){
+        action->setEnabled(false);
+      }
+    }
+    image_view_->autofocus_button()->setEnabled(false);
+}
+
+void AssemblyMainWindow::enable_imageButtons(QObject* sender)
+{
+    NQLog("AssemblyMainWindow", NQLog::Debug) << "Camera release request. (from " << sender->metaObject()->className() << ")";
+
+    camera_blocking_objects_.removeAll(sender);
+    if(camera_blocking_objects_.size())
+    {
+      NQLog("AssemblyMainWindow", NQLog::Debug) << "There are still " << camera_blocking_objects_.size() << " objects blocking the camera:";
+      for(auto& obj : camera_blocking_objects_){
+        NQLog("AssemblyMainWindow", NQLog::Debug) << "   "  << obj->metaObject()->className();
+      }
+    } else {
+      NQLog("AssemblyMainWindow", NQLog::Debug) << "Camera will be released.";
+      for(auto& action : toolBar_->actions()){
+        if(action->text() == "Snapshot"){
+          action->setEnabled(true);
+        }
+      }
+    }
+    image_view_->autofocus_button()->setEnabled(true);
+}

--- a/assembly/assembly/AssemblyMainWindow.cc
+++ b/assembly/assembly/AssemblyMainWindow.cc
@@ -278,6 +278,8 @@ AssemblyMainWindow::AssemblyMainWindow(const QString& outputdir_path, const QStr
     connect(aligner_view_->button_alignerEmergencyStop(), SIGNAL(clicked()), this, SLOT(disconnect_objectAligner()));
     connect(aligner_view_->button_alignerEmergencyStop(), SIGNAL(clicked()), motion_manager_, SLOT(emergency_stop()));
     connect(aligner_view_->button_alignerEmergencyStop(), SIGNAL(clicked()), zfocus_finder_ , SLOT(emergencyStop()));
+    connect(aligner_view_->button_alignerEmergencyStop(), SIGNAL(clicked()), image_ctr_    , SLOT(restore_autofocus_settings()));
+
 
     connect(this, SIGNAL(set_alignmentMode_PSP_request()), aligner_view_, SLOT(set_alignmentMode_PSP()));
     connect(this, SIGNAL(set_alignmentMode_PSS_request()), aligner_view_, SLOT(set_alignmentMode_PSS()));
@@ -435,6 +437,7 @@ AssemblyMainWindow::AssemblyMainWindow(const QString& outputdir_path, const QStr
     connect(metrology_view_->button_metrologyEmergencyStop(), SIGNAL(clicked()), this, SLOT(disconnect_metrology()));
     connect(metrology_view_->button_metrologyEmergencyStop(), SIGNAL(clicked()), motion_manager_, SLOT(emergency_stop()));
     connect(metrology_view_->button_metrologyEmergencyStop(), SIGNAL(clicked()), zfocus_finder_ , SLOT(emergencyStop()));
+    connect(metrology_view_->button_metrologyEmergencyStop(), SIGNAL(clicked()), image_ctr_ , SLOT(restore_autofocus_settings()));
     connect(metrology_view_->button_metrologyClearResults(), SIGNAL(clicked()), metrology_, SLOT(clear_results()));
 
     NQLog("AssemblyMainWindow", NQLog::Message) << "added view " << tabname_Metrology;
@@ -941,6 +944,9 @@ void AssemblyMainWindow::start_objectAligner(const AssemblyObjectAligner::Config
 
 void AssemblyMainWindow::disconnect_objectAligner()
 {
+  NQLog("AssemblyMainWindow", NQLog::Debug) << "disconnect_objectAligner"
+     << ": Disconnecting object aligner";
+
   if(image_ctr_ == nullptr)
   {
     NQLog("AssemblyMainWindow", NQLog::Warning) << "disconnect_objectAligner"

--- a/assembly/assembly/AssemblyMainWindow.cc
+++ b/assembly/assembly/AssemblyMainWindow.cc
@@ -1432,6 +1432,7 @@ void AssemblyMainWindow::disable_imageButtons(QObject* sender)
       }
     }
     image_view_->autofocus_button()->setEnabled(false);
+    aligner_view_->button_runAlignment()->setEnabled(false);
 }
 
 void AssemblyMainWindow::enable_imageButtons(QObject* sender)
@@ -1454,4 +1455,5 @@ void AssemblyMainWindow::enable_imageButtons(QObject* sender)
       }
     }
     image_view_->autofocus_button()->setEnabled(true);
+    aligner_view_->button_runAlignment()->setEnabled(true);
 }

--- a/assembly/assembly/AssemblyMainWindow.h
+++ b/assembly/assembly/AssemblyMainWindow.h
@@ -234,6 +234,7 @@ class AssemblyMainWindow : public QMainWindow
 
   QPushButton* button_mainEmergencyStop_;
   QPushButton* button_info_;
+  QPushButton* button_snapshot_;
 
   // flags
   bool images_enabled_;

--- a/assembly/assembly/AssemblyMainWindow.h
+++ b/assembly/assembly/AssemblyMainWindow.h
@@ -160,6 +160,10 @@ class AssemblyMainWindow : public QMainWindow
 
   void messageBox_restartMotionStage();
 
+  void disable_imageButtons(QObject*);
+
+  void enable_imageButtons(QObject*);
+
  protected:
 
   // Low-Level Controllers (Motion, Camera, Vacuum)
@@ -243,6 +247,8 @@ class AssemblyMainWindow : public QMainWindow
   int idx_alignment_tab;
   int idx_module_tab;
   int idx_manual_tab;
+
+  QList<QObject*> camera_blocking_objects_;
 };
 
 #endif // ASSEMBLYMAINWINDOW_H

--- a/assembly/assemblyCommon/AssemblyImageController.cc
+++ b/assembly/assemblyCommon/AssemblyImageController.cc
@@ -173,10 +173,15 @@ void AssemblyImageController::acquire_autofocused_image()
   connect(this, SIGNAL(autofocused_image_request()), this, SLOT(acquire_image()));
   connect(this, SIGNAL(image_acquired()), this, SLOT(restore_autofocus_settings()));
 
+  connect(this, SIGNAL(block_camera(QObject*)), parent(), SLOT(disable_imageButtons(QObject*)));
+  connect(this, SIGNAL(release_camera(QObject*)), parent(), SLOT(enable_imageButtons(QObject*)));
+
   NQLog("AssemblyImageController", NQLog::Message) << "acquire_autofocused_image"
      << ": emitting signal \"image_request\"";
 
   emit autofocused_image_request();
+
+  emit block_camera(this);
 }
 
 void AssemblyImageController::restore_autofocus_settings()
@@ -193,4 +198,10 @@ void AssemblyImageController::restore_autofocus_settings()
      << ": emitting signal \"autofocused_image_acquired\"";
 
   emit autofocused_image_acquired();
+
+  emit release_camera(this);
+
+  disconnect(this, SIGNAL(block_camera(QObject*)), parent(), SLOT(disable_imageButtons(QObject*)));
+  disconnect(this, SIGNAL(release_camera(QObject*)), parent(), SLOT(enable_imageButtons(QObject*)));
+
 }

--- a/assembly/assemblyCommon/AssemblyImageController.h
+++ b/assembly/assemblyCommon/AssemblyImageController.h
@@ -83,6 +83,9 @@ class AssemblyImageController : public QObject
 
     void autofocused_image_request();
     void autofocused_image_acquired();
+
+    void block_camera(QObject*);
+    void release_camera(QObject*);
 };
 
 #endif // ASSEMBLYIMAGECONTROLLER_H

--- a/assembly/assemblyCommon/AssemblyObjectAlignerView.h
+++ b/assembly/assemblyCommon/AssemblyObjectAlignerView.h
@@ -49,6 +49,7 @@ class AssemblyObjectAlignerView : public QWidget
   AssemblyUEyeView* PatRecTwo_Image() const { return patrecTwo_image_; }
 
   QPushButton* button_alignerEmergencyStop() const { return button_alignerEmergencyStop_; }
+  QPushButton* button_runAlignment() { return alignm_exealig_pusbu_; }
 
   AssemblyObjectAligner::Configuration get_configuration(bool&) const;
 


### PR DESCRIPTION
This blocks camera buttons (Snapshot / z-focus scan) while a z-focus or an alignment are ongoing.

To Do:
 * [x] Can we also block the "Run alignment" button?
 * [x] Testing (@schuetzepaul )