### PR TITLE
Add steps: calibration check

### DIFF
--- a/assembly/assemblyCommon/AssemblyAssemblyV2.cc
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2.cc
@@ -689,6 +689,55 @@ void AssemblyAssemblyV2::PushStep3ToDB_start()
 }
 
 // ----------------------------------------------------------------------------------------------------
+// GoToPlatformReferencePoint -----------------------------------------------------------------------
+// ----------------------------------------------------------------------------------------------------
+void AssemblyAssemblyV2::GoToPlatformReferencePoint_start()
+{
+  if(in_action_){
+
+    NQLog("AssemblyAssemblyV2", NQLog::Warning) << "GoToPlatformReferencePoint_start"
+       << ": logic error, an assembly step is still in progress, will not take further action";
+
+    return;
+  }
+
+  const double x0 = config_->getValue<double>("parameters", "RefPointPlatform_X");
+  const double y0 = config_->getValue<double>("parameters", "RefPointPlatform_Y");
+  const double z0 = config_->getValue<double>("parameters", "RefPointPlatform_Z");
+  const double a0 = config_->getValue<double>("parameters", "RefPointPlatform_A");
+
+  connect(this, SIGNAL(move_absolute_request(double, double, double, double)), motion_, SLOT(moveAbsolute(double, double, double, double)));
+  connect(motion_, SIGNAL(motion_finished()), this, SLOT(GoToPlatformReferencePoint_finish()));
+
+  in_action_ = true;
+
+  NQLog("AssemblyAssemblyV2", NQLog::Spam) << "GoToPlatformReferencePoint_start"
+     << ": emitting signal \"move_absolute_request(" << x0 << ", " << y0 << ", " << z0 << ", " << a0 << ")\"";
+
+  emit move_absolute_request(x0, y0, z0, a0);
+}
+
+void AssemblyAssemblyV2::GoToPlatformReferencePoint_finish()
+{
+  disconnect(this, SIGNAL(move_absolute_request(double, double, double, double)), motion_, SLOT(moveAbsolute(double, double, double, double)));
+  disconnect(motion_, SIGNAL(motion_finished()), this, SLOT(GoToPlatformReferencePoint_finish()));
+
+  if(in_action_){ in_action_ = false; }
+
+  NQLog("AssemblyAssemblyV2", NQLog::Spam) << "GoToPlatformReferencePoint_finish"
+     << ": emitting signal \"GoToPlatformReferencePoint_finished\"";
+
+  emit GoToPlatformReferencePoint_finished();
+
+  NQLog("AssemblyAssemblyV2", NQLog::Message) << "GoToPlatformReferencePoint_finish"
+     << ": assembly-step completed";
+
+  emit DBLogMessage("== Assembly step completed : [Move to platform's reference point (calibration check)]");
+}
+// ----------------------------------------------------------------------------------------------------
+
+
+// ----------------------------------------------------------------------------------------------------
 // GoToSensorMarkerPreAlignment -----------------------------------------------------------------------
 // ----------------------------------------------------------------------------------------------------
 void AssemblyAssemblyV2::GoToSensorMarkerPreAlignment_start(bool isMapsa)

--- a/assembly/assemblyCommon/AssemblyAssemblyV2.cc
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2.cc
@@ -736,6 +736,53 @@ void AssemblyAssemblyV2::GoToPlatformReferencePoint_finish()
 }
 // ----------------------------------------------------------------------------------------------------
 
+// ----------------------------------------------------------------------------------------------------
+// GoToOrigin -----------------------------------------------------------------------
+// ----------------------------------------------------------------------------------------------------
+void AssemblyAssemblyV2::GoToOrigin_start()
+{
+  if(in_action_){
+
+    NQLog("AssemblyAssemblyV2", NQLog::Warning) << "GoToOrigin_start"
+       << ": logic error, an assembly step is still in progress, will not take further action";
+
+    return;
+  }
+
+  const double x0 = 0;
+  const double y0 = 0;
+  const double z0 = 0;
+  const double a0 = 0;
+
+  connect(this, SIGNAL(move_absolute_request(double, double, double, double)), motion_, SLOT(moveAbsolute(double, double, double, double)));
+  connect(motion_, SIGNAL(motion_finished()), this, SLOT(GoToOrigin_finish()));
+
+  in_action_ = true;
+
+  NQLog("AssemblyAssemblyV2", NQLog::Spam) << "GoToOrigin_start"
+     << ": emitting signal \"move_absolute_request(" << x0 << ", " << y0 << ", " << z0 << ", " << a0 << ")\"";
+
+  emit move_absolute_request(x0, y0, z0, a0);
+}
+
+void AssemblyAssemblyV2::GoToOrigin_finish()
+{
+  disconnect(this, SIGNAL(move_absolute_request(double, double, double, double)), motion_, SLOT(moveAbsolute(double, double, double, double)));
+  disconnect(motion_, SIGNAL(motion_finished()), this, SLOT(GoToOrigin_finish()));
+
+  if(in_action_){ in_action_ = false; }
+
+  NQLog("AssemblyAssemblyV2", NQLog::Spam) << "GoToOrigin_finish"
+     << ": emitting signal \"GoToOrigin_finished\"";
+
+  emit GoToOrigin_finished();
+
+  NQLog("AssemblyAssemblyV2", NQLog::Message) << "GoToOrigin_finish"
+     << ": assembly-step completed";
+
+  emit DBLogMessage("== Assembly step completed : [Move to stage origin]");
+}
+// ----------------------------------------------------------------------------------------------------
 
 // ----------------------------------------------------------------------------------------------------
 // GoToSensorMarkerPreAlignment -----------------------------------------------------------------------

