### PR TITLE
Start GUI after stage connection is established

### DIFF
--- a/assembly/assembly/AssemblyMainWindow.cc
+++ b/assembly/assembly/AssemblyMainWindow.cc
@@ -339,18 +339,15 @@ AssemblyMainWindow::AssemblyMainWindow(const QString& outputdir_path, const QStr
       const int time_to_axes_startup(1.5 * motion_manager_->model()->updateInterval());
       QThread::msleep(time_to_axes_startup);
 
-      QTimer t_timeout;
-      t_timeout.setSingleShot(true);
       QEventLoop loop;
       connect(hwctr_view_->LStepExpress_Widget(), &LStepExpressWidget::restart_completed, &loop, &QEventLoop::quit);
-      connect(&t_timeout, &QTimer::timeout, &loop, &QEventLoop::quit);
-      t_timeout.start(10000);
+      connect(hwctr_view_->LStepExpress_Widget(), &LStepExpressWidget::restart_failed, &loop, &QEventLoop::quit);
 
-      hwctr_view_->LStepExpress_Widget()->restart();
+      QTimer::singleShot(1000, hwctr_view_->LStepExpress_Widget(), SLOT(restart()));
       loop.exec();
 
       disconnect(hwctr_view_->LStepExpress_Widget(), &LStepExpressWidget::restart_completed, &loop, &QEventLoop::quit);
-      disconnect(&t_timeout, &QTimer::timeout, &loop, &QEventLoop::quit);
+      disconnect(hwctr_view_->LStepExpress_Widget(), &LStepExpressWidget::restart_failed, &loop, &QEventLoop::quit);
 
       if(motion_model_->getDeviceState()==State::OFF) {
         NQLog("AssemblyMainWindow", NQLog::Fatal) << "Motion Stage Controller could not be started!";

--- a/assembly/assembly/AssemblyMainWindow.cc
+++ b/assembly/assembly/AssemblyMainWindow.cc
@@ -618,6 +618,8 @@ AssemblyMainWindow::AssemblyMainWindow(const QString& outputdir_path, const QStr
       stage_lay->addWidget(stage_values_.at(i), 1, i);
     }
 
+    update_stage_position();
+
     stage_wid->setLayout(stage_lay);
 
     toolBar_->addWidget(stage_wid);

--- a/assembly/assembly/AssemblyMainWindow.cc
+++ b/assembly/assembly/AssemblyMainWindow.cc
@@ -337,7 +337,31 @@ AssemblyMainWindow::AssemblyMainWindow(const QString& outputdir_path, const QStr
 
       // single-shot signal to switch ON motion stage axes automatically
       const int time_to_axes_startup(1.5 * motion_manager_->model()->updateInterval());
-      QTimer::singleShot(time_to_axes_startup, hwctr_view_->LStepExpress_Widget(), SLOT(restart()));
+      QThread::msleep(time_to_axes_startup);
+
+      QTimer t_timeout;
+      t_timeout.setSingleShot(true);
+      QEventLoop loop;
+      connect(hwctr_view_->LStepExpress_Widget(), &LStepExpressWidget::restart_completed, &loop, &QEventLoop::quit);
+      connect(&t_timeout, &QTimer::timeout, &loop, &QEventLoop::quit);
+      t_timeout.start(10000);
+
+      hwctr_view_->LStepExpress_Widget()->restart();
+      loop.exec();
+
+      disconnect(hwctr_view_->LStepExpress_Widget(), &LStepExpressWidget::restart_completed, &loop, &QEventLoop::quit);
+      disconnect(&t_timeout, &QTimer::timeout, &loop, &QEventLoop::quit);
+
+      if(motion_model_->getDeviceState()==State::OFF) {
+        NQLog("AssemblyMainWindow", NQLog::Fatal) << "Motion Stage Controller could not be started!";
+
+        QMessageBox* msgBox = new QMessageBox;
+        msgBox->setInformativeText("Motion Stage Controller is not available!");
+
+        msgBox->setStandardButtons(QMessageBox::Ok);
+
+        int ret = msgBox->exec();
+      }
 
       NQLog("AssemblyMainWindow", NQLog::Message) << "added view " << tabname_HWCtrl;
     }
@@ -645,17 +669,6 @@ AssemblyMainWindow::AssemblyMainWindow(const QString& outputdir_path, const QStr
     if(startup_camera)
     {
       this->enable_images();
-    }
-
-    if(startup_motion_stage && motion_model_->getDeviceState()==State::OFF) {
-      NQLog("AssemblyMainWindow", NQLog::Fatal) << "Motion Stage Controller could not be started!";
-
-      QMessageBox* msgBox = new QMessageBox;
-      msgBox->setInformativeText("Motion Stage Controller is not available!");
-
-      msgBox->setStandardButtons(QMessageBox::Ok);
-
-      int ret = msgBox->exec();
     }
     // ------------------------
 }

--- a/assembly/assemblyCommon/LStepExpressWidget.cc
+++ b/assembly/assemblyCommon/LStepExpressWidget.cc
@@ -235,6 +235,8 @@ void LStepExpressWidget::restart()
     NQLog("LStepExpressWidget", NQLog::Critical) << "restart [step=" << restart_step_ << "]"
        << ": logic error, motion stage NOT READY (try to initialize LStepExpressModel by ticking the \"Enable Controller\" box)";
 
+    emit restart_failed();
+
     return;
   }
 
@@ -248,6 +250,8 @@ void LStepExpressWidget::restart()
 
       NQLog("LStepExpressWidget", NQLog::Critical) << "restart [step=" << restart_step_ << "]"
          << ": logic error, restart-timer was already initialized (disabled now), restart procedure stopped";
+
+      emit restart_failed();
 
       return;
     }
@@ -470,7 +474,9 @@ void LStepExpressWidget::restart()
       int ret = msgBox->exec();
       switch(ret)
       {
-	case QMessageBox::No: break;
+	case QMessageBox::No:
+          emit restart_failed();
+          break;
         case QMessageBox::Yes:
           restart_step_ = 0;
           this->restart();

--- a/assembly/assemblyCommon/LStepExpressWidget.h
+++ b/assembly/assemblyCommon/LStepExpressWidget.h
@@ -102,6 +102,8 @@ class LStepExpressWidget : public QWidget
 
   void restart_completed();
 
+  void restart_failed();
+
   void moveToOrigin_request();
 
   void startCalibrate();


### PR DESCRIPTION
With this, the GUI startup is only issued when the stage is ready.
If the stage is not available, the user receives the corresponding message before the GUI startup and all motion buttons are deactivated. This avoids issuing a stage motion before the stage is properly connected, which could have led to undefined behaviour.

To Do:
 * [x] Testing @schuetzepaul 