### PR TITLE
Close software

### DIFF
--- a/assembly/assembly/AssemblyMainWindow.cc
+++ b/assembly/assembly/AssemblyMainWindow.cc
@@ -1393,7 +1393,8 @@ void AssemblyMainWindow::closeEvent (QCloseEvent *event)
      || std::fabs(motion_manager_->get_position_Z())>0.001
      || std::fabs(motion_manager_->get_position_A())>0.001 )) {
 
-        QMessageBox* msgBox = new QMessageBox;
+        QMessageBox* msgBox = new QMessageBox();
+        msgBox->setWindowTitle("Stage not at origin.");
         msgBox->setInformativeText("You are attempting to close the software. Would you like to move the stage back to the origin?");
         msgBox->setStandardButtons(QMessageBox::Cancel | QMessageBox::No | QMessageBox::Yes);
         msgBox->setDefaultButton(QMessageBox::Cancel);

--- a/assembly/assembly/AssemblyMainWindow.cc
+++ b/assembly/assembly/AssemblyMainWindow.cc
@@ -1381,3 +1381,39 @@ void AssemblyMainWindow::warn_on_stage_limits(const double target_pos, const cha
         QMessageBox::Ok
     );
 }
+
+void AssemblyMainWindow::closeEvent (QCloseEvent *event)
+{
+    bool motion_status;
+    motion_model_->getStatus(motion_status);
+
+    if(motion_status && (
+        std::fabs(motion_manager_->get_position_X())>0.001
+     || std::fabs(motion_manager_->get_position_Y())>0.001
+     || std::fabs(motion_manager_->get_position_Z())>0.001
+     || std::fabs(motion_manager_->get_position_A())>0.001 )) {
+
+        QMessageBox* msgBox = new QMessageBox;
+        msgBox->setInformativeText("You are attempting to close the software. Would you like to move the stage back to the origin?");
+        msgBox->setStandardButtons(QMessageBox::Cancel | QMessageBox::No | QMessageBox::Yes);
+        msgBox->setDefaultButton(QMessageBox::Cancel);
+        int ret = msgBox->exec();
+
+        if(ret == QMessageBox::Cancel) {
+            NQLog("AssemblyMainWindow", NQLog::Message) << "User decision: not closing the software.";
+            event->ignore();
+        } else if(ret == QMessageBox::No) {
+            NQLog("AssemblyMainWindow", NQLog::Message) << "User decision: leave stage at current position.";
+            event->accept();
+        } else {
+            NQLog("AssemblyMainWindow", NQLog::Message) << "User decision: move stage back to origin.";
+            motion_manager_->moveAbsolute();
+
+            QEventLoop loop;
+            connect(motion_manager_, &LStepExpressMotionManager::motion_finished, &loop, &QEventLoop::quit);
+            loop.exec();
+
+            event->accept();
+        }
+    }
+}

--- a/assembly/assembly/AssemblyMainWindow.cc
+++ b/assembly/assembly/AssemblyMainWindow.cc
@@ -1302,7 +1302,7 @@ void AssemblyMainWindow::update_stage_position()
   const auto z_status  = motion_model_->getAxisStatusText(2);
   const auto a_status  = motion_model_->getAxisStatusText(3);
 
-  for(unsigned int i=0; i<4; ++i)
+  for(unsigned int i=0; i<stage_values_.size(); ++i)
   {
     if(!motion_model_->getAxisEnabled(i)) {
       QString tpl = tr("<font color='%1'>%2</font>");

--- a/assembly/assembly/AssemblyMainWindow.h
+++ b/assembly/assembly/AssemblyMainWindow.h
@@ -86,6 +86,9 @@ class AssemblyMainWindow : public QMainWindow
   }
   void switchAndUpdate_alignment_tab(bool);
 
+ private:
+    void closeEvent (QCloseEvent *event);
+
  public slots:
 
   void  enable_images();

--- a/assembly/assemblyCommon/LStepExpressModel.cc
+++ b/assembly/assemblyCommon/LStepExpressModel.cc
@@ -1037,6 +1037,11 @@ void LStepExpressModel::initialize()
 
       const QStringList ports_list = portDir.entryList();
 
+#ifdef USE_FAKEIO
+      renewController("FakePort");
+      enabled = controller_->DeviceAvailable();
+#endif
+
       for(const auto& port : ports_list)
       {
         renewController(portDir.canonicalPath()+"/"+port);


### PR DESCRIPTION
This adds a dialogue asking the user whether the stages should move back to Origin (0,0,0,0) when the software is closed. 

<img width="386" height="254" alt="image" src="https://github.com/user-attachments/assets/9af63808-2544-472f-aeef-daccb032967f" />

This tackles #222 

To Do:

- [x] Test at assembly setup.
- [x] Discuss check for vacuum channels