--- a/assembly/assemblyCommon/AssemblyAssemblyV2.h
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2.h
@@ -90,6 +90,9 @@ class AssemblyAssemblyV2 : public QObject
   void GoToPSPSensorMarkerPreAlignment_start() {GoToSensorMarkerPreAlignment_start(true );};
   void GoToPSSSensorMarkerPreAlignment_start() {GoToSensorMarkerPreAlignment_start(false);};
 
+  void GoToPlatformReferencePoint_start();
+  void GoToPlatformReferencePoint_finish();
+
   void GoToSensorMarkerPreAlignment_start(const bool isMapsa);
   void GoToSensorMarkerPreAlignment_finish();
 
@@ -240,6 +243,8 @@ class AssemblyAssemblyV2 : public QObject
   void PushStep1ToDB_aborted();
   void PushStep2ToDB_aborted();
   void PushStep3ToDB_aborted();
+
+  void GoToPlatformReferencePoint_finished();
 
   void GoToSensorMarkerPreAlignment_finished();
 

--- a/assembly/assemblyCommon/AssemblyAssemblyV2.h
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2.h
@@ -93,6 +93,9 @@ class AssemblyAssemblyV2 : public QObject
   void GoToPlatformReferencePoint_start();
   void GoToPlatformReferencePoint_finish();
 
+  void GoToOrigin_start();
+  void GoToOrigin_finish();
+
   void GoToSensorMarkerPreAlignment_start(const bool isMapsa);
   void GoToSensorMarkerPreAlignment_finish();
 
@@ -245,6 +248,8 @@ class AssemblyAssemblyV2 : public QObject
   void PushStep3ToDB_aborted();
 
   void GoToPlatformReferencePoint_finished();
+
+  void GoToOrigin_finished();
 
   void GoToSensorMarkerPreAlignment_finished();
 

--- a/assembly/assemblyCommon/AssemblyAssemblyV2View.cc
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2View.cc
@@ -182,6 +182,19 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
       }
       // ----------
 
+      // step: Go to origin
+      {
+        ++assembly_step_N;
+
+        AssemblyAssemblyActionWidget* tmp_wid = new AssemblyAssemblyActionWidget;
+        tmp_wid->label()->setText(QString::number(assembly_step_N));
+        tmp_wid->button()->setText("Go To Origin");
+        PSPToBasep_lay->addWidget(tmp_wid);
+
+        tmp_wid->connect_action(assembly, SLOT(GoToOrigin_start()), SIGNAL(GoToOrigin_finished()));
+      }
+      // ----------
+
       // step: Define/Scan Module ID
       {
         ++assembly_step_N;

--- a/assembly/assemblyCommon/AssemblyAssemblyV2View.cc
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2View.cc
@@ -158,6 +158,30 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
   wid_PSPToBasep_->setLayout(PSPToBasep_lay);
 
   if(assembly->GetAssemblyCenter() == assembly::Center::DESY){
+      // step: Go to platform reference point
+      {
+        ++assembly_step_N;
+
+        AssemblyAssemblyActionWidget* tmp_wid = new AssemblyAssemblyActionWidget;
+        tmp_wid->label()->setText(QString::number(assembly_step_N));
+        tmp_wid->button()->setText("Go To Platform Reference Point");
+        PSPToBasep_lay->addWidget(tmp_wid);
+
+        tmp_wid->connect_action(assembly, SLOT(GoToPlatformReferencePoint_start()), SIGNAL(GoToPlatformReferencePoint_finished()));
+      }
+      // ----------
+
+      // step: Check platform reference point
+      {
+        ++assembly_step_N;
+
+        AssemblyAssemblyTextWidget* tmp_wid = new AssemblyAssemblyTextWidget;
+        tmp_wid->label()->setText(QString::number(assembly_step_N));
+        tmp_wid->text()->setText("Take an Image and validate that the Platform Reference Marker is centered in the Image");
+        PSPToBasep_lay->addWidget(tmp_wid);
+      }
+      // ----------
+
       // step: Define/Scan Module ID
       {
         ++assembly_step_N;


### PR DESCRIPTION
This adds three steps to the assembly workflow (Part I, MaPSA to BP) for a validation of the stage calibration:
1. Go to the assembly platform reference point (Action)
2. Take an image and validate that the marker is centered (Text)
3. Move to Origin (Action)

The last step makes sure that there's enough space for placing the MaPSA on the platform.

This is only implemented for the DESY assembly sequence and has been tested here.