### PR TITLE
Assembly in action

### DIFF
--- a/assembly/assembly/AssemblyMainWindow.cc
+++ b/assembly/assembly/AssemblyMainWindow.cc
@@ -995,6 +995,7 @@ void AssemblyMainWindow::disconnect_objectAligner()
   aligner_connected_ = false;
 
   this->enable_imageButtons(this);
+  assemblyV2_->set_in_action(false);
 
   return;
 }

--- a/assembly/assembly/AssemblyMainWindow.cc
+++ b/assembly/assembly/AssemblyMainWindow.cc
@@ -940,6 +940,7 @@ void AssemblyMainWindow::start_objectAligner(const AssemblyObjectAligner::Config
   aligner_->update_configuration(conf);
 
   this->disable_imageButtons(this);
+  assemblyV2_->set_in_action(true);
 
   return;
 }

--- a/assembly/assembly/AssemblyMainWindow.cc
+++ b/assembly/assembly/AssemblyMainWindow.cc
@@ -706,7 +706,7 @@ void AssemblyMainWindow::enable_images()
 
   if(image_ctr_ == nullptr)
   {
-    image_ctr_ = new AssemblyImageController(camera_, zfocus_finder_);
+    image_ctr_ = new AssemblyImageController(camera_, zfocus_finder_, this);
   }
 
   connect(this      , SIGNAL(images_ON())      , image_ctr_, SLOT(enable()));

--- a/assembly/assembly/AssemblyMainWindow.cc
+++ b/assembly/assembly/AssemblyMainWindow.cc
@@ -933,6 +933,8 @@ void AssemblyMainWindow::start_objectAligner(const AssemblyObjectAligner::Config
   // if successful, emits signal "configuration_updated()"
   aligner_->update_configuration(conf);
 
+  this->disable_imageButtons(this);
+
   return;
 }
 
@@ -982,6 +984,8 @@ void AssemblyMainWindow::disconnect_objectAligner()
   aligner_view_->Configuration_Widget()->setEnabled(true);
 
   aligner_connected_ = false;
+
+  this->enable_imageButtons(this);
 
   return;
 }

--- a/assembly/assembly/AssemblyMainWindow.cc
+++ b/assembly/assembly/AssemblyMainWindow.cc
@@ -95,6 +95,7 @@ AssemblyMainWindow::AssemblyMainWindow(const QString& outputdir_path, const QStr
 
   button_mainEmergencyStop_(nullptr),
   button_info_(nullptr),
+  button_snapshot_(nullptr),
 
   // flags
   images_enabled_(false),
@@ -510,10 +511,10 @@ AssemblyMainWindow::AssemblyMainWindow(const QString& outputdir_path, const QStr
     spacer1->setMinimumSize(QSize(50,1));
     toolBar_->addWidget(spacer1);
 
-    auto button_snapshot = new QPushButton(tr("Snapshot"));
-    button_snapshot->setStyleSheet("QPushButton { background-color: rgb(0, 170, 0); font: 18px; border-radius: 8px; padding: 7px; } QPushButton:hover { background-color: green; font: bold 18px; border-radius: 8px; padding: 2px; }");
-    toolBar_->addWidget(button_snapshot);
-    connect(button_snapshot, SIGNAL(clicked()), this, SLOT( get_image ()));
+    button_snapshot_ = new QPushButton(tr("Snapshot"));
+    button_snapshot_->setStyleSheet("QPushButton { background-color: rgb(0, 170, 0); font: 18px; border-radius: 8px; padding: 7px; } QPushButton:hover { background-color: green; font: bold 18px; border-radius: 8px; padding: 2px; }");
+    toolBar_->addWidget(button_snapshot_);
+    connect(button_snapshot_, SIGNAL(clicked()), this, SLOT( get_image ()));
 
     QWidget *spacer2 = new QWidget();
     spacer2->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
@@ -1426,11 +1427,7 @@ void AssemblyMainWindow::disable_imageButtons(QObject* sender)
 
     NQLog("AssemblyMainWindow", NQLog::Debug) << "Blocking the camera. (from " << sender->metaObject()->className() << ")";
 
-    for(auto& action : toolBar_->actions()){
-      if(action->text() == "Snapshot"){
-        action->setEnabled(false);
-      }
-    }
+    button_snapshot_->setEnabled(false);
     image_view_->autofocus_button()->setEnabled(false);
     aligner_view_->button_runAlignment()->setEnabled(false);
 }
@@ -1448,12 +1445,8 @@ void AssemblyMainWindow::enable_imageButtons(QObject* sender)
       }
     } else {
       NQLog("AssemblyMainWindow", NQLog::Debug) << "Camera will be released.";
-      for(auto& action : toolBar_->actions()){
-        if(action->text() == "Snapshot"){
-          action->setEnabled(true);
-        }
-      }
+      button_snapshot_->setEnabled(true);
+      image_view_->autofocus_button()->setEnabled(true);
+      aligner_view_->button_runAlignment()->setEnabled(true);
     }
-    image_view_->autofocus_button()->setEnabled(true);
-    aligner_view_->button_runAlignment()->setEnabled(true);
 }

--- a/assembly/assembly/AssemblyMainWindow.cc
+++ b/assembly/assembly/AssemblyMainWindow.cc
@@ -278,7 +278,6 @@ AssemblyMainWindow::AssemblyMainWindow(const QString& outputdir_path, const QStr
     connect(aligner_view_->button_alignerEmergencyStop(), SIGNAL(clicked()), this, SLOT(disconnect_objectAligner()));
     connect(aligner_view_->button_alignerEmergencyStop(), SIGNAL(clicked()), motion_manager_, SLOT(emergency_stop()));
     connect(aligner_view_->button_alignerEmergencyStop(), SIGNAL(clicked()), zfocus_finder_ , SLOT(emergencyStop()));
-    connect(aligner_view_->button_alignerEmergencyStop(), SIGNAL(clicked()), image_ctr_    , SLOT(restore_autofocus_settings()));
 
 
     connect(this, SIGNAL(set_alignmentMode_PSP_request()), aligner_view_, SLOT(set_alignmentMode_PSP()));
@@ -437,7 +436,6 @@ AssemblyMainWindow::AssemblyMainWindow(const QString& outputdir_path, const QStr
     connect(metrology_view_->button_metrologyEmergencyStop(), SIGNAL(clicked()), this, SLOT(disconnect_metrology()));
     connect(metrology_view_->button_metrologyEmergencyStop(), SIGNAL(clicked()), motion_manager_, SLOT(emergency_stop()));
     connect(metrology_view_->button_metrologyEmergencyStop(), SIGNAL(clicked()), zfocus_finder_ , SLOT(emergencyStop()));
-    connect(metrology_view_->button_metrologyEmergencyStop(), SIGNAL(clicked()), image_ctr_ , SLOT(restore_autofocus_settings()));
     connect(metrology_view_->button_metrologyClearResults(), SIGNAL(clicked()), metrology_, SLOT(clear_results()));
 
     NQLog("AssemblyMainWindow", NQLog::Message) << "added view " << tabname_Metrology;
@@ -723,6 +721,10 @@ void AssemblyMainWindow::enable_images()
   connect(this      , SIGNAL(autofocus_ON ())  , image_ctr_, SLOT(enable_autofocus()));
   connect(this      , SIGNAL(autofocus_OFF())  , image_ctr_, SLOT(disable_autofocus()));
   connect(image_view_, SIGNAL(request_image()), image_ctr_, SLOT(acquire_image()));
+
+  connect(button_mainEmergencyStop_, SIGNAL(clicked()), image_ctr_, SLOT(restore_autofocus_settings()));
+  connect(metrology_view_->button_metrologyEmergencyStop(), SIGNAL(clicked()), image_ctr_, SLOT(restore_autofocus_settings()));
+  connect(aligner_view_->button_alignerEmergencyStop(), SIGNAL(clicked()), image_ctr_, SLOT(restore_autofocus_settings()));
 
   NQLog("AssemblyMainWindow", NQLog::Message) << "enable_images"
      << ": connecting AssemblyImageController";

--- a/assembly/assembly/AssemblyMainWindow.cc
+++ b/assembly/assembly/AssemblyMainWindow.cc
@@ -1415,3 +1415,39 @@ void AssemblyMainWindow::closeEvent (QCloseEvent *event)
         }
     }
 }
+
+void AssemblyMainWindow::disable_imageButtons(QObject* sender)
+{
+    camera_blocking_objects_.append(sender);
+
+    NQLog("AssemblyMainWindow", NQLog::Debug) << "Blocking the camera. (from " << sender->metaObject()->className() << ")";
+
+    for(auto& action : toolBar_->actions()){
+      if(action->text() == "Snapshot"){
+        action->setEnabled(false);
+      }
+    }
+    image_view_->autofocus_button()->setEnabled(false);
+}
+
+void AssemblyMainWindow::enable_imageButtons(QObject* sender)
+{
+    NQLog("AssemblyMainWindow", NQLog::Debug) << "Camera release request. (from " << sender->metaObject()->className() << ")";
+
+    camera_blocking_objects_.removeAll(sender);
+    if(camera_blocking_objects_.size())
+    {
+      NQLog("AssemblyMainWindow", NQLog::Debug) << "There are still " << camera_blocking_objects_.size() << " objects blocking the camera:";
+      for(auto& obj : camera_blocking_objects_){
+        NQLog("AssemblyMainWindow", NQLog::Debug) << "   "  << obj->metaObject()->className();
+      }
+    } else {
+      NQLog("AssemblyMainWindow", NQLog::Debug) << "Camera will be released.";
+      for(auto& action : toolBar_->actions()){
+        if(action->text() == "Snapshot"){
+          action->setEnabled(true);
+        }
+      }
+    }
+    image_view_->autofocus_button()->setEnabled(true);
+}

--- a/assembly/assembly/AssemblyMainWindow.cc
+++ b/assembly/assembly/AssemblyMainWindow.cc
@@ -278,6 +278,8 @@ AssemblyMainWindow::AssemblyMainWindow(const QString& outputdir_path, const QStr
     connect(aligner_view_->button_alignerEmergencyStop(), SIGNAL(clicked()), this, SLOT(disconnect_objectAligner()));
     connect(aligner_view_->button_alignerEmergencyStop(), SIGNAL(clicked()), motion_manager_, SLOT(emergency_stop()));
     connect(aligner_view_->button_alignerEmergencyStop(), SIGNAL(clicked()), zfocus_finder_ , SLOT(emergencyStop()));
+    connect(aligner_view_->button_alignerEmergencyStop(), SIGNAL(clicked()), image_ctr_    , SLOT(restore_autofocus_settings()));
+
 
     connect(this, SIGNAL(set_alignmentMode_PSP_request()), aligner_view_, SLOT(set_alignmentMode_PSP()));
     connect(this, SIGNAL(set_alignmentMode_PSS_request()), aligner_view_, SLOT(set_alignmentMode_PSS()));
@@ -435,6 +437,7 @@ AssemblyMainWindow::AssemblyMainWindow(const QString& outputdir_path, const QStr
     connect(metrology_view_->button_metrologyEmergencyStop(), SIGNAL(clicked()), this, SLOT(disconnect_metrology()));
     connect(metrology_view_->button_metrologyEmergencyStop(), SIGNAL(clicked()), motion_manager_, SLOT(emergency_stop()));
     connect(metrology_view_->button_metrologyEmergencyStop(), SIGNAL(clicked()), zfocus_finder_ , SLOT(emergencyStop()));
+    connect(metrology_view_->button_metrologyEmergencyStop(), SIGNAL(clicked()), image_ctr_ , SLOT(restore_autofocus_settings()));
     connect(metrology_view_->button_metrologyClearResults(), SIGNAL(clicked()), metrology_, SLOT(clear_results()));
 
     NQLog("AssemblyMainWindow", NQLog::Message) << "added view " << tabname_Metrology;
@@ -941,6 +944,9 @@ void AssemblyMainWindow::start_objectAligner(const AssemblyObjectAligner::Config
 
 void AssemblyMainWindow::disconnect_objectAligner()
 {
+  NQLog("AssemblyMainWindow", NQLog::Debug) << "disconnect_objectAligner"
+     << ": Disconnecting object aligner";
+
   if(image_ctr_ == nullptr)
   {
     NQLog("AssemblyMainWindow", NQLog::Warning) << "disconnect_objectAligner"

--- a/assembly/assembly/AssemblyMainWindow.cc
+++ b/assembly/assembly/AssemblyMainWindow.cc
@@ -1432,6 +1432,7 @@ void AssemblyMainWindow::disable_imageButtons(QObject* sender)
       }
     }
     image_view_->autofocus_button()->setEnabled(false);
+    aligner_view_->button_runAlignment()->setEnabled(false);
 }
 
 void AssemblyMainWindow::enable_imageButtons(QObject* sender)
@@ -1454,4 +1455,5 @@ void AssemblyMainWindow::enable_imageButtons(QObject* sender)
       }
     }
     image_view_->autofocus_button()->setEnabled(true);
+    aligner_view_->button_runAlignment()->setEnabled(true);
 }

--- a/assembly/assembly/AssemblyMainWindow.h
+++ b/assembly/assembly/AssemblyMainWindow.h
@@ -234,6 +234,7 @@ class AssemblyMainWindow : public QMainWindow
 
   QPushButton* button_mainEmergencyStop_;
   QPushButton* button_info_;
+  QPushButton* button_snapshot_;
 
   // flags
   bool images_enabled_;

--- a/assembly/assembly/AssemblyMainWindow.h
+++ b/assembly/assembly/AssemblyMainWindow.h
@@ -160,6 +160,10 @@ class AssemblyMainWindow : public QMainWindow
 
   void messageBox_restartMotionStage();
 
+  void disable_imageButtons(QObject*);
+
+  void enable_imageButtons(QObject*);
+
  protected:
 
   // Low-Level Controllers (Motion, Camera, Vacuum)
@@ -243,6 +247,8 @@ class AssemblyMainWindow : public QMainWindow
   int idx_alignment_tab;
   int idx_module_tab;
   int idx_manual_tab;
+
+  QList<QObject*> camera_blocking_objects_;
 };
 
 #endif // ASSEMBLYMAINWINDOW_H

--- a/assembly/assemblyCommon/AssemblyAssemblyActionWidget.cc
+++ b/assembly/assemblyCommon/AssemblyAssemblyActionWidget.cc
@@ -155,6 +155,8 @@ void AssemblyAssemblyActionWidget::disable_action()
 
     disconnect(qobject_, stop_signal_, this, SLOT(disable_action()));
 
+    disconnect(qobject_, abort_signal_, this, SLOT(abort_action()));
+
     inhibit_dialogue_ = true;
     checkbox_->setCheckState(Qt::Checked);
   }
@@ -167,6 +169,9 @@ void AssemblyAssemblyActionWidget::disable_action()
 
 void AssemblyAssemblyActionWidget::abort_action()
 {
+  NQLog("AssemblyAssemblyActionWidget", NQLog::Message) << "abort_action"
+       << ": action aborted";
+
   if(qobject_)
   {
     disconnect(this, SIGNAL(action_request()), qobject_, start_slot_);

--- a/assembly/assemblyCommon/AssemblyAssemblyV2.cc
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2.cc
@@ -694,11 +694,8 @@ void AssemblyAssemblyV2::PushStep3ToDB_start()
 void AssemblyAssemblyV2::GoToPlatformReferencePoint_start()
 {
   if(in_action_){
-
-    NQLog("AssemblyAssemblyV2", NQLog::Warning) << "GoToPlatformReferencePoint_start"
-       << ": logic error, an assembly step is still in progress, will not take further action";
-
-    return;
+      reportInAction("GoToPlatformReferencePoint", SIGNAL(GoToPlatformReferencePoint_abort()));
+      return;
   }
 
   const double x0 = config_->getValue<double>("parameters", "RefPointPlatform_X");
@@ -709,7 +706,7 @@ void AssemblyAssemblyV2::GoToPlatformReferencePoint_start()
   connect(this, SIGNAL(move_absolute_request(double, double, double, double)), motion_, SLOT(moveAbsolute(double, double, double, double)));
   connect(motion_, SIGNAL(motion_finished()), this, SLOT(GoToPlatformReferencePoint_finish()));
 
-  in_action_ = true;
+  set_in_action(true);
 
   NQLog("AssemblyAssemblyV2", NQLog::Spam) << "GoToPlatformReferencePoint_start"
      << ": emitting signal \"move_absolute_request(" << x0 << ", " << y0 << ", " << z0 << ", " << a0 << ")\"";
@@ -722,7 +719,7 @@ void AssemblyAssemblyV2::GoToPlatformReferencePoint_finish()
   disconnect(this, SIGNAL(move_absolute_request(double, double, double, double)), motion_, SLOT(moveAbsolute(double, double, double, double)));
   disconnect(motion_, SIGNAL(motion_finished()), this, SLOT(GoToPlatformReferencePoint_finish()));
 
-  if(in_action_){ in_action_ = false; }
+  if(in_action_){ set_in_action(false); }
 
   NQLog("AssemblyAssemblyV2", NQLog::Spam) << "GoToPlatformReferencePoint_finish"
      << ": emitting signal \"GoToPlatformReferencePoint_finished\"";
@@ -742,11 +739,8 @@ void AssemblyAssemblyV2::GoToPlatformReferencePoint_finish()
 void AssemblyAssemblyV2::GoToOrigin_start()
 {
   if(in_action_){
-
-    NQLog("AssemblyAssemblyV2", NQLog::Warning) << "GoToOrigin_start"
-       << ": logic error, an assembly step is still in progress, will not take further action";
-
-    return;
+      reportInAction("GoToOrigin", SIGNAL(GoToOrigin_abort()));
+      return;
   }
 
   const double x0 = 0;
@@ -757,7 +751,7 @@ void AssemblyAssemblyV2::GoToOrigin_start()
   connect(this, SIGNAL(move_absolute_request(double, double, double, double)), motion_, SLOT(moveAbsolute(double, double, double, double)));
   connect(motion_, SIGNAL(motion_finished()), this, SLOT(GoToOrigin_finish()));
 
-  in_action_ = true;
+  set_in_action(true);
 
   NQLog("AssemblyAssemblyV2", NQLog::Spam) << "GoToOrigin_start"
      << ": emitting signal \"move_absolute_request(" << x0 << ", " << y0 << ", " << z0 << ", " << a0 << ")\"";
@@ -770,7 +764,7 @@ void AssemblyAssemblyV2::GoToOrigin_finish()
   disconnect(this, SIGNAL(move_absolute_request(double, double, double, double)), motion_, SLOT(moveAbsolute(double, double, double, double)));
   disconnect(motion_, SIGNAL(motion_finished()), this, SLOT(GoToOrigin_finish()));
 
-  if(in_action_){ in_action_ = false; }
+  if(in_action_){ set_in_action(false); }
 
   NQLog("AssemblyAssemblyV2", NQLog::Spam) << "GoToOrigin_finish"
      << ": emitting signal \"GoToOrigin_finished\"";
@@ -790,7 +784,7 @@ void AssemblyAssemblyV2::GoToOrigin_finish()
 void AssemblyAssemblyV2::GoToSensorMarkerPreAlignment_start(bool isMapsa)
 {
   if(in_action_){
-    reportInAction("GoToSensorMarkerPreAlignment");
+    reportInAction("GoToSensorMarkerPreAlignment", SIGNAL(GoToSensorMarkerPreAlignment_abort()));
     return;
   }
 
@@ -836,7 +830,7 @@ void AssemblyAssemblyV2::GoToSensorMarkerPreAlignment_finish()
 void AssemblyAssemblyV2::EnableVacuumPickupTool_start()
 {
   if(in_action_){
-    reportInAction("EnableVacuumPickupTool");
+    reportInAction("EnableVacuumPickupTool", SIGNAL(EnableVacuumPickupTool_abort()));
     return;
   }
 
@@ -882,7 +876,7 @@ void AssemblyAssemblyV2::EnableVacuumPickupTool_finish()
 void AssemblyAssemblyV2::DisableVacuumPickupTool_start()
 {
   if(in_action_){
-    reportInAction("DisableVacuumPickupTool");
+    reportInAction("DisableVacuumPickupTool", SIGNAL(DisableVacuumPickupTool_abort()));
     return;
   }
 
@@ -928,7 +922,7 @@ void AssemblyAssemblyV2::DisableVacuumPickupTool_finish()
 void AssemblyAssemblyV2::EnableVacuumSpacers_start()
 {
   if(in_action_){
-    reportInAction("EnableVacuumSpacers");
+    reportInAction("EnableVacuumSpacers", SIGNAL(EnableVacuumSpacers_abort()));
     return;
   }
 
@@ -974,7 +968,7 @@ void AssemblyAssemblyV2::EnableVacuumSpacers_finish()
 void AssemblyAssemblyV2::DisableVacuumSpacers_start()
 {
   if(in_action_){
-    reportInAction("DisableVacuumSpacers");
+    reportInAction("DisableVacuumSpacers", SIGNAL(DisableVacuumSpacers_abort()));
     return;
   }
 
@@ -1020,7 +1014,7 @@ void AssemblyAssemblyV2::DisableVacuumSpacers_finish()
 void AssemblyAssemblyV2::EnableVacuumBaseplate_start()
 {
   if(in_action_){
-    reportInAction("EnableVacuumBaseplate");
+    reportInAction("EnableVacuumBaseplate", SIGNAL(EnableVacuumBaseplate_abort()));
     return;
   }
 
@@ -1066,7 +1060,7 @@ void AssemblyAssemblyV2::EnableVacuumBaseplate_finish()
 void AssemblyAssemblyV2::DisableVacuumBaseplate_start()
 {
   if(in_action_){
-    reportInAction("DisableVacuumBaseplate");
+    reportInAction("DisableVacuumBaseplate", SIGNAL(DisableVacuumBaseplate_abort()));
     return;
   }
 
@@ -1112,7 +1106,7 @@ void AssemblyAssemblyV2::DisableVacuumBaseplate_finish()
 void AssemblyAssemblyV2::GoFromSensorMarkerToPickupXY_start()
 {
   if(in_action_){
-    reportInAction("GoFromSensorMarkerToPickupXY");
+    reportInAction("GoFromSensorMarkerToPickupXY", SIGNAL(GoFromSensorMarkerToPickupXY_abort()));
     return;
   }
 
@@ -1157,7 +1151,7 @@ void AssemblyAssemblyV2::GoFromSensorMarkerToPickupXY_finish()
 void AssemblyAssemblyV2::LowerPickupToolOntoMaPSA_start()
 {
   if(in_action_){
-    reportInAction("LowerPickupToolOntoMaPSA");
+    reportInAction("LowerPickupToolOntoMaPSA", SIGNAL(LowerPickupToolOntoMaPSA_abort()));
     return;
   }
 
@@ -1243,7 +1237,7 @@ void AssemblyAssemblyV2::LowerPickupToolOntoMaPSA_finish()
 void AssemblyAssemblyV2::LowerPickupToolOntoPSS_start()
 {
   if(in_action_){
-    reportInAction("LowerPickupToolOntoPSS");
+    reportInAction("LowerPickupToolOntoPSS", SIGNAL(LowerPickupToolOntoPSS_abort()));
     return;
   }
 
@@ -1326,7 +1320,7 @@ void AssemblyAssemblyV2::LowerPickupToolOntoPSS_finish()
 void AssemblyAssemblyV2::PickupMaPSA_start()
 {
   if(in_action_){
-    reportInAction("PickupMaPSA");
+    reportInAction("PickupMaPSA", SIGNAL(PickupMaPSA_abort()));
     return;
   }
 
@@ -1392,7 +1386,7 @@ void AssemblyAssemblyV2::PickupMaPSA_finish()
 void AssemblyAssemblyV2::PickupPSS_start()
 {
   if(in_action_){
-    reportInAction("PickupPSS");
+    reportInAction("PickupPSS_abort", SIGNAL(PickupPSS_abort()));
     return;
   }
 
@@ -1460,7 +1454,7 @@ void AssemblyAssemblyV2::PickupPSS_finish()
 void AssemblyAssemblyV2::GoToXYAPositionToGlueMaPSAToBaseplate_start()
 {
   if(in_action_){
-    reportInAction("GoToXYAPositionToGlueMaPSAToBaseplate");
+    reportInAction("GoToXYAPositionToGlueMaPSAToBaseplate", SIGNAL(GoToXYAPositionToGlueMaPSAToBaseplate_abort()));
     return;
   }
 
@@ -1520,7 +1514,7 @@ void AssemblyAssemblyV2::GoToXYAPositionToGlueMaPSAToBaseplate_finish()
 void AssemblyAssemblyV2::LowerMaPSAOntoBaseplate_start()
 {
   if(in_action_){
-    reportInAction("LowerMaPSAOntoBaseplate");
+    reportInAction("LowerMaPSAOntoBaseplate", SIGNAL(LowerMaPSAOntoBaseplate_abort()));
     return;
   }
 
@@ -1613,7 +1607,7 @@ void AssemblyAssemblyV2::LowerMaPSAOntoBaseplate_finish()
 void AssemblyAssemblyV2::GoToXYAPositionToGluePSSToSpacers_start()
 {
   if(in_action_){
-    reportInAction("GoToXYAPositionToGluePSSToSpacers");
+    reportInAction("GoToXYAPositionToGluePSSToSpacers", SIGNAL(GoToXYAPositionToGluePSSToSpacers_abort()));
     return;
   }
 
@@ -1673,7 +1667,7 @@ void AssemblyAssemblyV2::GoToXYAPositionToGluePSSToSpacers_finish()
 void AssemblyAssemblyV2::LowerPSSOntoSpacers_start()
 {
   if(in_action_){
-    reportInAction("LowerPSSOntoSpacers");
+    reportInAction("LowerPSSOntoSpacers", SIGNAL(LowerPSSOntoSpacers_abort()));
     return;
   }
 
@@ -1768,7 +1762,7 @@ void AssemblyAssemblyV2::LowerPSSOntoSpacers_finish()
 void AssemblyAssemblyV2::GoToPSPMarkerIdealPosition_start()
 {
   if(in_action_){
-    reportInAction("GoToPSPMarkerIdealPosition");
+    reportInAction("GoToPSPMarkerIdealPosition", SIGNAL(GoToPSPMarkerIdealPosition_abort()));
     return;
   }
 
@@ -1824,7 +1818,7 @@ void AssemblyAssemblyV2::GoToPSPMarkerIdealPosition_finish()
 void AssemblyAssemblyV2::ApplyPSPToPSSXYOffset_start()
 {
   if(in_action_){
-    reportInAction("ApplyPSPToPSSXYOffset");
+    reportInAction("ApplyPSPToPSSXYOffset", SIGNAL(ApplyPSPToPSSXYOffset_abort()));
     return;
   }
 
@@ -1869,7 +1863,7 @@ void AssemblyAssemblyV2::ApplyPSPToPSSXYOffset_finish()
 void AssemblyAssemblyV2::MakeSpaceOnPlatform_start()
 {
   if(in_action_){
-    reportInAction("MakeSpaceOnPlatform");
+    reportInAction("MakeSpaceOnPlatfor", SIGNAL(MakeSpaceOnPlatform_abort()));
     return;
   }
 
@@ -1933,7 +1927,7 @@ void AssemblyAssemblyV2::MakeSpaceOnPlatform_finish()
 void AssemblyAssemblyV2::ReturnToPlatform_start()
 {
   if(in_action_){
-    reportInAction("ReturnToPlatform");
+    reportInAction("ReturnToPlatform", SIGNAL(ReturnToPlatform_abort()));
     return;
   }
 
@@ -2032,7 +2026,7 @@ void AssemblyAssemblyV2::ReturnToPlatform_finish()
 void AssemblyAssemblyV2::RegisterPSSPlusSpacersToMaPSAPosition_start()
 {
   if(in_action_){
-    reportInAction("RegisterPSSPlusSpacersToMaPSAPosition");
+    reportInAction("RegisterPSSPlusSpacersToMaPSAPosition", SIGNAL(RegisterPSSPlusSpacersToMaPSAPosition_abort()));
     return;
   }
 
@@ -2081,7 +2075,7 @@ void AssemblyAssemblyV2::RegisterPSSPlusSpacersToMaPSAPosition_finish()
 void AssemblyAssemblyV2::GoFromPSSPlusSpacersToMaPSAPositionToGluingStageRefPointXY_start()
 {
   if(in_action_){
-    reportInAction("GoFromPSSPlusSpacersToMaPSAPositionToGluingStageRefPointXY");
+    reportInAction("GoFromPSSPlusSpacersToMaPSAPositionToGluingStageRefPointXY", SIGNAL(GoFromPSSPlusSpacersToMaPSAPositionToGluingStageRefPointXY_abort()));
     return;
   }
 
@@ -2145,7 +2139,7 @@ void AssemblyAssemblyV2::GoFromPSSPlusSpacersToMaPSAPositionToGluingStageRefPoin
 void AssemblyAssemblyV2::LowerPSSPlusSpacersOntoGluingStage_start()
 {
   if(in_action_){
-    reportInAction("LowerPSSPlusSpacersOntoGluingStage");
+    reportInAction("LowerPSSPlusSpacersOntoGluingStage", SIGNAL(LowerPSSPlusSpacersOntoGluingStage_abort()));
     return;
   }
 
@@ -2238,7 +2232,7 @@ void AssemblyAssemblyV2::LowerPSSPlusSpacersOntoGluingStage_finish()
 void AssemblyAssemblyV2::SlowlyLiftFromGluingStage_start()
 {
   if(in_action_){
-    reportInAction("SlowlyLiftFromGluingStage");
+    reportInAction("SlowlyLiftFromGluingStage", SIGNAL(SlowlyLiftFromGluingStage_abort()));
     return;
   }
 
@@ -2320,7 +2314,7 @@ void AssemblyAssemblyV2::SlowlyLiftFromGluingStage_finish()
 void AssemblyAssemblyV2::ReturnToPSSPlusSpacersToMaPSAPosition_start()
 {
   if(in_action_){
-    reportInAction("ReturnToPSSPlusSpacersToMaPSAPosition");
+    reportInAction("ReturnToPSSPlusSpacersToMaPSAPosition", SIGNAL(ReturnToPSSPlusSpacersToMaPSAPosition_abort()));
     return;
   }
 
@@ -2414,7 +2408,7 @@ void AssemblyAssemblyV2::ReturnToPSSPlusSpacersToMaPSAPosition_finish()
 void AssemblyAssemblyV2::LowerPSSPlusSpacersOntoMaPSA_start()
 {
   if(in_action_){
-    reportInAction("LowerPSSPlusSpacersOntoMaPSA");
+    reportInAction("LowerPSSPlusSpacersOntoMaPSA", SIGNAL(LowerPSSPlusSpacersOntoMaPSA_abort()));
     return;
   }
 
@@ -2506,7 +2500,7 @@ void AssemblyAssemblyV2::LowerPSSPlusSpacersOntoMaPSA_finish()
 void AssemblyAssemblyV2::PickupPSSPlusSpacers_start()
 {
   if(in_action_){
-    reportInAction("PickupPSSPlusSpacers");
+    reportInAction("PickupPSSPlusSpacers", SIGNAL(PickupPSSPlusSpacers_abort()));
     return;
   }
 
@@ -2574,7 +2568,7 @@ void AssemblyAssemblyV2::PickupPSSPlusSpacers_finish()
 void AssemblyAssemblyV2::LiftUpPickupTool_start()
 {
   if(in_action_){
-    reportInAction("LiftUpPickupTool");
+    reportInAction("LiftUpPickupTool", SIGNAL(LiftUpPickupTool_abort()));
     return;
   }
 
@@ -2628,7 +2622,7 @@ void AssemblyAssemblyV2::LiftUpPickupTool_finish()
 void AssemblyAssemblyV2::AssemblyCompleted_start()
 {
   if(in_action_){
-    reportInAction("AssemblyCompleted");
+    reportInAction("AssemblyCompleted", SIGNAL(AssemblyCompleted_abort()));
     return;
   }
 
@@ -2651,7 +2645,7 @@ void AssemblyAssemblyV2::AssemblyCompleted_start()
 void AssemblyAssemblyV2::switchToAlignmentTab_PSP()
 {
   if(in_action_){
-    reportInAction("switchToAlignmentTab");
+    reportInAction("switchToAlignmentTab_PSP", SIGNAL(switchToAlignmentTab_PSP_abort()));
     return;
   }
 
@@ -2672,7 +2666,7 @@ void AssemblyAssemblyV2::switchToAlignmentTab_PSP()
 void AssemblyAssemblyV2::switchToAlignmentTab_PSS()
 {
   if(in_action_){
-    reportInAction("switchToAlignmentTab_PSS");
+    reportInAction("switchToAlignmentTab_PSS", SIGNAL(switchToAlignmentTab_PSS_abort()));
     return;
   }
 

--- a/assembly/assemblyCommon/AssemblyAssemblyV2.cc
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2.cc
@@ -2687,16 +2687,18 @@ void AssemblyAssemblyV2::switchToAlignmentTab_PSS()
 }
 // ----------------------------------------------------------------------------------------------------
 
-void AssemblyAssemblyV2::reportInAction(std::string target_step)
+void AssemblyAssemblyV2::reportInAction(const QString target_step, const char* abort_signal)
 {
-    NQLog("AssemblyAssemblyV2", NQLog::Warning) << QString::fromStdString(target_step)
+    NQLog("AssemblyAssemblyV2", NQLog::Warning) << target_step
       << ": logic error, an assembly step is still in progress, will not take further action";
-    NQLog("AssemblyAssemblyV2", NQLog::Warning) << QString::fromStdString(target_step)
-      << ": in_action: " << in_action_;
+
+    connect(this, SIGNAL(abort_this()), this, abort_signal);
+    emit abort_this();
+    disconnect(this, SIGNAL(abort_this()), this, abort_signal);
 
     QMessageBox msgBox;
     msgBox.setWindowTitle(tr("Error"));
-    QString msg = QString("An assembly step is still in progress.\nCould not perform step:\n") + QString::fromStdString(target_step);
+    QString msg = QString("An assembly step is still in progress.\nCould not perform step:\n") + target_step;
     msgBox.setText(msg);
     msgBox.setInformativeText("Please wait until the step has been completed.\nHint: once an alignment step has been clicked, the alignment has to be performed before being able to continue the assembly.");
     msgBox.setStandardButtons(QMessageBox::Ok);

--- a/assembly/assemblyCommon/AssemblyAssemblyV2.cc
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2.cc
@@ -790,10 +790,7 @@ void AssemblyAssemblyV2::GoToOrigin_finish()
 void AssemblyAssemblyV2::GoToSensorMarkerPreAlignment_start(bool isMapsa)
 {
   if(in_action_){
-
-    NQLog("AssemblyAssemblyV2", NQLog::Warning) << "GoToSensorMarkerPreAlignment_start"
-       << ": logic error, an assembly step is still in progress, will not take further action";
-
+    reportInAction("GoToSensorMarkerPreAlignment");
     return;
   }
 
@@ -806,7 +803,7 @@ void AssemblyAssemblyV2::GoToSensorMarkerPreAlignment_start(bool isMapsa)
   connect(this, SIGNAL(move_absolute_request(double, double, double, double)), motion_, SLOT(moveAbsolute(double, double, double, double)));
   connect(motion_, SIGNAL(motion_finished()), this, SLOT(GoToSensorMarkerPreAlignment_finish()));
 
-  in_action_ = true;
+  set_in_action(true);
 
   NQLog("AssemblyAssemblyV2", NQLog::Spam) << "GoToSensorMarkerPreAlignment_start"
      << ": emitting signal \"move_absolute_request(" << x0 << ", " << y0 << ", " << z0 << ", " << a0 << ")\"";
@@ -819,7 +816,7 @@ void AssemblyAssemblyV2::GoToSensorMarkerPreAlignment_finish()
   disconnect(this, SIGNAL(move_absolute_request(double, double, double, double)), motion_, SLOT(moveAbsolute(double, double, double, double)));
   disconnect(motion_, SIGNAL(motion_finished()), this, SLOT(GoToSensorMarkerPreAlignment_finish()));
 
-  if(in_action_){ in_action_ = false; }
+  if(in_action_){ set_in_action(false); }
 
   NQLog("AssemblyAssemblyV2", NQLog::Spam) << "GoToSensorMarkerPreAlignment_finish"
      << ": emitting signal \"GoToSensorMarkerPreAlignment_finished\"";
@@ -839,10 +836,7 @@ void AssemblyAssemblyV2::GoToSensorMarkerPreAlignment_finish()
 void AssemblyAssemblyV2::EnableVacuumPickupTool_start()
 {
   if(in_action_){
-
-    NQLog("AssemblyAssemblyV2", NQLog::Warning) << "EnableVacuumPickupTool_start"
-       << ": logic error, an assembly step is still in progress, will not take further action";
-
+    reportInAction("EnableVacuumPickupTool");
     return;
   }
 
@@ -852,7 +846,7 @@ void AssemblyAssemblyV2::EnableVacuumPickupTool_start()
   connect(this->vacuum(), SIGNAL(vacuum_toggled()), this, SLOT(EnableVacuumPickupTool_finish()));
   connect(this->vacuum(), SIGNAL(vacuum_error  ()), this, SLOT(EnableVacuumPickupTool_finish()));
 
-  in_action_ = true;
+  set_in_action(true);
 
   NQLog("AssemblyAssemblyV2", NQLog::Spam) << "EnableVacuumPickupTool_start"
      << ": emitting signal \"vacuum_ON_request(" << vacuum_pickup_ << ")\"";
@@ -868,7 +862,7 @@ void AssemblyAssemblyV2::EnableVacuumPickupTool_finish()
   disconnect(this->vacuum(), SIGNAL(vacuum_toggled()), this, SLOT(EnableVacuumPickupTool_finish()));
   disconnect(this->vacuum(), SIGNAL(vacuum_error  ()), this, SLOT(EnableVacuumPickupTool_finish()));
 
-  if(in_action_){ in_action_ = false; }
+  if(in_action_){ set_in_action(false); }
 
   NQLog("AssemblyAssemblyV2", NQLog::Spam) << "EnableVacuumPickupTool_finish"
      << ": emitting signal \"EnableVacuumPickupTool_finished\"";
@@ -888,10 +882,7 @@ void AssemblyAssemblyV2::EnableVacuumPickupTool_finish()
 void AssemblyAssemblyV2::DisableVacuumPickupTool_start()
 {
   if(in_action_){
-
-    NQLog("AssemblyAssemblyV2", NQLog::Warning) << "DisableVacuumPickupTool_start"
-       << ": logic error, an assembly step is still in progress, will not take further action";
-
+    reportInAction("DisableVacuumPickupTool");
     return;
   }
 
@@ -901,7 +892,7 @@ void AssemblyAssemblyV2::DisableVacuumPickupTool_start()
   connect(this->vacuum(), SIGNAL(vacuum_toggled ()), this, SLOT(DisableVacuumPickupTool_finish()));
   connect(this->vacuum(), SIGNAL(vacuum_error   ()), this, SLOT(DisableVacuumPickupTool_finish()));
 
-  in_action_ = true;
+  set_in_action(true);
 
   NQLog("AssemblyAssemblyV2", NQLog::Spam) << "DisableVacuumPickupTool_start"
      << ": emitting signal \"vacuum_OFF_request(" << vacuum_pickup_ << ")\"";
@@ -917,7 +908,7 @@ void AssemblyAssemblyV2::DisableVacuumPickupTool_finish()
   disconnect(this->vacuum(), SIGNAL(vacuum_toggled ()), this, SLOT(DisableVacuumPickupTool_finish()));
   disconnect(this->vacuum(), SIGNAL(vacuum_error   ()), this, SLOT(DisableVacuumPickupTool_finish()));
 
-  if(in_action_){ in_action_ = false; }
+  if(in_action_){ set_in_action(false); }
 
   NQLog("AssemblyAssemblyV2", NQLog::Spam) << "DisableVacuumPickupTool_finish"
      << ": emitting signal \"DisableVacuumPickupTool_finished\"";
@@ -937,10 +928,7 @@ void AssemblyAssemblyV2::DisableVacuumPickupTool_finish()
 void AssemblyAssemblyV2::EnableVacuumSpacers_start()
 {
   if(in_action_){
-
-    NQLog("AssemblyAssemblyV2", NQLog::Warning) << "EnableVacuumSpacers_start"
-       << ": logic error, an assembly step is still in progress, will not take further action";
-
+    reportInAction("EnableVacuumSpacers");
     return;
   }
 
@@ -950,7 +938,7 @@ void AssemblyAssemblyV2::EnableVacuumSpacers_start()
   connect(this->vacuum(), SIGNAL(vacuum_toggled()), this, SLOT(EnableVacuumSpacers_finish()));
   connect(this->vacuum(), SIGNAL(vacuum_error  ()), this, SLOT(EnableVacuumSpacers_finish()));
 
-  in_action_ = true;
+  set_in_action(true);
 
   NQLog("AssemblyAssemblyV2", NQLog::Spam) << "EnableVacuumSpacers_start"
      << ": emitting signal \"vacuum_ON_request(" << vacuum_spacer_ << ")\"";
@@ -966,7 +954,7 @@ void AssemblyAssemblyV2::EnableVacuumSpacers_finish()
   disconnect(this->vacuum(), SIGNAL(vacuum_toggled()), this, SLOT(EnableVacuumSpacers_finish()));
   disconnect(this->vacuum(), SIGNAL(vacuum_error  ()), this, SLOT(EnableVacuumSpacers_finish()));
 
-  if(in_action_){ in_action_ = false; }
+  if(in_action_){ set_in_action(false); }
 
   NQLog("AssemblyAssemblyV2", NQLog::Spam) << "EnableVacuumSpacers_finish"
      << ": emitting signal \"EnableVacuumSpacers_finished\"";
@@ -986,10 +974,7 @@ void AssemblyAssemblyV2::EnableVacuumSpacers_finish()
 void AssemblyAssemblyV2::DisableVacuumSpacers_start()
 {
   if(in_action_){
-
-    NQLog("AssemblyAssemblyV2", NQLog::Warning) << "DisableVacuumSpacers_start"
-       << ": logic error, an assembly step is still in progress, will not take further action";
-
+    reportInAction("DisableVacuumSpacers");
     return;
   }
 
@@ -999,7 +984,7 @@ void AssemblyAssemblyV2::DisableVacuumSpacers_start()
   connect(this->vacuum(), SIGNAL(vacuum_toggled ()), this, SLOT(DisableVacuumSpacers_finish()));
   connect(this->vacuum(), SIGNAL(vacuum_error   ()), this, SLOT(DisableVacuumSpacers_finish()));
 
-  in_action_ = true;
+  set_in_action(true);
 
   NQLog("AssemblyAssemblyV2", NQLog::Spam) << "DisableVacuumSpacers_start"
      << ": emitting signal \"vacuum_OFF_request(" << vacuum_spacer_ << ")\"";
@@ -1015,7 +1000,7 @@ void AssemblyAssemblyV2::DisableVacuumSpacers_finish()
   disconnect(this->vacuum(), SIGNAL(vacuum_toggled ()), this, SLOT(DisableVacuumSpacers_finish()));
   disconnect(this->vacuum(), SIGNAL(vacuum_error   ()), this, SLOT(DisableVacuumSpacers_finish()));
 
-  if(in_action_){ in_action_ = false; }
+  if(in_action_){ set_in_action(false); }
 
   NQLog("AssemblyAssemblyV2", NQLog::Spam) << "DisableVacuumSpacers_finish"
      << ": emitting signal \"DisableVacuumSpacers_finished\"";
@@ -1035,10 +1020,7 @@ void AssemblyAssemblyV2::DisableVacuumSpacers_finish()
 void AssemblyAssemblyV2::EnableVacuumBaseplate_start()
 {
   if(in_action_){
-
-    NQLog("AssemblyAssemblyV2", NQLog::Warning) << "EnableVacuumBaseplate_start"
-       << ": logic error, an assembly step is still in progress, will not take further action";
-
+    reportInAction("EnableVacuumBaseplate");
     return;
   }
 
@@ -1048,7 +1030,7 @@ void AssemblyAssemblyV2::EnableVacuumBaseplate_start()
   connect(this->vacuum(), SIGNAL(vacuum_toggled()), this, SLOT(EnableVacuumBaseplate_finish()));
   connect(this->vacuum(), SIGNAL(vacuum_error  ()), this, SLOT(EnableVacuumBaseplate_finish()));
 
-  in_action_ = true;
+  set_in_action(true);
 
   NQLog("AssemblyAssemblyV2", NQLog::Spam) << "EnableVacuumBaseplate_start"
      << ": emitting signal \"vacuum_ON_request(" << vacuum_basepl_ << ")\"";
@@ -1064,7 +1046,7 @@ void AssemblyAssemblyV2::EnableVacuumBaseplate_finish()
   disconnect(this->vacuum(), SIGNAL(vacuum_toggled()), this, SLOT(EnableVacuumBaseplate_finish()));
   disconnect(this->vacuum(), SIGNAL(vacuum_error  ()), this, SLOT(EnableVacuumBaseplate_finish()));
 
-  if(in_action_){ in_action_ = false; }
+  if(in_action_){ set_in_action(false); }
 
   NQLog("AssemblyAssemblyV2", NQLog::Spam) << "EnableVacuumBaseplate_finish"
      << ": emitting signal \"EnableVacuumBaseplate_finished\"";
@@ -1084,10 +1066,7 @@ void AssemblyAssemblyV2::EnableVacuumBaseplate_finish()
 void AssemblyAssemblyV2::DisableVacuumBaseplate_start()
 {
   if(in_action_){
-
-    NQLog("AssemblyAssemblyV2", NQLog::Warning) << "DisableVacuumBaseplate_start"
-       << ": logic error, an assembly step is still in progress, will not take further action";
-
+    reportInAction("DisableVacuumBaseplate");
     return;
   }
 
@@ -1097,7 +1076,7 @@ void AssemblyAssemblyV2::DisableVacuumBaseplate_start()
   connect(this->vacuum(), SIGNAL(vacuum_toggled ()), this, SLOT(DisableVacuumBaseplate_finish()));
   connect(this->vacuum(), SIGNAL(vacuum_error   ()), this, SLOT(DisableVacuumBaseplate_finish()));
 
-  in_action_ = true;
+  set_in_action(true);
 
   NQLog("AssemblyAssemblyV2", NQLog::Spam) << "DisableVacuumBaseplate_start"
      << ": emitting signal \"vacuum_OFF_request(" << vacuum_basepl_ << ")\"";
@@ -1113,7 +1092,7 @@ void AssemblyAssemblyV2::DisableVacuumBaseplate_finish()
   disconnect(this->vacuum(), SIGNAL(vacuum_toggled ()), this, SLOT(DisableVacuumBaseplate_finish()));
   disconnect(this->vacuum(), SIGNAL(vacuum_error   ()), this, SLOT(DisableVacuumBaseplate_finish()));
 
-  if(in_action_){ in_action_ = false; }
+  if(in_action_){ set_in_action(false); }
 
   NQLog("AssemblyAssemblyV2", NQLog::Spam) << "DisableVacuumBaseplate_finish"
      << ": emitting signal \"DisableVacuumBaseplate_finished\"";
@@ -1133,10 +1112,7 @@ void AssemblyAssemblyV2::DisableVacuumBaseplate_finish()
 void AssemblyAssemblyV2::GoFromSensorMarkerToPickupXY_start()
 {
   if(in_action_){
-
-    NQLog("AssemblyAssemblyV2", NQLog::Warning) << "GoFromSensorMarkerToPickupXY_start"
-       << ": logic error, an assembly step is still in progress, will not take further action";
-
+    reportInAction("GoFromSensorMarkerToPickupXY");
     return;
   }
 
@@ -1148,7 +1124,7 @@ void AssemblyAssemblyV2::GoFromSensorMarkerToPickupXY_start()
   connect(this, SIGNAL(move_relative_request(double, double, double, double)), motion_, SLOT(moveRelative(double, double, double, double)));
   connect(motion_, SIGNAL(motion_finished()), this, SLOT(GoFromSensorMarkerToPickupXY_finish()));
 
-  in_action_ = true;
+  set_in_action(true);
 
   NQLog("AssemblyAssemblyV2", NQLog::Spam) << "GoFromSensorMarkerToPickupXY_start"
      << ": emitting signal \"move_relative_request(" << dx0 << ", " << dy0 << ", " << dz0 << ", " << da0 << ")\"";
@@ -1161,7 +1137,7 @@ void AssemblyAssemblyV2::GoFromSensorMarkerToPickupXY_finish()
   disconnect(this, SIGNAL(move_relative_request(double, double, double, double)), motion_, SLOT(moveRelative(double, double, double, double)));
   disconnect(motion_, SIGNAL(motion_finished()), this, SLOT(GoFromSensorMarkerToPickupXY_finish()));
 
-  if(in_action_){ in_action_ = false; }
+  if(in_action_){ set_in_action(false); }
 
   NQLog("AssemblyAssemblyV2", NQLog::Spam) << "GoFromSensorMarkerToPickupXY_finish"
      << ": emitting signal \"GoFromSensorMarkerToPickupXY_finished\"";
@@ -1181,10 +1157,7 @@ void AssemblyAssemblyV2::GoFromSensorMarkerToPickupXY_finish()
 void AssemblyAssemblyV2::LowerPickupToolOntoMaPSA_start()
 {
   if(in_action_){
-
-    NQLog("AssemblyAssemblyV2", NQLog::Warning) << "LowerPickupToolOntoMaPSA_start"
-       << ": logic error, an assembly step is still in progress, will not take further action";
-
+    reportInAction("LowerPickupToolOntoMaPSA");
     return;
   }
 
@@ -1220,7 +1193,7 @@ void AssemblyAssemblyV2::LowerPickupToolOntoMaPSA_start()
     connect(this, SIGNAL(move_relative_request(double, double, double, double)), smart_motion_, SLOT(move_relative(double, double, double, double)));
     connect(smart_motion_, SIGNAL(motion_completed()), this, SLOT(LowerPickupToolOntoMaPSA_finish()));
 
-    in_action_ = true;
+    set_in_action(true);
 
     NQLog("AssemblyAssemblyV2", NQLog::Spam) << "LowerPickupToolOntoMaPSA_start"
        << ": emitting signal \"move_relative_request(" << dx0 << ", " << dy0 << ", " << dz0 << ", " << da0 << ")\"";
@@ -1250,7 +1223,7 @@ void AssemblyAssemblyV2::LowerPickupToolOntoMaPSA_finish()
   disconnect(this, SIGNAL(move_relative_request(double, double, double, double)), smart_motion_, SLOT(move_relative(double, double, double, double)));
   disconnect(smart_motion_, SIGNAL(motion_completed()), this, SLOT(LowerPickupToolOntoMaPSA_finish()));
 
-  if(in_action_){ in_action_ = false; }
+  if(in_action_){ set_in_action(false); }
 
   NQLog("AssemblyAssemblyV2", NQLog::Spam) << "LowerPickupToolOntoMaPSA_finish"
      << ": emitting signal \"LowerPickupToolOntoMaPSA_finished\"";
@@ -1270,10 +1243,7 @@ void AssemblyAssemblyV2::LowerPickupToolOntoMaPSA_finish()
 void AssemblyAssemblyV2::LowerPickupToolOntoPSS_start()
 {
   if(in_action_){
-
-    NQLog("AssemblyAssemblyV2", NQLog::Warning) << "LowerPickupToolOntoPSS_start"
-       << ": logic error, an assembly step is still in progress, will not take further action";
-
+    reportInAction("LowerPickupToolOntoPSS");
     return;
   }
 
@@ -1306,7 +1276,7 @@ void AssemblyAssemblyV2::LowerPickupToolOntoPSS_start()
     connect(this, SIGNAL(move_relative_request(double, double, double, double)), smart_motion_, SLOT(move_relative(double, double, double, double)));
     connect(smart_motion_, SIGNAL(motion_completed()), this, SLOT(LowerPickupToolOntoPSS_finish()));
 
-    in_action_ = true;
+    set_in_action(true);
 
     NQLog("AssemblyAssemblyV2", NQLog::Spam) << "LowerPickupToolOntoPSS_start"
        << ": emitting signal \"move_relative_request(" << dx0 << ", " << dy0 << ", " << dz0 << ", " << da0 << ")\"";
@@ -1336,7 +1306,7 @@ void AssemblyAssemblyV2::LowerPickupToolOntoPSS_finish()
   disconnect(this, SIGNAL(move_relative_request(double, double, double, double)), smart_motion_, SLOT(move_relative(double, double, double, double)));
   disconnect(smart_motion_, SIGNAL(motion_completed()), this, SLOT(LowerPickupToolOntoPSS_finish()));
 
-  if(in_action_){ in_action_ = false; }
+  if(in_action_){ set_in_action(false); }
 
   NQLog("AssemblyAssemblyV2", NQLog::Spam) << "LowerPickupToolOntoPSS_finish"
      << ": emitting signal \"LowerPickupToolOntoPSS_finished\"";
@@ -1356,10 +1326,7 @@ void AssemblyAssemblyV2::LowerPickupToolOntoPSS_finish()
 void AssemblyAssemblyV2::PickupMaPSA_start()
 {
   if(in_action_){
-
-    NQLog("AssemblyAssemblyV2", NQLog::Warning) << "PickupMaPSA_start"
-       << ": logic error, an assembly step is still in progress, will not take further action";
-
+    reportInAction("PickupMaPSA");
     return;
   }
 
@@ -1389,7 +1356,7 @@ void AssemblyAssemblyV2::PickupMaPSA_start()
       connect(motion_, SIGNAL(motion_finished()), this, SLOT(PickupMaPSA_finish()));
   }
 
-  in_action_ = true;
+  set_in_action(true);
 
   NQLog("AssemblyAssemblyV2", NQLog::Spam) << "PickupMaPSA_start"
      << ": emitting signal \"move_relative_request(" << dx0 << ", " << dy0 << ", " << dz0 << ", " << da0 << ")\"";
@@ -1407,7 +1374,7 @@ void AssemblyAssemblyV2::PickupMaPSA_finish()
       disconnect(motion_, SIGNAL(motion_finished()), this, SLOT(PickupMaPSA_finish()));
   }
 
-  if(in_action_){ in_action_ = false; }
+  if(in_action_){ set_in_action(false); }
 
   NQLog("AssemblyAssemblyV2", NQLog::Spam) << "PickupMaPSA_finish"
      << ": emitting signal \"PickupMaPSA_finished\"";
@@ -1425,10 +1392,7 @@ void AssemblyAssemblyV2::PickupMaPSA_finish()
 void AssemblyAssemblyV2::PickupPSS_start()
 {
   if(in_action_){
-
-    NQLog("AssemblyAssemblyV2", NQLog::Warning) << "PickupPSS_start"
-       << ": logic error, an assembly step is still in progress, will not take further action";
-
+    reportInAction("PickupPSS");
     return;
   }
 
@@ -1458,7 +1422,7 @@ void AssemblyAssemblyV2::PickupPSS_start()
       connect(motion_, SIGNAL(motion_finished()), this, SLOT(PickupPSS_finish()));
   }
 
-  in_action_ = true;
+  set_in_action(true);
 
   NQLog("AssemblyAssemblyV2", NQLog::Spam) << "PickupPSS_start"
      << ": emitting signal \"move_relative_request(" << dx0 << ", " << dy0 << ", " << dz0 << ", " << da0 << ")\"";
@@ -1476,7 +1440,7 @@ void AssemblyAssemblyV2::PickupPSS_finish()
       disconnect(motion_, SIGNAL(motion_finished()), this, SLOT(PickupPSS_finish()));
   }
 
-  if(in_action_){ in_action_ = false; }
+  if(in_action_){ set_in_action(false); }
 
   NQLog("AssemblyAssemblyV2", NQLog::Spam) << "PickupPSS_finish"
      << ": emitting signal \"PickupPSS_finished\"";
@@ -1496,10 +1460,7 @@ void AssemblyAssemblyV2::PickupPSS_finish()
 void AssemblyAssemblyV2::GoToXYAPositionToGlueMaPSAToBaseplate_start()
 {
   if(in_action_){
-
-    NQLog("AssemblyAssemblyV2", NQLog::Warning) << "GoToXYAPositionToGlueMaPSAToBaseplate_start"
-       << ": logic error, an assembly step is still in progress, will not take further action";
-
+    reportInAction("GoToXYAPositionToGlueMaPSAToBaseplate");
     return;
   }
 
@@ -1526,7 +1487,7 @@ void AssemblyAssemblyV2::GoToXYAPositionToGlueMaPSAToBaseplate_start()
   connect(this, SIGNAL(move_relative_request(double, double, double, double)), motion_, SLOT(moveRelative(double, double, double, double)));
   connect(motion_, SIGNAL(motion_finished()), this, SLOT(GoToXYAPositionToGlueMaPSAToBaseplate_finish()));
 
-  in_action_ = true;
+  set_in_action(true);
 
   NQLog("AssemblyAssemblyV2", NQLog::Spam) << "GoToXYAPositionToGlueMaPSAToBaseplate_start"
      << ": emitting signal \"move_relative_request(" << dx0 << ", " << dy0 << ", " << dz0 << ", " << da0 << ")\"";
@@ -1539,7 +1500,7 @@ void AssemblyAssemblyV2::GoToXYAPositionToGlueMaPSAToBaseplate_finish()
   disconnect(this, SIGNAL(move_relative_request(double, double, double, double)), motion_, SLOT(moveRelative(double, double, double, double)));
   disconnect(motion_, SIGNAL(motion_finished()), this, SLOT(GoToXYAPositionToGlueMaPSAToBaseplate_finish()));
 
-  if(in_action_){ in_action_ = false; }
+  if(in_action_){ set_in_action(false); }
 
   NQLog("AssemblyAssemblyV2", NQLog::Spam) << "GoToXYAPositionToGlueMaPSAToBaseplate_finish"
      << ": emitting signal \"GoToXYAPositionToGlueMaPSAToBaseplate_finished\"";
@@ -1559,10 +1520,7 @@ void AssemblyAssemblyV2::GoToXYAPositionToGlueMaPSAToBaseplate_finish()
 void AssemblyAssemblyV2::LowerMaPSAOntoBaseplate_start()
 {
   if(in_action_){
-
-    NQLog("AssemblyAssemblyV2", NQLog::Warning) << "LowerMaPSAOntoBaseplate_start"
-       << ": logic error, an assembly step is still in progress, will not take further action";
-
+    reportInAction("LowerMaPSAOntoBaseplate");
     return;
   }
 
@@ -1605,7 +1563,7 @@ void AssemblyAssemblyV2::LowerMaPSAOntoBaseplate_start()
     connect(this, SIGNAL(move_relative_request(double, double, double, double)), smart_motion_, SLOT(move_relative(double, double, double, double)));
     connect(smart_motion_, SIGNAL(motion_completed()), this, SLOT(LowerMaPSAOntoBaseplate_finish()));
 
-    in_action_ = true;
+    set_in_action(true);
 
     NQLog("AssemblyAssemblyV2", NQLog::Spam) << "LowerMaPSAOntoBaseplate_start"
        << ": emitting signal \"move_relative_request(" << dx0 << ", " << dy0 << ", " << dz0 << ", " << da0 << ")\"";
@@ -1635,7 +1593,7 @@ void AssemblyAssemblyV2::LowerMaPSAOntoBaseplate_finish()
   disconnect(this, SIGNAL(move_relative_request(double, double, double, double)), smart_motion_, SLOT(move_relative(double, double, double, double)));
   disconnect(smart_motion_, SIGNAL(motion_completed()), this, SLOT(LowerMaPSAOntoBaseplate_finish()));
 
-  if(in_action_){ in_action_ = false; }
+  if(in_action_){ set_in_action(false); }
 
   NQLog("AssemblyAssemblyV2", NQLog::Spam) << "LowerMaPSAOntoBaseplate_finish"
      << ": emitting signal \"LowerMaPSAOntoBaseplate_finished\"";
@@ -1655,10 +1613,7 @@ void AssemblyAssemblyV2::LowerMaPSAOntoBaseplate_finish()
 void AssemblyAssemblyV2::GoToXYAPositionToGluePSSToSpacers_start()
 {
   if(in_action_){
-
-    NQLog("AssemblyAssemblyV2", NQLog::Warning) << "GoToXYAPositionToGluePSSToSpacers_start"
-       << ": logic error, an assembly step is still in progress, will not take further action";
-
+    reportInAction("GoToXYAPositionToGluePSSToSpacers");
     return;
   }
 
@@ -1685,7 +1640,7 @@ void AssemblyAssemblyV2::GoToXYAPositionToGluePSSToSpacers_start()
   connect(this, SIGNAL(move_relative_request(double, double, double, double)), motion_, SLOT(moveRelative(double, double, double, double)));
   connect(motion_, SIGNAL(motion_finished()), this, SLOT(GoToXYAPositionToGluePSSToSpacers_finish()));
 
-  in_action_ = true;
+  set_in_action(true);
 
   NQLog("AssemblyAssemblyV2", NQLog::Spam) << "GoToXYAPositionToGluePSSToSpacers_start"
      << ": emitting signal \"move_relative_request(" << dx0 << ", " << dy0 << ", " << dz0 << ", " << da0 << ")\"";
@@ -1698,7 +1653,7 @@ void AssemblyAssemblyV2::GoToXYAPositionToGluePSSToSpacers_finish()
   disconnect(this, SIGNAL(move_relative_request(double, double, double, double)), motion_, SLOT(moveRelative(double, double, double, double)));
   disconnect(motion_, SIGNAL(motion_finished()), this, SLOT(GoToXYAPositionToGluePSSToSpacers_finish()));
 
-  if(in_action_){ in_action_ = false; }
+  if(in_action_){ set_in_action(false); }
 
   NQLog("AssemblyAssemblyV2", NQLog::Spam) << "GoToXYAPositionToGluePSSToSpacers_finish"
      << ": emitting signal \"GoToXYAPositionToGluePSSToSpacers_finished\"";
@@ -1718,10 +1673,7 @@ void AssemblyAssemblyV2::GoToXYAPositionToGluePSSToSpacers_finish()
 void AssemblyAssemblyV2::LowerPSSOntoSpacers_start()
 {
   if(in_action_){
-
-    NQLog("AssemblyAssemblyV2", NQLog::Warning) << "LowerPSSOntoSpacers_start"
-       << ": logic error, an assembly step is still in progress, will not take further action";
-
+    reportInAction("LowerPSSOntoSpacers");
     return;
   }
 
@@ -1766,7 +1718,7 @@ void AssemblyAssemblyV2::LowerPSSOntoSpacers_start()
     connect(this, SIGNAL(move_relative_request(double, double, double, double)), smart_motion_, SLOT(move_relative(double, double, double, double)));
     connect(smart_motion_, SIGNAL(motion_completed()), this, SLOT(LowerPSSOntoSpacers_finish()));
 
-    in_action_ = true;
+    set_in_action(true);
 
     NQLog("AssemblyAssemblyV2", NQLog::Spam) << "LowerPSSOntoSpacers_start"
        << ": emitting signal \"move_relative_request(" << dx0 << ", " << dy0 << ", " << dz0 << ", " << da0 << ")\"";
@@ -1796,7 +1748,7 @@ void AssemblyAssemblyV2::LowerPSSOntoSpacers_finish()
   disconnect(this, SIGNAL(move_relative_request(double, double, double, double)), smart_motion_, SLOT(move_relative(double, double, double, double)));
   disconnect(smart_motion_, SIGNAL(motion_completed()), this, SLOT(LowerPSSOntoSpacers_finish()));
 
-  if(in_action_){ in_action_ = false; }
+  if(in_action_){ set_in_action(false); }
 
   NQLog("AssemblyAssemblyV2", NQLog::Spam) << "LowerPSSOntoSpacers_finish"
      << ": emitting signal \"LowerPSSOntoSpacers_finished\"";
@@ -1816,10 +1768,7 @@ void AssemblyAssemblyV2::LowerPSSOntoSpacers_finish()
 void AssemblyAssemblyV2::GoToPSPMarkerIdealPosition_start()
 {
   if(in_action_){
-
-    NQLog("AssemblyAssemblyV2", NQLog::Warning) << "GoToPSPMarkerIdealPosition_start"
-       << ": logic error, an assembly step is still in progress, will not take further action";
-
+    reportInAction("GoToPSPMarkerIdealPosition");
     return;
   }
 
@@ -1844,7 +1793,7 @@ void AssemblyAssemblyV2::GoToPSPMarkerIdealPosition_start()
   connect(this, SIGNAL(move_absolute_request(double, double, double, double)), motion_, SLOT(moveAbsolute(double, double, double, double)));
   connect(motion_, SIGNAL(motion_finished()), this, SLOT(GoToPSPMarkerIdealPosition_finish()));
 
-  in_action_ = true;
+  set_in_action(true);
 
   NQLog("AssemblyAssemblyV2", NQLog::Spam) << "GoToPSPMarkerIdealPosition_start"
      << ": emitting signal \"move_absolute_request(" << x0 << ", " << y0 << ", " << z0 << ", " << a0 << ")\"";
@@ -1857,7 +1806,7 @@ void AssemblyAssemblyV2::GoToPSPMarkerIdealPosition_finish()
   disconnect(this, SIGNAL(move_absolute_request(double, double, double, double)), motion_, SLOT(moveAbsolute(double, double, double, double)));
   disconnect(motion_, SIGNAL(motion_finished()), this, SLOT(GoToPSPMarkerIdealPosition_finish()));
 
-  if(in_action_){ in_action_ = false; }
+  if(in_action_){ set_in_action(false); }
 
   NQLog("AssemblyAssemblyV2", NQLog::Spam) << "GoToPSPMarkerIdealPosition_finish"
      << ": emitting signal \"GoToPSPMarkerIdealPosition_finished\"";
@@ -1875,10 +1824,7 @@ void AssemblyAssemblyV2::GoToPSPMarkerIdealPosition_finish()
 void AssemblyAssemblyV2::ApplyPSPToPSSXYOffset_start()
 {
   if(in_action_){
-
-    NQLog("AssemblyAssemblyV2", NQLog::Warning) << "ApplyPSPToPSSXYOffset_start"
-       << ": logic error, an assembly step is still in progress, will not take further action";
-
+    reportInAction("ApplyPSPToPSSXYOffset");
     return;
   }
 
@@ -1890,7 +1836,7 @@ void AssemblyAssemblyV2::ApplyPSPToPSSXYOffset_start()
   connect(this, SIGNAL(move_relative_request(double, double, double, double)), motion_, SLOT(moveRelative(double, double, double, double)));
   connect(motion_, SIGNAL(motion_finished()), this, SLOT(ApplyPSPToPSSXYOffset_finish()));
 
-  in_action_ = true;
+  set_in_action(true);
 
   NQLog("AssemblyAssemblyV2", NQLog::Spam) << "ApplyPSPToPSSXYOffset_start"
      << ": emitting signal \"move_relative_request(" << dx0 << ", " << dy0 << ", " << dz0 << ", " << da0 << ")\"";
@@ -1903,7 +1849,7 @@ void AssemblyAssemblyV2::ApplyPSPToPSSXYOffset_finish()
   disconnect(this, SIGNAL(move_relative_request(double, double, double, double)), motion_, SLOT(moveRelative(double, double, double, double)));
   disconnect(motion_, SIGNAL(motion_finished()), this, SLOT(ApplyPSPToPSSXYOffset_finish()));
 
-  if(in_action_){ in_action_ = false; }
+  if(in_action_){ set_in_action(false); }
 
   NQLog("AssemblyAssemblyV2", NQLog::Spam) << "ApplyPSPToPSSXYOffset_finish"
      << ": emitting signal \"ApplyPSPToPSSXYOffset_finished\"";
@@ -1923,10 +1869,7 @@ void AssemblyAssemblyV2::ApplyPSPToPSSXYOffset_finish()
 void AssemblyAssemblyV2::MakeSpaceOnPlatform_start()
 {
   if(in_action_){
-
-    NQLog("AssemblyAssemblyV2", NQLog::Warning) << "MakeSpaceOnPlatform_start"
-       << ": logic error, an assembly step is still in progress, will not take further action";
-
+    reportInAction("MakeSpaceOnPlatform");
     return;
   }
 
@@ -1957,7 +1900,7 @@ void AssemblyAssemblyV2::MakeSpaceOnPlatform_start()
   connect(this, SIGNAL(move_relative_request(double, double, double, double)), motion_, SLOT(moveRelative(double, double, double, double)));
   connect(motion_, SIGNAL(motion_finished()), this, SLOT(MakeSpaceOnPlatform_finish()));
 
-  in_action_ = true;
+  set_in_action(true);
 
   NQLog("AssemblyAssemblyV2", NQLog::Spam) << "MakeSpaceOnPlatform_start"
      << ": emitting signal \"move_relative_request(" << dx0 << ", " << dy0 << ", " << dz0 << ", " << da0 << ")\"";
@@ -1970,7 +1913,7 @@ void AssemblyAssemblyV2::MakeSpaceOnPlatform_finish()
   disconnect(this, SIGNAL(move_relative_request(double, double, double, double)), motion_, SLOT(moveRelative(double, double, double, double)));
   disconnect(motion_, SIGNAL(motion_finished()), this, SLOT(MakeSpaceOnPlatform_finish()));
 
-  if(in_action_){ in_action_ = false; }
+  if(in_action_){ set_in_action(false); }
 
   NQLog("AssemblyAssemblyV2", NQLog::Spam) << "MakeSpaceOnPlatform_finish"
      << ": emitting signal \"LiftUpPickupTool_finished\"";
@@ -1990,10 +1933,7 @@ void AssemblyAssemblyV2::MakeSpaceOnPlatform_finish()
 void AssemblyAssemblyV2::ReturnToPlatform_start()
 {
   if(in_action_){
-
-    NQLog("AssemblyAssemblyV2", NQLog::Warning) << "ReturnToPlatform_start"
-       << ": logic error, an assembly step is still in progress, will not take further action";
-
+    reportInAction("ReturnToPlatform");
     return;
   }
 
@@ -2057,7 +1997,7 @@ void AssemblyAssemblyV2::ReturnToPlatform_start()
   connect(this, SIGNAL(move_relative_request(double, double, double, double)), motion_, SLOT(moveRelative(double, double, double, double)));
   connect(motion_, SIGNAL(motion_finished()), this, SLOT(ReturnToPlatform_finish()));
 
-  in_action_ = true;
+  set_in_action(true);
 
   NQLog("AssemblyAssemblyV2", NQLog::Spam) << "ReturnToPlatform_start"
      << ": emitting signal \"move_relative_request(" << dx0 << ", " << dy0 << ", " << dz0 << ", " << da0 << ")\"";
@@ -2070,7 +2010,7 @@ void AssemblyAssemblyV2::ReturnToPlatform_finish()
   disconnect(this, SIGNAL(move_relative_request(double, double, double, double)), motion_, SLOT(moveRelative(double, double, double, double)));
   disconnect(motion_, SIGNAL(motion_finished()), this, SLOT(ReturnToPlatform_finish()));
 
-  if(in_action_){ in_action_ = false; }
+  if(in_action_){ set_in_action(false); }
 
   position_before_makespace_stored_ = false;
 
@@ -2092,10 +2032,7 @@ void AssemblyAssemblyV2::ReturnToPlatform_finish()
 void AssemblyAssemblyV2::RegisterPSSPlusSpacersToMaPSAPosition_start()
 {
   if(in_action_){
-
-    NQLog("AssemblyAssemblyV2", NQLog::Warning) << "RegisterPSSPlusSpacersToMaPSAPosition_start"
-       << ": logic error, an assembly step is still in progress, will not take further action";
-
+    reportInAction("RegisterPSSPlusSpacersToMaPSAPosition");
     return;
   }
 
@@ -2112,7 +2049,7 @@ void AssemblyAssemblyV2::RegisterPSSPlusSpacersToMaPSAPosition_start()
 
   connect(this, SIGNAL(PSSPlusSpacersToMaPSAPosition_registered()), this, SLOT(RegisterPSSPlusSpacersToMaPSAPosition_finish()));
 
-  in_action_ = true;
+  set_in_action(true);
 
   NQLog("AssemblyAssemblyV2", NQLog::Spam) << "RegisterPSSPlusSpacersToMaPSAPosition_start"
      << ": emitting signal \"PSSPlusSpacersToMaPSAPosition_registered\"";
@@ -2124,7 +2061,7 @@ void AssemblyAssemblyV2::RegisterPSSPlusSpacersToMaPSAPosition_finish()
 {
   disconnect(this, SIGNAL(PSSPlusSpacersToMaPSAPosition_registered()), this, SLOT(RegisterPSSPlusSpacersToMaPSAPosition_finish()));
 
-  if(in_action_){ in_action_ = false; }
+  if(in_action_){ set_in_action(false); }
 
   NQLog("AssemblyAssemblyV2", NQLog::Spam) << "RegisterPSSPlusSpacersToMaPSAPosition_finish"
      << ": emitting signal \"RegisterPSSPlusSpacersToMaPSAPosition_finished\"";
@@ -2144,10 +2081,7 @@ void AssemblyAssemblyV2::RegisterPSSPlusSpacersToMaPSAPosition_finish()
 void AssemblyAssemblyV2::GoFromPSSPlusSpacersToMaPSAPositionToGluingStageRefPointXY_start()
 {
   if(in_action_){
-
-    NQLog("AssemblyAssemblyV2", NQLog::Warning) << "GoFromPSSPlusSpacersToMaPSAPositionToGluingStageRefPointXY_start"
-       << ": logic error, an assembly step is still in progress, will not take further action";
-
+    reportInAction("GoFromPSSPlusSpacersToMaPSAPositionToGluingStageRefPointXY");
     return;
   }
 
@@ -2161,7 +2095,7 @@ void AssemblyAssemblyV2::GoFromPSSPlusSpacersToMaPSAPositionToGluingStageRefPoin
     connect(this, SIGNAL(move_relative_request(double, double, double, double)), smart_motion_, SLOT(move_relative(double, double, double, double)));
     connect(smart_motion_, SIGNAL(motion_completed()), this, SLOT(GoFromPSSPlusSpacersToMaPSAPositionToGluingStageRefPointXY_finish()));
 
-    in_action_ = true;
+    set_in_action(true);
 
     NQLog("AssemblyAssemblyV2", NQLog::Spam) << "GoFromPSSPlusSpacersToMaPSAPositionToGluingStageRefPointXY_start"
        << ": emitting signal \"move_relative_request(" << dx0 << ", " << dy0 << ", " << dz0 << ", " << da0 << ")\"";
@@ -2191,7 +2125,7 @@ void AssemblyAssemblyV2::GoFromPSSPlusSpacersToMaPSAPositionToGluingStageRefPoin
   disconnect(this, SIGNAL(move_relative_request(double, double, double, double)), smart_motion_, SLOT(move_relative(double, double, double, double)));
   disconnect(smart_motion_, SIGNAL(motion_completed()), this, SLOT(GoFromPSSPlusSpacersToMaPSAPositionToGluingStageRefPointXY_finish()));
 
-  if(in_action_){ in_action_ = false; }
+  if(in_action_){ set_in_action(false); }
 
   NQLog("AssemblyAssemblyV2", NQLog::Spam) << "GoFromPSSPlusSpacersToMaPSAPositionToGluingStageRefPointXY_finish"
      << ": emitting signal \"GoFromPSSPlusSpacersToMaPSAPositionToGluingStageRefPointXY_finished\"";
@@ -2211,10 +2145,7 @@ void AssemblyAssemblyV2::GoFromPSSPlusSpacersToMaPSAPositionToGluingStageRefPoin
 void AssemblyAssemblyV2::LowerPSSPlusSpacersOntoGluingStage_start()
 {
   if(in_action_){
-
-    NQLog("AssemblyAssemblyV2", NQLog::Warning) << "LowerPSSPlusSpacersOntoGluingStage_start"
-       << ": logic error, an assembly step is still in progress, will not take further action";
-
+    reportInAction("LowerPSSPlusSpacersOntoGluingStage");
     return;
   }
 
@@ -2256,7 +2187,7 @@ void AssemblyAssemblyV2::LowerPSSPlusSpacersOntoGluingStage_start()
     connect(this, SIGNAL(move_relative_request(double, double, double, double)), smart_motion_, SLOT(move_relative(double, double, double, double)));
     connect(smart_motion_, SIGNAL(motion_completed()), this, SLOT(LowerPSSPlusSpacersOntoGluingStage_finish()));
 
-    in_action_ = true;
+    set_in_action(true);
 
     NQLog("AssemblyAssemblyV2", NQLog::Spam) << "LowerPSSPlusSpacersOntoGluingStage_start"
        << ": emitting signal \"move_relative_request(" << dx0 << ", " << dy0 << ", " << dz0 << ", " << da0 << ")\"";
@@ -2286,7 +2217,7 @@ void AssemblyAssemblyV2::LowerPSSPlusSpacersOntoGluingStage_finish()
   disconnect(this, SIGNAL(move_relative_request(double, double, double, double)), smart_motion_, SLOT(move_relative(double, double, double, double)));
   disconnect(smart_motion_, SIGNAL(motion_completed()), this, SLOT(LowerPSSPlusSpacersOntoGluingStage_finish()));
 
-  if(in_action_){ in_action_ = false; }
+  if(in_action_){ set_in_action(false); }
 
   NQLog("AssemblyAssemblyV2", NQLog::Spam) << "LowerPSSPlusSpacersOntoGluingStage_finish"
      << ": emitting signal \"LowerPSSPlusSpacersOntoGluingStage_finished\"";
@@ -2307,10 +2238,7 @@ void AssemblyAssemblyV2::LowerPSSPlusSpacersOntoGluingStage_finish()
 void AssemblyAssemblyV2::SlowlyLiftFromGluingStage_start()
 {
   if(in_action_){
-
-    NQLog("AssemblyAssemblyV2", NQLog::Warning) << "SlowlyLiftFromGluingStage_start"
-       << ": logic error, an assembly step is still in progress, will not take further action";
-
+    reportInAction("SlowlyLiftFromGluingStage");
     return;
   }
 
@@ -2335,7 +2263,7 @@ void AssemblyAssemblyV2::SlowlyLiftFromGluingStage_start()
     connect(this, SIGNAL(move_relative_request(double, double, double, double)), smart_motion_, SLOT(move_relative(double, double, double, double)));
     connect(smart_motion_, SIGNAL(motion_completed()), this, SLOT(SlowlyLiftFromGluingStage_finish()));
 
-    in_action_ = true;
+    set_in_action(true);
 
     NQLog("AssemblyAssemblyV2", NQLog::Spam) << "SlowlyLiftFromGluingStage_start"
        << ": emitting signal \"move_relative_request(" << dx0 << ", " << dy0 << ", " << dz0 << ", " << da0 << ")\"";
@@ -2371,7 +2299,7 @@ void AssemblyAssemblyV2::SlowlyLiftFromGluingStage_finish()
   disconnect(this, SIGNAL(move_relative_request(double, double, double, double)), smart_motion_, SLOT(move_relative(double, double, double, double)));
   disconnect(smart_motion_, SIGNAL(motion_completed()), this, SLOT(SlowlyLiftFromGluingStage_finish()));
 
-  if(in_action_){ in_action_ = false; }
+  if(in_action_){ set_in_action(false); }
 
   NQLog("AssemblyAssemblyV2", NQLog::Spam) << "SlowlyLiftFromGluingStage_finish"
      << ": emitting signal \"SlowlyLiftFromGluingStage_finished\"";
@@ -2392,10 +2320,7 @@ void AssemblyAssemblyV2::SlowlyLiftFromGluingStage_finish()
 void AssemblyAssemblyV2::ReturnToPSSPlusSpacersToMaPSAPosition_start()
 {
   if(in_action_){
-
-    NQLog("AssemblyAssemblyV2", NQLog::Warning) << "ReturnToPSSPlusSpacersToMaPSAPosition_start"
-       << ": logic error, an assembly step is still in progress, will not take further action";
-
+    reportInAction("ReturnToPSSPlusSpacersToMaPSAPosition");
     return;
   }
 
@@ -2439,7 +2364,7 @@ void AssemblyAssemblyV2::ReturnToPSSPlusSpacersToMaPSAPosition_start()
     connect(this, SIGNAL(move_relative_request(double, double, double, double)), smart_motion_, SLOT(move_relative(double, double, double, double)));
     connect(smart_motion_, SIGNAL(motion_completed()), this, SLOT(ReturnToPSSPlusSpacersToMaPSAPosition_finish()));
 
-    in_action_ = true;
+    set_in_action(true);
 
     NQLog("AssemblyAssemblyV2", NQLog::Spam) << "ReturnToPSSPlusSpacersToMaPSAPosition_start"
        << ": emitting signal \"move_relative_request(" << dx0 << ", " << dy0 << ", " << dz0 << ", " << da0 << ")\"";
@@ -2469,7 +2394,7 @@ void AssemblyAssemblyV2::ReturnToPSSPlusSpacersToMaPSAPosition_finish()
   disconnect(this, SIGNAL(move_relative_request(double, double, double, double)), smart_motion_, SLOT(move_relative(double, double, double, double)));
   disconnect(smart_motion_, SIGNAL(motion_completed()), this, SLOT(ReturnToPSSPlusSpacersToMaPSAPosition_finish()));
 
-  if(in_action_){ in_action_ = false; }
+  if(in_action_){ set_in_action(false); }
 
   NQLog("AssemblyAssemblyV2", NQLog::Spam) << "ReturnToPSSPlusSpacersToMaPSAPosition_finish"
      << ": emitting signal \"ReturnToPSSPlusSpacersToMaPSAPosition_finished\"";
@@ -2489,10 +2414,7 @@ void AssemblyAssemblyV2::ReturnToPSSPlusSpacersToMaPSAPosition_finish()
 void AssemblyAssemblyV2::LowerPSSPlusSpacersOntoMaPSA_start()
 {
   if(in_action_){
-
-    NQLog("AssemblyAssemblyV2", NQLog::Warning) << "LowerPSSPlusSpacersOntoMaPSA_start"
-       << ": logic error, an assembly step is still in progress, will not take further action";
-
+    reportInAction("LowerPSSPlusSpacersOntoMaPSA");
     return;
   }
 
@@ -2534,7 +2456,7 @@ void AssemblyAssemblyV2::LowerPSSPlusSpacersOntoMaPSA_start()
     connect(this, SIGNAL(move_relative_request(double, double, double, double)), smart_motion_, SLOT(move_relative(double, double, double, double)));
     connect(smart_motion_, SIGNAL(motion_completed()), this, SLOT(LowerPSSPlusSpacersOntoMaPSA_finish()));
 
-    in_action_ = true;
+    set_in_action(true);
 
     NQLog("AssemblyAssemblyV2", NQLog::Spam) << "LowerPSSPlusSpacersOntoMaPSA_start"
        << ": emitting signal \"move_relative_request(" << dx0 << ", " << dy0 << ", " << dz0 << ", " << da0 << ")\"";
@@ -2564,7 +2486,7 @@ void AssemblyAssemblyV2::LowerPSSPlusSpacersOntoMaPSA_finish()
   disconnect(this, SIGNAL(move_relative_request(double, double, double, double)), smart_motion_, SLOT(move_relative(double, double, double, double)));
   disconnect(smart_motion_, SIGNAL(motion_completed()), this, SLOT(LowerPSSPlusSpacersOntoMaPSA_finish()));
 
-  if(in_action_){ in_action_ = false; }
+  if(in_action_){ set_in_action(false); }
 
   NQLog("AssemblyAssemblyV2", NQLog::Spam) << "LowerPSSPlusSpacersOntoMaPSA_finish"
      << ": emitting signal \"LowerPSSPlusSpacersOntoMaPSA_finished\"";
@@ -2584,10 +2506,7 @@ void AssemblyAssemblyV2::LowerPSSPlusSpacersOntoMaPSA_finish()
 void AssemblyAssemblyV2::PickupPSSPlusSpacers_start()
 {
   if(in_action_){
-
-    NQLog("AssemblyAssemblyV2", NQLog::Warning) << "PickupPSSPlusSpacers_start"
-       << ": logic error, an assembly step is still in progress, will not take further action";
-
+    reportInAction("PickupPSSPlusSpacers");
     return;
   }
 
@@ -2617,7 +2536,7 @@ void AssemblyAssemblyV2::PickupPSSPlusSpacers_start()
       connect(motion_, SIGNAL(motion_finished()), this, SLOT(PickupPSSPlusSpacers_finish()));
   }
 
-  in_action_ = true;
+  set_in_action(true);
 
   NQLog("AssemblyAssemblyV2", NQLog::Spam) << "PickupPSSPlusSpacers_start"
      << ": emitting signal \"move_relative_request(" << dx0 << ", " << dy0 << ", " << dz0 << ", " << da0 << ")\"";
@@ -2635,7 +2554,7 @@ void AssemblyAssemblyV2::PickupPSSPlusSpacers_finish()
       disconnect(motion_, SIGNAL(motion_finished()), this, SLOT(PickupPSSPlusSpacers_finish()));
   }
 
-  if(in_action_){ in_action_ = false; }
+  if(in_action_){ set_in_action(false); }
 
   NQLog("AssemblyAssemblyV2", NQLog::Spam) << "PickupPSSPlusSpacers_finish"
      << ": emitting signal \"PickupPSSPlusSpacers_finished\"";
@@ -2655,10 +2574,7 @@ void AssemblyAssemblyV2::PickupPSSPlusSpacers_finish()
 void AssemblyAssemblyV2::LiftUpPickupTool_start()
 {
   if(in_action_){
-
-    NQLog("AssemblyAssemblyV2", NQLog::Warning) << "LiftUpPickupTool_start"
-       << ": logic error, an assembly step is still in progress, will not take further action";
-
+    reportInAction("LiftUpPickupTool");
     return;
   }
 
@@ -2683,7 +2599,7 @@ void AssemblyAssemblyV2::LiftUpPickupTool_start()
   connect(this, SIGNAL(move_relative_request(double, double, double, double)), motion_, SLOT(moveRelative(double, double, double, double)));
   connect(motion_, SIGNAL(motion_finished()), this, SLOT(LiftUpPickupTool_finish()));
 
-  in_action_ = true;
+  set_in_action(true);
 
   NQLog("AssemblyAssemblyV2", NQLog::Spam) << "LiftUpPickupTool_start"
      << ": emitting signal \"move_relative_request(" << dx0 << ", " << dy0 << ", " << dz0 << ", " << da0 << ")\"";
@@ -2696,7 +2612,7 @@ void AssemblyAssemblyV2::LiftUpPickupTool_finish()
   disconnect(this, SIGNAL(move_relative_request(double, double, double, double)), motion_, SLOT(moveRelative(double, double, double, double)));
   disconnect(motion_, SIGNAL(motion_finished()), this, SLOT(LiftUpPickupTool_finish()));
 
-  if(in_action_){ in_action_ = false; }
+  if(in_action_){ set_in_action(false); }
 
   NQLog("AssemblyAssemblyV2", NQLog::Spam) << "LiftUpPickupTool_finish"
      << ": emitting signal \"LiftUpPickupTool_finished\"";
@@ -2712,10 +2628,7 @@ void AssemblyAssemblyV2::LiftUpPickupTool_finish()
 void AssemblyAssemblyV2::AssemblyCompleted_start()
 {
   if(in_action_){
-
-    NQLog("AssemblyAssemblyV2", NQLog::Warning) << "AssemblyCompleted_start"
-       << ": logic error, an assembly step is still in progress, will not take further action";
-
+    reportInAction("AssemblyCompleted");
     return;
   }
 
@@ -2738,21 +2651,16 @@ void AssemblyAssemblyV2::AssemblyCompleted_start()
 void AssemblyAssemblyV2::switchToAlignmentTab_PSP()
 {
   if(in_action_){
-
-    NQLog("AssemblyAssembly", NQLog::Warning) << "switchToAlignmentTab_PSP"
-       << ": logic error, an assembly step is still in progress, will not take further action";
-
+    reportInAction("switchToAlignmentTab");
     return;
   }
 
-  in_action_ = true;
+  set_in_action(true);
 
-  NQLog("AssemblyAssembly", NQLog::Spam) << "switchToAlignmentTab_PSP"
+  NQLog("AssemblyAssemblyV2", NQLog::Spam) << "switchToAlignmentTab_PSP"
     << ": emitting signal \"switchToAlignmentTab_PSP_request\"";
 
   emit switchToAlignmentTab_PSP_request(); //Will auto-switch to 'Alignment' sub-tab, and select PSP mode
-
-  in_action_ = false;
 
   return;
 }
@@ -2764,22 +2672,40 @@ void AssemblyAssemblyV2::switchToAlignmentTab_PSP()
 void AssemblyAssemblyV2::switchToAlignmentTab_PSS()
 {
   if(in_action_){
-
-    NQLog("AssemblyAssembly", NQLog::Warning) << "switchToAlignmentTab_PSS"
-       << ": logic error, an assembly step is still in progress, will not take further action";
-
+    reportInAction("switchToAlignmentTab_PSS");
     return;
   }
 
-  in_action_ = true;
+  set_in_action(true);
 
-  NQLog("AssemblyAssembly", NQLog::Spam) << "switchToAlignmentTab_PSS"
+  NQLog("AssemblyAssemblyV2", NQLog::Spam) << "switchToAlignmentTab_PSS"
     << ": emitting signal \"switchToAlignmentTab_PSS_request\"";
 
   emit switchToAlignmentTab_PSS_request(); //Will auto-switch to 'Alignment' sub-tab, and select PSS mode
 
-  in_action_ = false;
-
   return;
 }
 // ----------------------------------------------------------------------------------------------------
+
+void AssemblyAssemblyV2::reportInAction(std::string target_step)
+{
+    NQLog("AssemblyAssemblyV2", NQLog::Warning) << QString::fromStdString(target_step)
+      << ": logic error, an assembly step is still in progress, will not take further action";
+    NQLog("AssemblyAssemblyV2", NQLog::Warning) << QString::fromStdString(target_step)
+      << ": in_action: " << in_action_;
+
+    QMessageBox msgBox;
+    msgBox.setWindowTitle(tr("Error"));
+    QString msg = QString("An assembly step is still in progress.\nCould not perform step:\n") + QString::fromStdString(target_step);
+    msgBox.setText(msg);
+    msgBox.setInformativeText("Please wait until the step has been completed.\nHint: once an alignment step has been clicked, the alignment has to be performed before being able to continue the assembly.");
+    msgBox.setStandardButtons(QMessageBox::Ok);
+    msgBox.exec();
+}
+
+void AssemblyAssemblyV2::set_in_action(bool in_action)
+{
+  in_action_mutex_.lock();
+  in_action_ = in_action;
+  in_action_mutex_.unlock();
+}

--- a/assembly/assemblyCommon/AssemblyAssemblyV2.h
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2.h
@@ -39,6 +39,8 @@ class AssemblyAssemblyV2 : public QObject
 
   const AssemblySmartMotionManager* smart_motion() const;
 
+  void set_in_action(bool in_action);
+
  protected:
   const LStepExpressMotionManager* const motion_;
   const RelayCardManager* const vacuum_;
@@ -62,6 +64,7 @@ class AssemblyAssemblyV2 : public QObject
 
   bool use_smartMove_;
   bool in_action_;
+  std::mutex in_action_mutex_;
 
   bool PSSPlusSpacersToMaPSAPosition_isRegistered_;
   double PSSPlusSpacersToMaPSAPosition_X_;
@@ -81,6 +84,9 @@ class AssemblyAssemblyV2 : public QObject
 
  public:
   assembly::Center GetAssemblyCenter() const {return assembly_center_;};
+
+protected slots:
+  void reportInAction(std::string target_step);
 
  public slots:
 

--- a/assembly/assemblyCommon/AssemblyAssemblyV2.h
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2.h
@@ -86,7 +86,7 @@ class AssemblyAssemblyV2 : public QObject
   assembly::Center GetAssemblyCenter() const {return assembly_center_;};
 
 protected slots:
-  void reportInAction(std::string target_step);
+  void reportInAction(const QString target_step, const char*);
 
  public slots:
 
@@ -320,8 +320,9 @@ protected slots:
   void Module_ID_updated(const QString);
   // ------
 
-
   void DBLogMessage(const QString);
+
+  void abort_this();
 };
 
 #endif // ASSEMBLYASSEMBLYV2_H

--- a/assembly/assemblyCommon/AssemblyAssemblyV2.h
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2.h
@@ -254,40 +254,76 @@ protected slots:
   void PushStep3ToDB_aborted();
 
   void GoToPlatformReferencePoint_finished();
+  void GoToPlatformReferencePoint_abort();
 
   void GoToOrigin_finished();
+  void GoToOrigin_abort();
 
   void GoToSensorMarkerPreAlignment_finished();
+  void GoToSensorMarkerPreAlignment_abort();
 
   void GoFromSensorMarkerToPickupXY_finished();
+  void GoFromSensorMarkerToPickupXY_abort();
 
   void LowerPickupToolOntoMaPSA_finished();
+  void LowerPickupToolOntoMaPSA_abort();
+
   void PickupMaPSA_finished();
+  void PickupMaPSA_abort();
 
   void GoToXYAPositionToGlueMaPSAToBaseplate_finished();
+  void GoToXYAPositionToGlueMaPSAToBaseplate_abort();
+
   void LowerMaPSAOntoBaseplate_finished();
+  void LowerMaPSAOntoBaseplate_abort();
 
   void LowerPickupToolOntoPSS_finished();
+  void LowerPickupToolOntoPSS_abort();
+
   void PickupPSS_finished();
+  void PickupPSS_abort();
 
   void GoToXYAPositionToGluePSSToSpacers_finished();
+  void GoToXYAPositionToGluePSSToSpacers_abort();
+
   void LowerPSSOntoSpacers_finished();
+  void LowerPSSOntoSpacers_abort();
+
   void PickupPSSPlusSpacers_finished();
+  void PickupPSSPlusSpacers_abort();
 
   void GoToPSPMarkerIdealPosition_finished();
+  void GoToPSPMarkerIdealPosition_abort();
 
   void ApplyPSPToPSSXYOffset_finished();
+  void ApplyPSPToPSSXYOffset_abort();
+
   void MakeSpaceOnPlatform_finished();
+  void MakeSpaceOnPlatform_abort();
+
   void ReturnToPlatform_finished();
+  void ReturnToPlatform_abort();
+
   void PSSPlusSpacersToMaPSAPosition_registered();
+  void PSSPlusSpacersToMaPSAPosition_abort();
 
   void GoFromPSSPlusSpacersToMaPSAPositionToGluingStageRefPointXY_finished();
+  void GoFromPSSPlusSpacersToMaPSAPositionToGluingStageRefPointXY_abort();
+
   void LowerPSSPlusSpacersOntoGluingStage_finished();
+  void LowerPSSPlusSpacersOntoGluingStage_abort();
+
   void ReturnToPSSPlusSpacersToMaPSAPosition_finished();
+  void ReturnToPSSPlusSpacersToMaPSAPosition_abort();
 
   void SlowlyLiftFromGluingStage_finished();
+  void SlowlyLiftFromGluingStage_abort();
+
   void LowerPSSPlusSpacersOntoMaPSA_finished();
+  void LowerPSSPlusSpacersOntoMaPSA_abort();
+
   void LiftUpPickupTool_finished();
+  void LiftUpPickupTool_abort();
   // ------
 
   // vacuum
@@ -295,21 +331,31 @@ protected slots:
   void vacuum_OFF_request(const int);
 
   void EnableVacuumPickupTool_finished();
+  void EnableVacuumPickupTool_abort();
   void DisableVacuumPickupTool_finished();
+  void DisableVacuumPickupTool_abort();
 
   void EnableVacuumSpacers_finished();
+  void EnableVacuumSpacers_abort();
   void DisableVacuumSpacers_finished();
+  void DisableVacuumSpacers_abort();
 
   void EnableVacuumBaseplate_finished();
+  void EnableVacuumBaseplate_abort();
   void DisableVacuumBaseplate_finished();
+  void DisableVacuumBaseplate_abort();
 
   void AssemblyCompleted_finished();
+  void AssemblyCompleted_abort();
   // ------
 
   // others
   void RegisterPSSPlusSpacersToMaPSAPosition_finished();
+  void RegisterPSSPlusSpacersToMaPSAPosition_abort();
   void switchToAlignmentTab_PSP_request();
+  void switchToAlignmentTab_PSP_abort();
   void switchToAlignmentTab_PSS_request();
+  void switchToAlignmentTab_PSS_abort();
 
   void MaPSA_ID_updated(const QString);
   void PSS_ID_updated(const QString);

--- a/assembly/assemblyCommon/AssemblyAssemblyV2View.cc
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2View.cc
@@ -167,7 +167,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
         tmp_wid->button()->setText("Go To Platform Reference Point");
         PSPToBasep_lay->addWidget(tmp_wid);
 
-        tmp_wid->connect_action(assembly, SLOT(GoToPlatformReferencePoint_start()), SIGNAL(GoToPlatformReferencePoint_finished()));
+        tmp_wid->connect_action(assembly, SLOT(GoToPlatformReferencePoint_start()), SIGNAL(GoToPlatformReferencePoint_finished()), SIGNAL(GoToPlatformReferencePoint_abort()));
       }
       // ----------
 
@@ -191,7 +191,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
         tmp_wid->button()->setText("Go To Origin");
         PSPToBasep_lay->addWidget(tmp_wid);
 
-        tmp_wid->connect_action(assembly, SLOT(GoToOrigin_start()), SIGNAL(GoToOrigin_finished()));
+        tmp_wid->connect_action(assembly, SLOT(GoToOrigin_start()), SIGNAL(GoToOrigin_finished()), SIGNAL(GoToOrigin_abort()));
       }
       // ----------
 
@@ -255,7 +255,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
     tmp_wid->button()->setText("Enable Vacuum on MaPSA");
     PSPToBasep_lay->addWidget(tmp_wid);
 
-    tmp_wid->connect_action(assembly, SLOT(EnableVacuumBaseplate_start()), SIGNAL(EnableVacuumBaseplate_finished()));
+    tmp_wid->connect_action(assembly, SLOT(EnableVacuumBaseplate_start()), SIGNAL(EnableVacuumBaseplate_finished()), SIGNAL(EnableVacuumBaseplate_abort()));
   }
   // ----------
 
@@ -268,7 +268,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
     tmp_wid->button()->setText("Go To Measurement Position on MaPSA");
     PSPToBasep_lay->addWidget(tmp_wid);
 
-    tmp_wid->connect_action(assembly, SLOT(GoToPSPSensorMarkerPreAlignment_start()), SIGNAL(GoToSensorMarkerPreAlignment_finished()));
+    tmp_wid->connect_action(assembly, SLOT(GoToPSPSensorMarkerPreAlignment_start()), SIGNAL(GoToSensorMarkerPreAlignment_finished()), SIGNAL(GoToSensorMarkerPreAlignment_abort()));
   }
   // ----------
 
@@ -284,7 +284,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
     tmp_wid->button()->setText("Align MaPSA to Motion Stage (Go to \"Alignment\" Tab and select \"PS-p Sensor\")");
     PSPToBasep_lay->addWidget(tmp_wid);
 
-    tmp_wid->connect_action(assembly, SLOT(switchToAlignmentTab_PSP()), SIGNAL(switchToAlignmentTab_PSP_request()));
+    tmp_wid->connect_action(assembly, SLOT(switchToAlignmentTab_PSP()), SIGNAL(switchToAlignmentTab_PSP_request()), SIGNAL(switchToAlignmentTab_PSP_abort()));
   }
   // ----------
 
@@ -297,7 +297,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
     tmp_wid->button()->setText("Go From Sensor Marker Ref-Point to Pickup XY");
     PSPToBasep_lay->addWidget(tmp_wid);
 
-    tmp_wid->connect_action(assembly, SLOT(GoFromSensorMarkerToPickupXY_start()), SIGNAL(GoFromSensorMarkerToPickupXY_finished()));
+    tmp_wid->connect_action(assembly, SLOT(GoFromSensorMarkerToPickupXY_start()), SIGNAL(GoFromSensorMarkerToPickupXY_finished()), SIGNAL(GoFromSensorMarkerToPickupXY_abort()));
   }
   // ----------
 
@@ -310,7 +310,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
     tmp_wid->button()->setText("Lower Pickup-Tool onto MaPSA");
     PSPToBasep_lay->addWidget(tmp_wid);
 
-    tmp_wid->connect_action(assembly, SLOT(LowerPickupToolOntoMaPSA_start()), SIGNAL(LowerPickupToolOntoMaPSA_finished()));
+    tmp_wid->connect_action(assembly, SLOT(LowerPickupToolOntoMaPSA_start()), SIGNAL(LowerPickupToolOntoMaPSA_finished()), SIGNAL(LowerPickupToolOntoMaPSA_abort()));
   }
   // ----------
 
@@ -323,7 +323,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
     tmp_wid->button()->setText("Enable Vacuum on Pickup-Tool");
     PSPToBasep_lay->addWidget(tmp_wid);
 
-    tmp_wid->connect_action(assembly, SLOT(EnableVacuumPickupTool_start()), SIGNAL(EnableVacuumPickupTool_finished()));
+    tmp_wid->connect_action(assembly, SLOT(EnableVacuumPickupTool_start()), SIGNAL(EnableVacuumPickupTool_finished()), SIGNAL(EnableVacuumPickupTool_abort()));
   }
   // ----------
 
@@ -336,7 +336,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
     tmp_wid->button()->setText("Disable Vacuum on MaPSA");
     PSPToBasep_lay->addWidget(tmp_wid);
 
-    tmp_wid->connect_action(assembly, SLOT(DisableVacuumBaseplate_start()), SIGNAL(DisableVacuumBaseplate_finished()));
+    tmp_wid->connect_action(assembly, SLOT(DisableVacuumBaseplate_start()), SIGNAL(DisableVacuumBaseplate_finished()), SIGNAL(DisableVacuumBaseplate_abort()));
   }
   // ----------
 
@@ -349,7 +349,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
     tmp_wid->button()->setText("Pick Up MaPSA");
     PSPToBasep_lay->addWidget(tmp_wid);
 
-    tmp_wid->connect_action(assembly, SLOT(PickupMaPSA_start()), SIGNAL(PickupMaPSA_finished()));
+    tmp_wid->connect_action(assembly, SLOT(PickupMaPSA_start()), SIGNAL(PickupMaPSA_finished()), SIGNAL(PickupMaPSA_abort()));
   }
   // ----------
 
@@ -401,7 +401,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
     tmp_wid->button()->setText("Enable Vacuum on Baseplate");
     PSPToBasep_lay->addWidget(tmp_wid);
 
-    tmp_wid->connect_action(assembly, SLOT(EnableVacuumBaseplate_start()), SIGNAL(EnableVacuumBaseplate_finished()));
+    tmp_wid->connect_action(assembly, SLOT(EnableVacuumBaseplate_start()), SIGNAL(EnableVacuumBaseplate_finished()), SIGNAL(EnableVacuumBaseplate_abort()));
   }
   // ----------
 
@@ -427,7 +427,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
     tmp_wid->button()->setText("Go To XYA Position To Glue MaPSA To Baseplate");
     PSPToBasep_lay->addWidget(tmp_wid);
 
-    tmp_wid->connect_action(assembly, SLOT(GoToXYAPositionToGlueMaPSAToBaseplate_start()), SIGNAL(GoToXYAPositionToGlueMaPSAToBaseplate_finished()));
+    tmp_wid->connect_action(assembly, SLOT(GoToXYAPositionToGlueMaPSAToBaseplate_start()), SIGNAL(GoToXYAPositionToGlueMaPSAToBaseplate_finished()), SIGNAL(GoToXYAPositionToGlueMaPSAToBaseplate_abort()));
   }
   // ----------
 
@@ -441,7 +441,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
         tmp_wid->button()->setText("Move away pickup tool to make space for dispensing of fast glue");
         PSPToBasep_lay->addWidget(tmp_wid);
 
-        tmp_wid->connect_action(assembly, SLOT(MakeSpaceOnPlatform_start()), SIGNAL(MakeSpaceOnPlatform_finished()));
+        tmp_wid->connect_action(assembly, SLOT(MakeSpaceOnPlatform_start()), SIGNAL(MakeSpaceOnPlatform_finished()), SIGNAL(MakeSpaceOnPlatform_abort()));
       }
       // ----------
 
@@ -465,7 +465,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
         tmp_wid->button()->setText("Return to previous position");
         PSPToBasep_lay->addWidget(tmp_wid);
 
-        tmp_wid->connect_action(assembly, SLOT(ReturnToPlatform_start()), SIGNAL(ReturnToPlatform_finished()));
+        tmp_wid->connect_action(assembly, SLOT(ReturnToPlatform_start()), SIGNAL(ReturnToPlatform_finished()), SIGNAL(ReturnToPlatform_abort()));
       }
       // ----------
   }
@@ -479,10 +479,10 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
     tmp_wid->button()->setText("Lower MaPSA onto Baseplate");
     PSPToBasep_lay->addWidget(tmp_wid);
 
-    tmp_wid->connect_action(assembly, SLOT(LowerMaPSAOntoBaseplate_start()), SIGNAL(LowerMaPSAOntoBaseplate_finished()));
+    tmp_wid->connect_action(assembly, SLOT(LowerMaPSAOntoBaseplate_start()), SIGNAL(LowerMaPSAOntoBaseplate_finished()), SIGNAL(LowerMaPSAOntoBaseplate_abort()));
   }
   // ----------
-  
+
   // step: Push IDs to Database
   if(assembly->GetAssemblyCenter() == assembly::Center::DESY)
   {
@@ -527,7 +527,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
     tmp_wid->button()->setText("Disable Vacuum on Pickup-Tool");
     PSPToBasep_lay->addWidget(tmp_wid);
 
-    tmp_wid->connect_action(assembly, SLOT(DisableVacuumPickupTool_start()), SIGNAL(DisableVacuumPickupTool_finished()));
+    tmp_wid->connect_action(assembly, SLOT(DisableVacuumPickupTool_start()), SIGNAL(DisableVacuumPickupTool_finished()), SIGNAL(DisableVacuumPickupTool_abort()));
   }
   // ----------
 
@@ -540,7 +540,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
     tmp_wid->button()->setText("Lift Up Pickup-Tool");
     PSPToBasep_lay->addWidget(tmp_wid);
 
-    tmp_wid->connect_action(assembly, SLOT(LiftUpPickupTool_start()), SIGNAL(LiftUpPickupTool_finished()));
+    tmp_wid->connect_action(assembly, SLOT(LiftUpPickupTool_start()), SIGNAL(LiftUpPickupTool_finished()), SIGNAL(LiftUpPickupTool_abort()));
   }
   // ----------
 
@@ -564,7 +564,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
     tmp_wid->button()->setText("Disable Vacuum on Baseplate");
     PSPToBasep_lay->addWidget(tmp_wid);
 
-    tmp_wid->connect_action(assembly, SLOT(DisableVacuumBaseplate_start()), SIGNAL(DisableVacuumBaseplate_finished()));
+    tmp_wid->connect_action(assembly, SLOT(DisableVacuumBaseplate_start()), SIGNAL(DisableVacuumBaseplate_finished()), SIGNAL(DisableVacuumBaseplate_abort()));
   }
   // ----------
 
@@ -624,7 +624,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
     tmp_wid->button()->setText("Enable Vacuum on PS-s");
     PSSToSpacers_lay->addWidget(tmp_wid);
 
-    tmp_wid->connect_action(assembly, SLOT(EnableVacuumBaseplate_start()), SIGNAL(EnableVacuumBaseplate_finished()));
+    tmp_wid->connect_action(assembly, SLOT(EnableVacuumBaseplate_start()), SIGNAL(EnableVacuumBaseplate_finished()), SIGNAL(EnableVacuumBaseplate_abort()));
   }
   // ----------
 
@@ -637,7 +637,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
     tmp_wid->button()->setText("Go To Measurement Position on PS-s");
     PSSToSpacers_lay->addWidget(tmp_wid);
 
-    tmp_wid->connect_action(assembly, SLOT(GoToPSSSensorMarkerPreAlignment_start()), SIGNAL(GoToSensorMarkerPreAlignment_finished()));
+    tmp_wid->connect_action(assembly, SLOT(GoToPSSSensorMarkerPreAlignment_start()), SIGNAL(GoToSensorMarkerPreAlignment_finished()), SIGNAL(GoToSensorMarkerPreAlignment_abort()));
   }
   // ----------
 
@@ -653,7 +653,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
     tmp_wid->button()->setText("Align PS-s to Motion Stage (Go to \"Alignment\" Tab and select \"PS-s Sensor\")");
     PSSToSpacers_lay->addWidget(tmp_wid);
 
-    tmp_wid->connect_action(assembly, SLOT(switchToAlignmentTab_PSS()), SIGNAL(switchToAlignmentTab_PSS_request()));
+    tmp_wid->connect_action(assembly, SLOT(switchToAlignmentTab_PSS()), SIGNAL(switchToAlignmentTab_PSS_request()), SIGNAL(switchToAlignmentTab_PSS_abort()));
   }
   // ----------
 
@@ -666,7 +666,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
     tmp_wid->button()->setText("Go From Sensor Marker Ref-Point to Pickup XY");
     PSSToSpacers_lay->addWidget(tmp_wid);
 
-    tmp_wid->connect_action(assembly, SLOT(GoFromSensorMarkerToPickupXY_start()), SIGNAL(GoFromSensorMarkerToPickupXY_finished()));
+    tmp_wid->connect_action(assembly, SLOT(GoFromSensorMarkerToPickupXY_start()), SIGNAL(GoFromSensorMarkerToPickupXY_finished()), SIGNAL(GoFromSensorMarkerToPickupXY_abort()));
   }
   // ----------
 
@@ -679,7 +679,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
     tmp_wid->button()->setText("Lower Pickup-Tool onto PS-s");
     PSSToSpacers_lay->addWidget(tmp_wid);
 
-    tmp_wid->connect_action(assembly, SLOT(LowerPickupToolOntoPSS_start()), SIGNAL(LowerPickupToolOntoPSS_finished()));
+    tmp_wid->connect_action(assembly, SLOT(LowerPickupToolOntoPSS_start()), SIGNAL(LowerPickupToolOntoPSS_finished()), SIGNAL(LowerPickupToolOntoPSS_abort()));
   }
   // ----------
 
@@ -692,7 +692,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
     tmp_wid->button()->setText("Enable Vacuum on Pickup-Tool");
     PSSToSpacers_lay->addWidget(tmp_wid);
 
-    tmp_wid->connect_action(assembly, SLOT(EnableVacuumPickupTool_start()), SIGNAL(EnableVacuumPickupTool_finished()));
+    tmp_wid->connect_action(assembly, SLOT(EnableVacuumPickupTool_start()), SIGNAL(EnableVacuumPickupTool_finished()), SIGNAL(EnableVacuumPickupTool_abort()));
   }
   // ----------
 
@@ -705,7 +705,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
     tmp_wid->button()->setText("Disable Vacuum on Assembly Platform");
     PSSToSpacers_lay->addWidget(tmp_wid);
 
-    tmp_wid->connect_action(assembly, SLOT(DisableVacuumBaseplate_start()), SIGNAL(DisableVacuumBaseplate_finished()));
+    tmp_wid->connect_action(assembly, SLOT(DisableVacuumBaseplate_start()), SIGNAL(DisableVacuumBaseplate_finished()), SIGNAL(DisableVacuumBaseplate_abort()));
   }
   // ----------
 
@@ -718,7 +718,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
     tmp_wid->button()->setText("Pick Up PS-s");
     PSSToSpacers_lay->addWidget(tmp_wid);
 
-    tmp_wid->connect_action(assembly, SLOT(PickupPSS_start()), SIGNAL(PickupPSS_finished()));
+    tmp_wid->connect_action(assembly, SLOT(PickupPSS_start()), SIGNAL(PickupPSS_finished()), SIGNAL(PickupPSS_abort()));
   }
   // ----------
 
@@ -731,7 +731,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
     tmp_wid->button()->setText("Go To XYA Position To Glue PS-s to Spacers");
     PSSToSpacers_lay->addWidget(tmp_wid);
 
-    tmp_wid->connect_action(assembly, SLOT(GoToXYAPositionToGluePSSToSpacers_start()), SIGNAL(GoToXYAPositionToGluePSSToSpacers_finished()));
+    tmp_wid->connect_action(assembly, SLOT(GoToXYAPositionToGluePSSToSpacers_start()), SIGNAL(GoToXYAPositionToGluePSSToSpacers_finished()), SIGNAL(GoToXYAPositionToGluePSSToSpacers_abort()));
   }
   // ----------
 
@@ -758,7 +758,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
       tmp_wid->button()->setText("Move away pickup tool to make space for placing spacers and dispensing of fast glue");
       PSSToSpacers_lay->addWidget(tmp_wid);
 
-      tmp_wid->connect_action(assembly, SLOT(MakeSpaceOnPlatform_start()), SIGNAL(MakeSpaceOnPlatform_finished()));
+      tmp_wid->connect_action(assembly, SLOT(MakeSpaceOnPlatform_start()), SIGNAL(MakeSpaceOnPlatform_finished()), SIGNAL(MakeSpaceOnPlatform_abort()));
     }
     // ----------
 
@@ -771,7 +771,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
       tmp_wid->button()->setText("Enable Vacuum on Spacers");
       PSSToSpacers_lay->addWidget(tmp_wid);
 
-      tmp_wid->connect_action(assembly, SLOT(EnableVacuumSpacers_start()), SIGNAL(EnableVacuumSpacers_finished()));
+      tmp_wid->connect_action(assembly, SLOT(EnableVacuumSpacers_start()), SIGNAL(EnableVacuumSpacers_finished()), SIGNAL(EnableVacuumSpacers_abort()));
     }
     // ----------
 
@@ -806,7 +806,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
       tmp_wid->button()->setText("Return to previous position");
       PSSToSpacers_lay->addWidget(tmp_wid);
 
-      tmp_wid->connect_action(assembly, SLOT(ReturnToPlatform_start()), SIGNAL(ReturnToPlatform_finished()));
+      tmp_wid->connect_action(assembly, SLOT(ReturnToPlatform_start()), SIGNAL(ReturnToPlatform_finished()), SIGNAL(ReturnToPlatform_abort()));
     }
     // ----------
   } else {
@@ -830,7 +830,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
       tmp_wid->button()->setText("Enable Vacuum on Spacers");
       PSSToSpacers_lay->addWidget(tmp_wid);
 
-      tmp_wid->connect_action(assembly, SLOT(EnableVacuumSpacers_start()), SIGNAL(EnableVacuumSpacers_finished()));
+      tmp_wid->connect_action(assembly, SLOT(EnableVacuumSpacers_start()), SIGNAL(EnableVacuumSpacers_finished()), SIGNAL(EnableVacuumSpacers_abort()));
     }
     // ----------
 
@@ -854,7 +854,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
       tmp_wid->button()->setText("Move away pickup tool to make space for the Placement of the Spacer Clamp");
       PSSToSpacers_lay->addWidget(tmp_wid);
 
-      tmp_wid->connect_action(assembly, SLOT(MakeSpaceOnPlatform_start()), SIGNAL(MakeSpaceOnPlatform_finished()));
+      tmp_wid->connect_action(assembly, SLOT(MakeSpaceOnPlatform_start()), SIGNAL(MakeSpaceOnPlatform_finished()), SIGNAL(MakeSpaceOnPlatform_abort()));
     }
     // ----------
 
@@ -889,7 +889,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
         tmp_wid->button()->setText("Return to previous position");
         PSSToSpacers_lay->addWidget(tmp_wid);
 
-        tmp_wid->connect_action(assembly, SLOT(ReturnToPlatform_start()), SIGNAL(ReturnToPlatform_finished()));
+        tmp_wid->connect_action(assembly, SLOT(ReturnToPlatform_start()), SIGNAL(ReturnToPlatform_finished()), SIGNAL(ReturnToPlatform_abort()));
     }
     // ----------
   }
@@ -903,7 +903,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
     tmp_wid->button()->setText("Lower PS-s onto Spacers");
     PSSToSpacers_lay->addWidget(tmp_wid);
 
-    tmp_wid->connect_action(assembly, SLOT(LowerPSSOntoSpacers_start()), SIGNAL(LowerPSSOntoSpacers_finished()));
+    tmp_wid->connect_action(assembly, SLOT(LowerPSSOntoSpacers_start()), SIGNAL(LowerPSSOntoSpacers_finished()), SIGNAL(LowerPSSOntoSpacers_abort()));
   }
   // ----------
 
@@ -951,7 +951,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
     tmp_wid->button()->setText("Disable Vacuum on Spacers");
     PSSToSpacers_lay->addWidget(tmp_wid);
 
-    tmp_wid->connect_action(assembly, SLOT(DisableVacuumSpacers_start()), SIGNAL(DisableVacuumSpacers_finished()));
+    tmp_wid->connect_action(assembly, SLOT(DisableVacuumSpacers_start()), SIGNAL(DisableVacuumSpacers_finished()), SIGNAL(DisableVacuumSpacers_abort()));
   }
   // ----------
 
@@ -964,7 +964,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
     tmp_wid->button()->setText("Pick Up \"PS-s + Spacers\"");
     PSSToSpacers_lay->addWidget(tmp_wid);
 
-    tmp_wid->connect_action(assembly, SLOT(PickupPSSPlusSpacers_start()), SIGNAL(PickupPSSPlusSpacers_finished()));
+    tmp_wid->connect_action(assembly, SLOT(PickupPSSPlusSpacers_start()), SIGNAL(PickupPSSPlusSpacers_finished()), SIGNAL(PickupPSSPlusSpacers_abort()));
   }
   // ----------
 
@@ -1018,7 +1018,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
     tmp_wid->button()->setText("Enable Vacuum on Baseplate");
     PSSToMaPSA_lay->addWidget(tmp_wid);
 
-    tmp_wid->connect_action(assembly, SLOT(EnableVacuumBaseplate_start()), SIGNAL(EnableVacuumBaseplate_finished()));
+    tmp_wid->connect_action(assembly, SLOT(EnableVacuumBaseplate_start()), SIGNAL(EnableVacuumBaseplate_finished()), SIGNAL(EnableVacuumBaseplate_abort()));
   }
   // ----------
 
@@ -1042,7 +1042,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
     tmp_wid->button()->setText("Go To Measurement Position on \"MaPSA + Baseplate\"");
     PSSToMaPSA_lay->addWidget(tmp_wid);
 
-    tmp_wid->connect_action(assembly, SLOT(GoToPSPMarkerIdealPosition_start()), SIGNAL(GoToPSPMarkerIdealPosition_finished()));
+    tmp_wid->connect_action(assembly, SLOT(GoToPSPMarkerIdealPosition_start()), SIGNAL(GoToPSPMarkerIdealPosition_finished()), SIGNAL(GoToPSPMarkerIdealPosition_abort()));
   }
   // ----------
 
@@ -1058,7 +1058,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
     tmp_wid->button()->setText("Align MaPSA (Go to \"Alignment\" Tab and select \"PS-p Sensor\")");
     PSSToMaPSA_lay->addWidget(tmp_wid);
 
-    tmp_wid->connect_action(assembly, SLOT(switchToAlignmentTab_PSP()), SIGNAL(switchToAlignmentTab_PSP_request()));
+    tmp_wid->connect_action(assembly, SLOT(switchToAlignmentTab_PSP()), SIGNAL(switchToAlignmentTab_PSP_request()), SIGNAL(switchToAlignmentTab_PSP_request()));
   }
   // ----------
 
@@ -1071,7 +1071,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
     tmp_wid->button()->setText("Go From Sensor Marker Ref-Point to Pickup XY");
     PSSToMaPSA_lay->addWidget(tmp_wid);
 
-    tmp_wid->connect_action(assembly, SLOT(GoFromSensorMarkerToPickupXY_start()), SIGNAL(GoFromSensorMarkerToPickupXY_finished()));
+    tmp_wid->connect_action(assembly, SLOT(GoFromSensorMarkerToPickupXY_start()), SIGNAL(GoFromSensorMarkerToPickupXY_finished()), SIGNAL(GoFromSensorMarkerToPickupXY_abort()));
   }
   // ----------
 
@@ -1084,7 +1084,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
     tmp_wid->button()->setText("Apply \"PS-p To PS-s\" XY Offset");
     PSSToMaPSA_lay->addWidget(tmp_wid);
 
-    tmp_wid->connect_action(assembly, SLOT(ApplyPSPToPSSXYOffset_start()), SIGNAL(ApplyPSPToPSSXYOffset_finished()));
+    tmp_wid->connect_action(assembly, SLOT(ApplyPSPToPSSXYOffset_start()), SIGNAL(ApplyPSPToPSSXYOffset_finished()), SIGNAL(ApplyPSPToPSSXYOffset_abort()));
   }
   // ----------
 
@@ -1099,7 +1099,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
             tmp_wid->button()->setText("Move away pickup tool to make space for glue dispensing");
             PSSToMaPSA_lay->addWidget(tmp_wid);
 
-            tmp_wid->connect_action(assembly, SLOT(MakeSpaceOnPlatform_start()), SIGNAL(MakeSpaceOnPlatform_finished()));
+            tmp_wid->connect_action(assembly, SLOT(MakeSpaceOnPlatform_start()), SIGNAL(MakeSpaceOnPlatform_finished()), SIGNAL(MakeSpaceOnPlatform_abort()));
           }
           // ----------
 
@@ -1123,7 +1123,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
             tmp_wid->button()->setText("Return to previous position");
             PSSToMaPSA_lay->addWidget(tmp_wid);
 
-            tmp_wid->connect_action(assembly, SLOT(ReturnToPlatform_start()), SIGNAL(ReturnToPlatform_finished()));
+            tmp_wid->connect_action(assembly, SLOT(ReturnToPlatform_start()), SIGNAL(ReturnToPlatform_finished()), SIGNAL(ReturnToPlatform_abort()));
           }
           // ----------
 
@@ -1140,7 +1140,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
         tmp_wid->button()->setText("Register \"PS-s to MaPSA\" XYZA Position");
         PSSToMaPSA_lay->addWidget(tmp_wid);
 
-        tmp_wid->connect_action(assembly, SLOT(RegisterPSSPlusSpacersToMaPSAPosition_start()), SIGNAL(RegisterPSSPlusSpacersToMaPSAPosition_finished()));
+        tmp_wid->connect_action(assembly, SLOT(RegisterPSSPlusSpacersToMaPSAPosition_start()), SIGNAL(RegisterPSSPlusSpacersToMaPSAPosition_finished()), SIGNAL(RegisterPSSPlusSpacersToMaPSAPosition_abort()));
       }
       // ----------
 
@@ -1164,7 +1164,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
         tmp_wid->button()->setText("Go From \"PS-s To MaPSA\" Position to Gluing Stage (XY) Ref-Point");
         PSSToMaPSA_lay->addWidget(tmp_wid);
 
-        tmp_wid->connect_action(assembly, SLOT(GoFromPSSPlusSpacersToMaPSAPositionToGluingStageRefPointXY_start()), SIGNAL(GoFromPSSPlusSpacersToMaPSAPositionToGluingStageRefPointXY_finished()));
+        tmp_wid->connect_action(assembly, SLOT(GoFromPSSPlusSpacersToMaPSAPositionToGluingStageRefPointXY_start()), SIGNAL(GoFromPSSPlusSpacersToMaPSAPositionToGluingStageRefPointXY_finished()), SIGNAL(GoFromPSSPlusSpacersToMaPSAPositionToGluingStageRefPointXY_abort()));
       }
       // ----------
 
@@ -1177,7 +1177,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
         tmp_wid->button()->setText("Lower \"PS-s + Spacers\" onto Gluing Stage");
         PSSToMaPSA_lay->addWidget(tmp_wid);
 
-        tmp_wid->connect_action(assembly, SLOT(LowerPSSPlusSpacersOntoGluingStage_start()), SIGNAL(LowerPSSPlusSpacersOntoGluingStage_finished()));
+        tmp_wid->connect_action(assembly, SLOT(LowerPSSPlusSpacersOntoGluingStage_start()), SIGNAL(LowerPSSPlusSpacersOntoGluingStage_finished()), SIGNAL(LowerPSSPlusSpacersOntoGluingStage_abort()));
       }
       // ----------
 
@@ -1201,7 +1201,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
           tmp_wid->button()->setText("Slowly lift from gluing stage by 5 mm");
           PSSToMaPSA_lay->addWidget(tmp_wid);
 
-          tmp_wid->connect_action(assembly, SLOT(SlowlyLiftFromGluingStage_start()), SIGNAL(SlowlyLiftFromGluingStage_finished()));
+          tmp_wid->connect_action(assembly, SLOT(SlowlyLiftFromGluingStage_start()), SIGNAL(SlowlyLiftFromGluingStage_finished()), SIGNAL(SlowlyLiftFromGluingStage_abort()));
       }
       // ----------
 
@@ -1215,7 +1215,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
         tmp_wid->button()->setText("Return To \"PS-s to MaPSA\" Position (XYZA)");
         PSSToMaPSA_lay->addWidget(tmp_wid);
 
-        tmp_wid->connect_action(assembly, SLOT(ReturnToPSSPlusSpacersToMaPSAPosition_start()), SIGNAL(ReturnToPSSPlusSpacersToMaPSAPosition_finished()));
+        tmp_wid->connect_action(assembly, SLOT(ReturnToPSSPlusSpacersToMaPSAPosition_start()), SIGNAL(ReturnToPSSPlusSpacersToMaPSAPosition_finished()), SIGNAL(ReturnToPSSPlusSpacersToMaPSAPosition_abort()));
       }
       // ----------
   }
@@ -1228,7 +1228,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
     tmp_wid->button()->setText("Lower \"PS-s + Spacers\" onto MaPSA");
     PSSToMaPSA_lay->addWidget(tmp_wid);
 
-    tmp_wid->connect_action(assembly, SLOT(LowerPSSPlusSpacersOntoMaPSA_start()), SIGNAL(LowerPSSPlusSpacersOntoMaPSA_finished()));
+    tmp_wid->connect_action(assembly, SLOT(LowerPSSPlusSpacersOntoMaPSA_start()), SIGNAL(LowerPSSPlusSpacersOntoMaPSA_finished()), SIGNAL(LowerPSSPlusSpacersOntoMaPSA_abort()));
   }
   // ----------
 
@@ -1252,7 +1252,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
     tmp_wid->button()->setText("Disable Vacuum on Pickup-Tool");
     PSSToMaPSA_lay->addWidget(tmp_wid);
 
-    tmp_wid->connect_action(assembly, SLOT(DisableVacuumPickupTool_start()), SIGNAL(DisableVacuumPickupTool_finished()));
+    tmp_wid->connect_action(assembly, SLOT(DisableVacuumPickupTool_start()), SIGNAL(DisableVacuumPickupTool_finished()), SIGNAL(DisableVacuumPickupTool_abort()));
   }
   // ----------
 
@@ -1265,7 +1265,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
     tmp_wid->button()->setText("Lift Up Pickup-Tool");
     PSSToMaPSA_lay->addWidget(tmp_wid);
 
-    tmp_wid->connect_action(assembly, SLOT(LiftUpPickupTool_start()), SIGNAL(LiftUpPickupTool_finished()));
+    tmp_wid->connect_action(assembly, SLOT(LiftUpPickupTool_start()), SIGNAL(LiftUpPickupTool_finished()), SIGNAL(LiftUpPickupTool_abort()));
   }
   // ----------
 
@@ -1278,7 +1278,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
     tmp_wid->button()->setText("Disable Vacuum on MaPSA");
     PSSToMaPSA_lay->addWidget(tmp_wid);
 
-    tmp_wid->connect_action(assembly, SLOT(DisableVacuumBaseplate_start()), SIGNAL(DisableVacuumBaseplate_finished()));
+    tmp_wid->connect_action(assembly, SLOT(DisableVacuumBaseplate_start()), SIGNAL(DisableVacuumBaseplate_finished()), SIGNAL(DisableVacuumBaseplate_abort()));
   }
   // ----------
 

--- a/assembly/assemblyCommon/AssemblyImageController.cc
+++ b/assembly/assemblyCommon/AssemblyImageController.cc
@@ -173,10 +173,15 @@ void AssemblyImageController::acquire_autofocused_image()
   connect(this, SIGNAL(autofocused_image_request()), this, SLOT(acquire_image()));
   connect(this, SIGNAL(image_acquired()), this, SLOT(restore_autofocus_settings()));
 
+  connect(this, SIGNAL(block_camera(QObject*)), parent(), SLOT(disable_imageButtons(QObject*)));
+  connect(this, SIGNAL(release_camera(QObject*)), parent(), SLOT(enable_imageButtons(QObject*)));
+
   NQLog("AssemblyImageController", NQLog::Message) << "acquire_autofocused_image"
      << ": emitting signal \"image_request\"";
 
   emit autofocused_image_request();
+
+  emit block_camera(this);
 }
 
 void AssemblyImageController::restore_autofocus_settings()
@@ -193,4 +198,10 @@ void AssemblyImageController::restore_autofocus_settings()
      << ": emitting signal \"autofocused_image_acquired\"";
 
   emit autofocused_image_acquired();
+
+  emit release_camera(this);
+
+  disconnect(this, SIGNAL(block_camera(QObject*)), parent(), SLOT(disable_imageButtons(QObject*)));
+  disconnect(this, SIGNAL(release_camera(QObject*)), parent(), SLOT(enable_imageButtons(QObject*)));
+
 }

--- a/assembly/assemblyCommon/AssemblyImageController.h
+++ b/assembly/assemblyCommon/AssemblyImageController.h
@@ -83,6 +83,9 @@ class AssemblyImageController : public QObject
 
     void autofocused_image_request();
     void autofocused_image_acquired();
+
+    void block_camera(QObject*);
+    void release_camera(QObject*);
 };
 
 #endif // ASSEMBLYIMAGECONTROLLER_H

--- a/assembly/assemblyCommon/AssemblyObjectAlignerView.h
+++ b/assembly/assemblyCommon/AssemblyObjectAlignerView.h
@@ -49,6 +49,7 @@ class AssemblyObjectAlignerView : public QWidget
   AssemblyUEyeView* PatRecTwo_Image() const { return patrecTwo_image_; }
 
   QPushButton* button_alignerEmergencyStop() const { return button_alignerEmergencyStop_; }
+  QPushButton* button_runAlignment() { return alignm_exealig_pusbu_; }
 
   AssemblyObjectAligner::Configuration get_configuration(bool&) const;
 


### PR DESCRIPTION
This changes the way to identify whether an assembly step is currently in action and the user interaction in such a case.

Up to now, there was only a log message and the step was not conducted.
This PR improves the interface for the user (pop-up window with message) and performs a proper abort of the attempted assembly action.
Also, now a running alignment procedure sets the assembly sequence to be busy, preventing an accidental continuation of the sequence during the alignment procedure.

Depends on #223 .

To Do:
 * [x] Test at setup (@schuetzepaul)