### PR TITLE
Sequence helpers

### DIFF
--- a/assembly/assembly/AssemblyMainWindow.cc
+++ b/assembly/assembly/AssemblyMainWindow.cc
@@ -310,8 +310,8 @@ AssemblyMainWindow::AssemblyMainWindow(const QString& outputdir_path, const QStr
       assemblyV2_view_ = new AssemblyAssemblyV2View(assemblyV2_, assembly_tab);
       assembly_tab->addTab(assemblyV2_view_, tabname_Assembly);
 
-      connect(assemblyV2_, SIGNAL(switchToAlignmentTab_PSP_request()), this, SLOT(update_alignment_tab_psp()));
-      connect(assemblyV2_, SIGNAL(switchToAlignmentTab_PSS_request()), this, SLOT(update_alignment_tab_pss()));
+      connect(assemblyV2_, SIGNAL(perform_alignment_PSP_request()), this, SLOT(perform_alignment_psp()));
+      connect(assemblyV2_, SIGNAL(perform_alignment_PSS_request()), this, SLOT(perform_alignment_pss()));
 
       connect(assemblyV2_, SIGNAL(TakeImage_request()), this, SLOT(select_image_tab()));
       connect(assemblyV2_, SIGNAL(TakeImage_request()), this, SLOT(get_image()));
@@ -449,7 +449,7 @@ AssemblyMainWindow::AssemblyMainWindow(const QString& outputdir_path, const QStr
 
     subassembly_pickup_ = new AssemblySubassemblyPickup(motion_manager_, relayCardManager_, smart_motion_);
 
-    connect(subassembly_pickup_, SIGNAL(switchToAlignmentTab_PSS_request()), this, SLOT(update_alignment_tab_pss()));
+    connect(subassembly_pickup_, SIGNAL(perform_alignment_PSS_request()), this, SLOT(perform_alignment_pss()));
 
     toolbox_view_ = new AssemblyToolboxView(motion_manager_, subassembly_pickup_, controls_tab);
     controls_tab->addTab(toolbox_view_, tabname_Toolbox);
@@ -1205,9 +1205,9 @@ void AssemblyMainWindow::disconnect_otherSlots()
     disconnect(image_view_, SIGNAL(sigRequestMoveRelative(double,double,double,double)), motion_manager_, SLOT(moveRelative(double,double,double,double)));
     disconnect(motion_manager_, SIGNAL(restartMotionStage_request()), hwctr_view_->LStepExpress_Widget(), SLOT(restart()));
     disconnect(motion_manager_, SIGNAL(restartMotionStage_request()), this, SLOT(messageBox_restartMotionStage()));
-    disconnect(assemblyV2_, SIGNAL(switchToAlignmentTab_PSP_request()), this, SLOT(update_alignment_tab_psp()));
-    disconnect(assemblyV2_, SIGNAL(switchToAlignmentTab_PSS_request()), this, SLOT(update_alignment_tab_pss()));
-    disconnect(subassembly_pickup_, SIGNAL(switchToAlignmentTab_PSS_request()), this, SLOT(update_alignment_tab_pss()));
+    disconnect(assemblyV2_, SIGNAL(perform_alignment_PSP_request()), this, SLOT(perform_alignment_psp()));
+    disconnect(assemblyV2_, SIGNAL(perform_alignment_PSS_request()), this, SLOT(perform_alignment_pss()));
+    disconnect(subassembly_pickup_, SIGNAL(perform_alignment_PSS_request()), this, SLOT(perform_alignment_pss()));
     disconnect(this, SIGNAL(set_alignmentMode_PSP_request()), aligner_view_, SLOT(set_alignmentMode_PSP()));
     disconnect(this, SIGNAL(set_alignmentMode_PSS_request()), aligner_view_, SLOT(set_alignmentMode_PSS()));
     disconnect(assemblyV2_, SIGNAL(TakeImage_request()), this, SLOT(select_image_tab()));
@@ -1284,15 +1284,15 @@ void AssemblyMainWindow::quit()
 }
 
 //-- Automatically switch to 'Alignment' sub-tab and emit signal relevant for PSS/PSP
-void AssemblyMainWindow::update_alignment_tab_psp()
+void AssemblyMainWindow::perform_alignment_psp()
 {
-    this->switchAndUpdate_alignment_tab(true);
+    this->switch_tab_and_perform_alignment(true);
 }
-void AssemblyMainWindow::update_alignment_tab_pss()
+void AssemblyMainWindow::perform_alignment_pss()
 {
-    this->switchAndUpdate_alignment_tab(false);
+    this->switch_tab_and_perform_alignment(false);
 }
-void AssemblyMainWindow::switchAndUpdate_alignment_tab(bool psp_mode)
+void AssemblyMainWindow::switch_tab_and_perform_alignment(bool psp_mode)
 {
     // std::cout<<"There are "<<main_tab->count()<<" main tabs"<<std::endl; //Count main tabs
     // QTabWidget* assemblyTab = main_tab->findChild<QTabWidget*>("Module Assembly");
@@ -1305,8 +1305,10 @@ void AssemblyMainWindow::switchAndUpdate_alignment_tab(bool psp_mode)
     assemblyTab->setCurrentIndex(idx_alignment_tab); //Switch to 'Alignment' sub-tab
 
     //Emit signal to set either PSP or PSS alignment mode
-    if(psp_mode) {emit set_alignmentMode_PSP_request();}
-    else {emit set_alignmentMode_PSS_request();}
+    if(psp_mode) {aligner_view_->set_alignmentMode_PSP();}
+    else {aligner_view_->set_alignmentMode_PSS();}
+
+    aligner_view_->transmit_configuration();
 
     return;
 }

--- a/assembly/assembly/AssemblyMainWindow.cc
+++ b/assembly/assembly/AssemblyMainWindow.cc
@@ -451,6 +451,10 @@ AssemblyMainWindow::AssemblyMainWindow(const QString& outputdir_path, const QStr
 
     connect(subassembly_pickup_, SIGNAL(perform_alignment_PSS_request()), this, SLOT(perform_alignment_pss()));
 
+    connect(subassembly_pickup_, SIGNAL(TakeImage_request()), this, SLOT(select_image_tab()));
+    connect(subassembly_pickup_, SIGNAL(TakeImage_request()), this, SLOT(get_image()));
+
+
     toolbox_view_ = new AssemblyToolboxView(motion_manager_, subassembly_pickup_, controls_tab);
     controls_tab->addTab(toolbox_view_, tabname_Toolbox);
 
@@ -1212,6 +1216,8 @@ void AssemblyMainWindow::disconnect_otherSlots()
     disconnect(this, SIGNAL(set_alignmentMode_PSS_request()), aligner_view_, SLOT(set_alignmentMode_PSS()));
     disconnect(assemblyV2_, SIGNAL(TakeImage_request()), this, SLOT(select_image_tab()));
     disconnect(assemblyV2_, SIGNAL(TakeImage_request()), this, SLOT(get_image()));
+    disconnect(subassembly_pickup_, SIGNAL(TakeImage_request()), this, SLOT(select_image_tab()));
+    disconnect(subassembly_pickup_, SIGNAL(TakeImage_request()), this, SLOT(get_image()));
 
     return;
 }

--- a/assembly/assembly/AssemblyMainWindow.cc
+++ b/assembly/assembly/AssemblyMainWindow.cc
@@ -216,7 +216,7 @@ AssemblyMainWindow::AssemblyMainWindow(const QString& outputdir_path, const QStr
     const QString tabname_Image("Image Viewer");
 
     image_view_ = new AssemblyImageView(assembly_tab);
-    assembly_tab->addTab(image_view_, tabname_Image);
+    idx_image_tab_ = assembly_tab->addTab(image_view_, tabname_Image);
 
     // Thresholder
     thresholder_ = new AssemblyThresholder();
@@ -312,6 +312,9 @@ AssemblyMainWindow::AssemblyMainWindow(const QString& outputdir_path, const QStr
 
       connect(assemblyV2_, SIGNAL(switchToAlignmentTab_PSP_request()), this, SLOT(update_alignment_tab_psp()));
       connect(assemblyV2_, SIGNAL(switchToAlignmentTab_PSS_request()), this, SLOT(update_alignment_tab_pss()));
+
+      connect(assemblyV2_, SIGNAL(TakeImage_request()), this, SLOT(select_image_tab()));
+      connect(assemblyV2_, SIGNAL(TakeImage_request()), this, SLOT(get_image()));
 
       NQLog("AssemblyMainWindow", NQLog::Message) << "added view " << tabname_Assembly
          << " (assembly_sequence = " << assembly_sequence << ")";
@@ -1207,6 +1210,8 @@ void AssemblyMainWindow::disconnect_otherSlots()
     disconnect(subassembly_pickup_, SIGNAL(switchToAlignmentTab_PSS_request()), this, SLOT(update_alignment_tab_pss()));
     disconnect(this, SIGNAL(set_alignmentMode_PSP_request()), aligner_view_, SLOT(set_alignmentMode_PSP()));
     disconnect(this, SIGNAL(set_alignmentMode_PSS_request()), aligner_view_, SLOT(set_alignmentMode_PSS()));
+    disconnect(assemblyV2_, SIGNAL(TakeImage_request()), this, SLOT(select_image_tab()));
+    disconnect(assemblyV2_, SIGNAL(TakeImage_request()), this, SLOT(get_image()));
 
     return;
 }
@@ -1304,6 +1309,16 @@ void AssemblyMainWindow::switchAndUpdate_alignment_tab(bool psp_mode)
     else {emit set_alignmentMode_PSS_request();}
 
     return;
+}
+
+void AssemblyMainWindow::select_image_tab()
+{
+    main_tab->setCurrentIndex(idx_module_tab);
+
+    QList<QTabWidget*> widgets = main_tab->findChildren<QTabWidget*>();
+    QTabWidget* assemblyTab = widgets[1];
+
+    assemblyTab->setCurrentIndex(idx_image_tab_);
 }
 
 void AssemblyMainWindow::update_stage_position()

--- a/assembly/assembly/AssemblyMainWindow.cc
+++ b/assembly/assembly/AssemblyMainWindow.cc
@@ -313,6 +313,12 @@ AssemblyMainWindow::AssemblyMainWindow(const QString& outputdir_path, const QStr
       connect(assemblyV2_, SIGNAL(perform_alignment_PSP_request()), this, SLOT(perform_alignment_psp()));
       connect(assemblyV2_, SIGNAL(perform_alignment_PSS_request()), this, SLOT(perform_alignment_pss()));
 
+      connect(aligner_, SIGNAL(execution_successful()), assemblyV2_, SLOT(FinishAlignment()));
+
+      connect(aligner_view_->button_alignerEmergencyStop(), SIGNAL(clicked()), assemblyV2_, SLOT(AbortAlignment()));
+      connect(aligner_view_, SIGNAL(execution_failed()), assemblyV2_, SLOT(AbortAlignment()));
+      connect(image_view_->autofocus_emergencyStop_button(), SIGNAL(clicked()), assemblyV2_, SLOT(AbortAlignment()));
+
       connect(assemblyV2_, SIGNAL(TakeImage_request()), this, SLOT(select_image_tab()));
       connect(assemblyV2_, SIGNAL(TakeImage_request()), this, SLOT(get_image()));
 
@@ -513,6 +519,7 @@ AssemblyMainWindow::AssemblyMainWindow(const QString& outputdir_path, const QStr
     connect(button_mainEmergencyStop_, SIGNAL(clicked()), metrology_view_, SLOT(metrology_abort()));
     connect(button_mainEmergencyStop_, SIGNAL(clicked()), this, SLOT(disconnect_metrology()));
     connect(button_mainEmergencyStop_, SIGNAL(clicked()), this, SLOT(disconnect_multiPickupTest()));
+    connect(button_mainEmergencyStop_, SIGNAL(clicked()), assemblyV2_, SLOT(AbortAlignment()));
 
     QWidget *spacer1 = new QWidget();
     spacer1->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Expanding);

--- a/assembly/assembly/AssemblyMainWindow.h
+++ b/assembly/assembly/AssemblyMainWindow.h
@@ -84,7 +84,8 @@ class AssemblyMainWindow : public QMainWindow
   {
       disconnect_otherSlots();
   }
-  void switchAndUpdate_alignment_tab(bool);
+  void switch_tab_and_perform_alignment(bool);
+
 
  private:
     void closeEvent (QCloseEvent *event);
@@ -118,8 +119,8 @@ class AssemblyMainWindow : public QMainWindow
   void quit_thread(QThread*, const QString&) const;
   void quit();
 
-  void update_alignment_tab_psp();
-  void update_alignment_tab_pss();
+  void perform_alignment_psp();
+  void perform_alignment_pss();
 
   void update_stage_position();
 

--- a/assembly/assembly/AssemblyMainWindow.h
+++ b/assembly/assembly/AssemblyMainWindow.h
@@ -164,6 +164,8 @@ class AssemblyMainWindow : public QMainWindow
 
   void enable_imageButtons(QObject*);
 
+  void select_image_tab();
+
  protected:
 
   // Low-Level Controllers (Motion, Camera, Vacuum)
@@ -248,6 +250,7 @@ class AssemblyMainWindow : public QMainWindow
   int idx_alignment_tab;
   int idx_module_tab;
   int idx_manual_tab;
+  int idx_image_tab_;
 
   QList<QObject*> camera_blocking_objects_;
 };

--- a/assembly/assemblyCommon/AssemblyAssemblyV2.cc
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2.cc
@@ -2662,7 +2662,7 @@ void AssemblyAssemblyV2::AssemblyCompleted_start()
 void AssemblyAssemblyV2::PerformAlignmentPSP()
 {
   if(in_action_){
-    reportInAction("PerformAlignmentPSP", SIGNAL(PerformAlignmentPSP_abort()));
+    reportInAction("PerformAlignmentPSP", SIGNAL(perform_alignment_aborted()));
     return;
   }
 
@@ -2683,7 +2683,7 @@ void AssemblyAssemblyV2::PerformAlignmentPSP()
 void AssemblyAssemblyV2::PerformAlignmentPSS()
 {
   if(in_action_){
-    reportInAction("PerformAlignmentPSS", SIGNAL(PerformAlignmentPSS_abort()));
+    reportInAction("PerformAlignmentPSS", SIGNAL(perform_alignment_aborted()));
     return;
   }
 
@@ -2697,6 +2697,23 @@ void AssemblyAssemblyV2::PerformAlignmentPSS()
   return;
 }
 // ----------------------------------------------------------------------------------------------------
+
+// ----------------------------------------------------------------------------------------------------
+// AbortAlignment ------------------------------------------------------------------------------
+// ----------------------------------------------------------------------------------------------------
+void AssemblyAssemblyV2::AbortAlignment()
+{
+    set_in_action(false);
+    emit perform_alignment_aborted();
+}
+
+// ----------------------------------------------------------------------------------------------------
+// FinishAlignment ------------------------------------------------------------------------------
+// ----------------------------------------------------------------------------------------------------
+void AssemblyAssemblyV2::FinishAlignment()
+{
+    emit perform_alignment_finished();
+}
 
 // ----------------------------------------------------------------------------------------------------
 // takeImage ------------------------------------------------------------------------------

--- a/assembly/assemblyCommon/AssemblyAssemblyV2.cc
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2.cc
@@ -2698,6 +2698,29 @@ void AssemblyAssemblyV2::switchToAlignmentTab_PSS()
 }
 // ----------------------------------------------------------------------------------------------------
 
+// ----------------------------------------------------------------------------------------------------
+// takeImage ------------------------------------------------------------------------------
+// ----------------------------------------------------------------------------------------------------
+void AssemblyAssemblyV2::TakeImage()
+{
+  if(in_action_){
+    reportInAction("TakeImage", SIGNAL(TakeImage_abort()));
+    return;
+  }
+
+  set_in_action(true);
+
+  NQLog("AssemblyAssemblyV2", NQLog::Spam) << "TakeImage"
+    << ": emitting signal \"TakeImage_request\"";
+
+  emit TakeImage_request(); //Will auto-switch to 'Alignment' sub-tab, and select PSS mode
+
+  set_in_action(false);
+
+  return;
+}
+// ----------------------------------------------------------------------------------------------------
+
 void AssemblyAssemblyV2::reportInAction(const QString target_step, const char* abort_signal)
 {
     NQLog("AssemblyAssemblyV2", NQLog::Warning) << target_step

--- a/assembly/assemblyCommon/AssemblyAssemblyV2.cc
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2.cc
@@ -2657,42 +2657,42 @@ void AssemblyAssemblyV2::AssemblyCompleted_start()
   emit AssemblyCompleted_finished();
 }
 // ----------------------------------------------------------------------------------------------------
-// switchToAlignmentTab_PSP ------------------------------------------------------------------------------
+// PerformAlignmentPSP ------------------------------------------------------------------------------
 // ----------------------------------------------------------------------------------------------------
-void AssemblyAssemblyV2::switchToAlignmentTab_PSP()
+void AssemblyAssemblyV2::PerformAlignmentPSP()
 {
   if(in_action_){
-    reportInAction("switchToAlignmentTab_PSP", SIGNAL(switchToAlignmentTab_PSP_abort()));
+    reportInAction("PerformAlignmentPSP", SIGNAL(PerformAlignmentPSP_abort()));
     return;
   }
 
   set_in_action(true);
 
-  NQLog("AssemblyAssemblyV2", NQLog::Spam) << "switchToAlignmentTab_PSP"
-    << ": emitting signal \"switchToAlignmentTab_PSP_request\"";
+  NQLog("AssemblyAssemblyV2", NQLog::Spam) << "PerformAlignmentPSP"
+    << ": emitting signal \"perform_alignment_PSP_request\"";
 
-  emit switchToAlignmentTab_PSP_request(); //Will auto-switch to 'Alignment' sub-tab, and select PSP mode
+  emit perform_alignment_PSP_request(); //Will auto-switch to 'Alignment' sub-tab, select PSP mode and start the alignment
 
   return;
 }
 // ----------------------------------------------------------------------------------------------------
 
 // ----------------------------------------------------------------------------------------------------
-// switchToAlignmentTab_PSS ------------------------------------------------------------------------------
+// PerformAlignmentPSS ------------------------------------------------------------------------------
 // ----------------------------------------------------------------------------------------------------
-void AssemblyAssemblyV2::switchToAlignmentTab_PSS()
+void AssemblyAssemblyV2::PerformAlignmentPSS()
 {
   if(in_action_){
-    reportInAction("switchToAlignmentTab_PSS", SIGNAL(switchToAlignmentTab_PSS_abort()));
+    reportInAction("PerformAlignmentPSS", SIGNAL(PerformAlignmentPSS_abort()));
     return;
   }
 
   set_in_action(true);
 
-  NQLog("AssemblyAssemblyV2", NQLog::Spam) << "switchToAlignmentTab_PSS"
-    << ": emitting signal \"switchToAlignmentTab_PSS_request\"";
+  NQLog("AssemblyAssemblyV2", NQLog::Spam) << "PerformAlignmentPSS"
+    << ": emitting signal \"perform_alignment_PSS_request\"";
 
-  emit switchToAlignmentTab_PSS_request(); //Will auto-switch to 'Alignment' sub-tab, and select PSS mode
+  emit perform_alignment_PSS_request(); //Will auto-switch to 'Alignment' sub-tab, select PSS mode and start the alignment
 
   return;
 }

--- a/assembly/assemblyCommon/AssemblyAssemblyV2.h
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2.h
@@ -216,7 +216,10 @@ protected slots:
   void RegisterPSSPlusSpacersToMaPSAPosition_finish();
 
   void switchToAlignmentTab_PSP();
+
   void switchToAlignmentTab_PSS();
+
+  void TakeImage();
   // ---------
 
  signals:
@@ -352,10 +355,15 @@ protected slots:
   // others
   void RegisterPSSPlusSpacersToMaPSAPosition_finished();
   void RegisterPSSPlusSpacersToMaPSAPosition_abort();
+
   void switchToAlignmentTab_PSP_request();
   void switchToAlignmentTab_PSP_abort();
+
   void switchToAlignmentTab_PSS_request();
   void switchToAlignmentTab_PSS_abort();
+
+  void TakeImage_request();
+  void TakeImage_abort();
 
   void MaPSA_ID_updated(const QString);
   void PSS_ID_updated(const QString);

--- a/assembly/assemblyCommon/AssemblyAssemblyV2.h
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2.h
@@ -215,9 +215,9 @@ protected slots:
   void RegisterPSSPlusSpacersToMaPSAPosition_start();
   void RegisterPSSPlusSpacersToMaPSAPosition_finish();
 
-  void switchToAlignmentTab_PSP();
+  void PerformAlignmentPSP();
 
-  void switchToAlignmentTab_PSS();
+  void PerformAlignmentPSS();
 
   void TakeImage();
   // ---------
@@ -356,11 +356,11 @@ protected slots:
   void RegisterPSSPlusSpacersToMaPSAPosition_finished();
   void RegisterPSSPlusSpacersToMaPSAPosition_abort();
 
-  void switchToAlignmentTab_PSP_request();
-  void switchToAlignmentTab_PSP_abort();
+  void perform_alignment_PSP_request();
+  void perform_alignment_PSP_abort();
 
-  void switchToAlignmentTab_PSS_request();
-  void switchToAlignmentTab_PSS_abort();
+  void perform_alignment_PSS_request();
+  void perform_alignment_PSS_abort();
 
   void TakeImage_request();
   void TakeImage_abort();

--- a/assembly/assemblyCommon/AssemblyAssemblyV2.h
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2.h
@@ -216,8 +216,10 @@ protected slots:
   void RegisterPSSPlusSpacersToMaPSAPosition_finish();
 
   void PerformAlignmentPSP();
-
   void PerformAlignmentPSS();
+
+  void AbortAlignment();
+  void FinishAlignment();
 
   void TakeImage();
   // ---------
@@ -357,10 +359,10 @@ protected slots:
   void RegisterPSSPlusSpacersToMaPSAPosition_abort();
 
   void perform_alignment_PSP_request();
-  void perform_alignment_PSP_abort();
-
   void perform_alignment_PSS_request();
-  void perform_alignment_PSS_abort();
+
+  void perform_alignment_aborted();
+  void perform_alignment_finished();
 
   void TakeImage_request();
   void TakeImage_abort();

--- a/assembly/assemblyCommon/AssemblyAssemblyV2View.cc
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2View.cc
@@ -171,14 +171,16 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
       }
       // ----------
 
-      // step: Check platform reference point
+      // step: Take an image
       {
         ++assembly_step_N;
 
-        AssemblyAssemblyTextWidget* tmp_wid = new AssemblyAssemblyTextWidget;
+        AssemblyAssemblyActionWidget* tmp_wid = new AssemblyAssemblyActionWidget;
         tmp_wid->label()->setText(QString::number(assembly_step_N));
-        tmp_wid->text()->setText("Take an Image and validate that the Platform Reference Marker is centered in the Image");
+        tmp_wid->button()->setText("Take an Image and validate that the Platform Reference Marker is centered in the Image");
         PSPToBasep_lay->addWidget(tmp_wid);
+
+        tmp_wid->connect_action(assembly, SLOT(TakeImage()), SIGNAL(TakeImage_request()), SIGNAL(TakeImage_abort()));
       }
       // ----------
 
@@ -269,6 +271,19 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
     PSPToBasep_lay->addWidget(tmp_wid);
 
     tmp_wid->connect_action(assembly, SLOT(GoToPSPSensorMarkerPreAlignment_start()), SIGNAL(GoToSensorMarkerPreAlignment_finished()), SIGNAL(GoToSensorMarkerPreAlignment_abort()));
+  }
+  // ----------
+
+  // step: Take an image
+  {
+    ++assembly_step_N;
+
+    AssemblyAssemblyActionWidget* tmp_wid = new AssemblyAssemblyActionWidget;
+    tmp_wid->label()->setText(QString::number(assembly_step_N));
+    tmp_wid->button()->setText("Take an Image and validate that the Fiducial Marker is within the Image");
+    PSPToBasep_lay->addWidget(tmp_wid);
+
+    tmp_wid->connect_action(assembly, SLOT(TakeImage()), SIGNAL(TakeImage_request()), SIGNAL(TakeImage_abort()));
   }
   // ----------
 
@@ -638,6 +653,19 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
     PSSToSpacers_lay->addWidget(tmp_wid);
 
     tmp_wid->connect_action(assembly, SLOT(GoToPSSSensorMarkerPreAlignment_start()), SIGNAL(GoToSensorMarkerPreAlignment_finished()), SIGNAL(GoToSensorMarkerPreAlignment_abort()));
+  }
+  // ----------
+
+  // step: Take an image
+  {
+    ++assembly_step_N;
+
+    AssemblyAssemblyActionWidget* tmp_wid = new AssemblyAssemblyActionWidget;
+    tmp_wid->label()->setText(QString::number(assembly_step_N));
+    tmp_wid->button()->setText("Take an Image and validate that the Fiducial Marker is within the Image");
+    PSSToSpacers_lay->addWidget(tmp_wid);
+
+    tmp_wid->connect_action(assembly, SLOT(TakeImage()), SIGNAL(TakeImage_request()), SIGNAL(TakeImage_abort()));
   }
   // ----------
 
@@ -1043,6 +1071,19 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
     PSSToMaPSA_lay->addWidget(tmp_wid);
 
     tmp_wid->connect_action(assembly, SLOT(GoToPSPMarkerIdealPosition_start()), SIGNAL(GoToPSPMarkerIdealPosition_finished()), SIGNAL(GoToPSPMarkerIdealPosition_abort()));
+  }
+  // ----------
+
+  // step: Take an image
+  {
+    ++assembly_step_N;
+
+    AssemblyAssemblyActionWidget* tmp_wid = new AssemblyAssemblyActionWidget;
+    tmp_wid->label()->setText(QString::number(assembly_step_N));
+    tmp_wid->button()->setText("Take an Image and validate that the Fiducial Marker is within the Image");
+    PSSToMaPSA_lay->addWidget(tmp_wid);
+
+    tmp_wid->connect_action(assembly, SLOT(TakeImage()), SIGNAL(TakeImage_request()), SIGNAL(TakeImage_abort()));
   }
   // ----------
 

--- a/assembly/assemblyCommon/AssemblyAssemblyV2View.cc
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2View.cc
@@ -296,10 +296,10 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
     AssemblyAssemblyActionWidget* tmp_wid = new AssemblyAssemblyActionWidget;
     tmp_wid->label()->setText(QString::number(assembly_step_N));
     // tmp_wid->text()->setText("Align MaPSA to Motion Stage (Go to \"Alignment\" Tab and select \"PS-p Sensor\")");
-    tmp_wid->button()->setText("Align MaPSA to Motion Stage (Go to \"Alignment\" Tab and select \"PS-p Sensor\")");
+    tmp_wid->button()->setText("Perform alignment: MaPSA to Motion Stage");
     PSPToBasep_lay->addWidget(tmp_wid);
 
-    tmp_wid->connect_action(assembly, SLOT(switchToAlignmentTab_PSP()), SIGNAL(switchToAlignmentTab_PSP_request()), SIGNAL(switchToAlignmentTab_PSP_abort()));
+    tmp_wid->connect_action(assembly, SLOT(PerformAlignmentPSP()), SIGNAL(perform_alignment_PSP_request()), SIGNAL(perform_alignment_PSP_abort()));
   }
   // ----------
 
@@ -678,10 +678,10 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
     AssemblyAssemblyActionWidget* tmp_wid = new AssemblyAssemblyActionWidget;
     tmp_wid->label()->setText(QString::number(assembly_step_N));
     // tmp_wid->text()->setText("Align PS-s to Motion Stage (Go to \"Alignment\" Tab and select \"PS-s Sensor\")");
-    tmp_wid->button()->setText("Align PS-s to Motion Stage (Go to \"Alignment\" Tab and select \"PS-s Sensor\")");
+    tmp_wid->button()->setText("Perform alignment: PS-s to Motion Stage");
     PSSToSpacers_lay->addWidget(tmp_wid);
 
-    tmp_wid->connect_action(assembly, SLOT(switchToAlignmentTab_PSS()), SIGNAL(switchToAlignmentTab_PSS_request()), SIGNAL(switchToAlignmentTab_PSS_abort()));
+    tmp_wid->connect_action(assembly, SLOT(PerformAlignmentPSS()), SIGNAL(perform_alignment_PSS_request()), SIGNAL(perform_alignment_PSS_abort()));
   }
   // ----------
 
@@ -1096,10 +1096,10 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
     AssemblyAssemblyActionWidget* tmp_wid = new AssemblyAssemblyActionWidget;
     tmp_wid->label()->setText(QString::number(assembly_step_N));
     // tmp_wid->text()->setText("Align MaPSA (Go to \"Alignment\" Tab and select \"PS-p Sensor\")");
-    tmp_wid->button()->setText("Align MaPSA (Go to \"Alignment\" Tab and select \"PS-p Sensor\")");
+    tmp_wid->button()->setText("Perform alignment: MaPSA to Motion Stage");
     PSSToMaPSA_lay->addWidget(tmp_wid);
 
-    tmp_wid->connect_action(assembly, SLOT(switchToAlignmentTab_PSP()), SIGNAL(switchToAlignmentTab_PSP_request()), SIGNAL(switchToAlignmentTab_PSP_request()));
+    tmp_wid->connect_action(assembly, SLOT(PerformAlignmentPSP()), SIGNAL(perform_alignment_PSP_request()), SIGNAL(perform_alignment_PSP_abort()));
   }
   // ----------
 

--- a/assembly/assemblyCommon/AssemblyAssemblyV2View.cc
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2View.cc
@@ -1096,7 +1096,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
     AssemblyAssemblyActionWidget* tmp_wid = new AssemblyAssemblyActionWidget;
     tmp_wid->label()->setText(QString::number(assembly_step_N));
     // tmp_wid->text()->setText("Align MaPSA (Go to \"Alignment\" Tab and select \"PS-p Sensor\")");
-    tmp_wid->button()->setText("Perform alignment: MaPSA to Motion Stage");
+    tmp_wid->button()->setText("Perform Alignment: MaPSA to Motion Stage");
     PSSToMaPSA_lay->addWidget(tmp_wid);
 
     tmp_wid->connect_action(assembly, SLOT(PerformAlignmentPSP()), SIGNAL(perform_alignment_PSP_request()), SIGNAL(perform_alignment_PSP_abort()));

--- a/assembly/assemblyCommon/AssemblyAssemblyV2View.cc
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2View.cc
@@ -299,7 +299,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
     tmp_wid->button()->setText("Perform alignment: MaPSA to Motion Stage");
     PSPToBasep_lay->addWidget(tmp_wid);
 
-    tmp_wid->connect_action(assembly, SLOT(PerformAlignmentPSP()), SIGNAL(perform_alignment_PSP_request()), SIGNAL(perform_alignment_PSP_abort()));
+    tmp_wid->connect_action(assembly, SLOT(PerformAlignmentPSP()), SIGNAL(perform_alignment_PSP_request()));
   }
   // ----------
 
@@ -681,7 +681,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
     tmp_wid->button()->setText("Perform alignment: PS-s to Motion Stage");
     PSSToSpacers_lay->addWidget(tmp_wid);
 
-    tmp_wid->connect_action(assembly, SLOT(PerformAlignmentPSS()), SIGNAL(perform_alignment_PSS_request()), SIGNAL(perform_alignment_PSS_abort()));
+    tmp_wid->connect_action(assembly, SLOT(PerformAlignmentPSS()), SIGNAL(perform_alignment_PSS_request()));
   }
   // ----------
 
@@ -1099,7 +1099,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
     tmp_wid->button()->setText("Perform Alignment: MaPSA to Motion Stage");
     PSSToMaPSA_lay->addWidget(tmp_wid);
 
-    tmp_wid->connect_action(assembly, SLOT(PerformAlignmentPSP()), SIGNAL(perform_alignment_PSP_request()), SIGNAL(perform_alignment_PSP_abort()));
+    tmp_wid->connect_action(assembly, SLOT(PerformAlignmentPSP()), SIGNAL(perform_alignment_PSP_request()));
   }
   // ----------
 

--- a/assembly/assemblyCommon/AssemblyAssemblyV2View.cc
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2View.cc
@@ -299,7 +299,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
     tmp_wid->button()->setText("Perform alignment: MaPSA to Motion Stage");
     PSPToBasep_lay->addWidget(tmp_wid);
 
-    tmp_wid->connect_action(assembly, SLOT(PerformAlignmentPSP()), SIGNAL(perform_alignment_PSP_request()));
+    tmp_wid->connect_action(assembly, SLOT(PerformAlignmentPSP()), SIGNAL(perform_alignment_finished()), SIGNAL(perform_alignment_aborted()));
   }
   // ----------
 
@@ -681,7 +681,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
     tmp_wid->button()->setText("Perform alignment: PS-s to Motion Stage");
     PSSToSpacers_lay->addWidget(tmp_wid);
 
-    tmp_wid->connect_action(assembly, SLOT(PerformAlignmentPSS()), SIGNAL(perform_alignment_PSS_request()));
+    tmp_wid->connect_action(assembly, SLOT(PerformAlignmentPSS()), SIGNAL(perform_alignment_finished()), SIGNAL(perform_alignment_aborted()));
   }
   // ----------
 
@@ -1099,7 +1099,7 @@ AssemblyAssemblyV2View::AssemblyAssemblyV2View(const AssemblyAssemblyV2* const a
     tmp_wid->button()->setText("Perform Alignment: MaPSA to Motion Stage");
     PSSToMaPSA_lay->addWidget(tmp_wid);
 
-    tmp_wid->connect_action(assembly, SLOT(PerformAlignmentPSP()), SIGNAL(perform_alignment_PSP_request()));
+    tmp_wid->connect_action(assembly, SLOT(PerformAlignmentPSP()), SIGNAL(perform_alignment_finished()), SIGNAL(perform_alignment_aborted()));
   }
   // ----------
 

--- a/assembly/assemblyCommon/AssemblyObjectAligner.cc
+++ b/assembly/assemblyCommon/AssemblyObjectAligner.cc
@@ -275,6 +275,7 @@ void AssemblyObjectAligner::run_alignment(const double patrec_dX, const double p
        this->reset_counter_numOfRotations();
 
        emit execution_completed();
+       emit execution_failed();
 
        return;
     }
@@ -614,4 +615,5 @@ void AssemblyObjectAligner::report_alignment_completed() {
     int ret = msgBox->exec();
 
     emit execution_completed();
+    emit execution_successful();
 }

--- a/assembly/assemblyCommon/AssemblyObjectAligner.h
+++ b/assembly/assemblyCommon/AssemblyObjectAligner.h
@@ -126,6 +126,10 @@ class AssemblyObjectAligner : public QObject
 
     void execution_completed();
 
+    void execution_failed();
+    
+    void execution_successful();
+
     void DBLogMessage(const QString);
 };
 

--- a/assembly/assemblyCommon/AssemblyObjectAlignerView.cc
+++ b/assembly/assemblyCommon/AssemblyObjectAlignerView.cc
@@ -680,6 +680,7 @@ void AssemblyObjectAlignerView::transmit_configuration()
     case QMessageBox::No:
       NQLog("AssemblyObjectAlignerView", NQLog::Critical) << "transmit_configuration"
       << ": abort start of alignment procedure";
+      emit execution_failed();
       return;
     default: return;
   }

--- a/assembly/assemblyCommon/AssemblyObjectAlignerView.h
+++ b/assembly/assemblyCommon/AssemblyObjectAlignerView.h
@@ -136,6 +136,7 @@ class AssemblyObjectAlignerView : public QWidget
  signals:
 
   void configuration(AssemblyObjectAligner::Configuration);
+  void execution_failed();
 };
 
 #endif // ASSEMBLYOBJECTALIGNERVIEW_H

--- a/assembly/assemblyCommon/AssemblySubassemblyPickup.cc
+++ b/assembly/assemblyCommon/AssemblySubassemblyPickup.cc
@@ -307,13 +307,13 @@ void AssemblySubassemblyPickup::EnableVacuumSubassembly_finish()
 // ----------------------------------------------------------------------------------------------------
 
 // ----------------------------------------------------------------------------------------------------
-// switchToAlignmentTab_PSS ------------------------------------------------------------------------------
+// PerformAlignmentPSS ------------------------------------------------------------------------------
 // ----------------------------------------------------------------------------------------------------
-void AssemblySubassemblyPickup::switchToAlignmentTab_PSS()
+void AssemblySubassemblyPickup::PerformAlignmentPSS()
 {
   if(in_action_){
 
-    NQLog("AssemblySubassemblyPickup", NQLog::Warning) << "switchToAlignmentTab_PSS"
+    NQLog("AssemblySubassemblyPickup", NQLog::Warning) << "PerformAlignmentPSS"
        << ": logic error, an assembly step is still in progress, will not take further action";
 
     return;
@@ -321,10 +321,35 @@ void AssemblySubassemblyPickup::switchToAlignmentTab_PSS()
 
   in_action_ = true;
 
-  NQLog("AssemblySubassemblyPickup", NQLog::Spam) << "switchToAlignmentTab_PSS"
-    << ": emitting signal \"switchToAlignmentTab_PSS_request\"";
+  NQLog("AssemblySubassemblyPickup", NQLog::Spam) << "PerformAlignmentPSS"
+    << ": emitting signal \"perform_alignment_PSS_request\"";
 
-  emit switchToAlignmentTab_PSS_request(); //Will auto-switch to 'Alignment' sub-tab, and select PSS mode
+  emit perform_alignment_PSS_request(); //Will auto-switch to 'Alignment' sub-tab, select PSS mode and start the alignment
+
+  in_action_ = false;
+
+  return;
+}
+// ----------------------------------------------------------------------------------------------------
+
+// ----------------------------------------------------------------------------------------------------
+// takeImage ------------------------------------------------------------------------------
+// ----------------------------------------------------------------------------------------------------
+void AssemblySubassemblyPickup::TakeImage()
+{
+  if(in_action_){
+      NQLog("AssemblySubassemblyPickup", NQLog::Warning) << "TakeImage"
+         << ": logic error, an assembly step is still in progress, will not take further action";
+
+    return;
+  }
+
+  in_action_ = true;
+
+  NQLog("AssemblySubassemblyPickup", NQLog::Spam) << "TakeImage"
+    << ": emitting signal \"TakeImage_request\"";
+
+  emit TakeImage_request(); //Will auto-switch to 'Alignment' sub-tab, and select PSS mode
 
   in_action_ = false;
 

--- a/assembly/assemblyCommon/AssemblySubassemblyPickup.h
+++ b/assembly/assemblyCommon/AssemblySubassemblyPickup.h
@@ -78,7 +78,9 @@ class AssemblySubassemblyPickup : public QObject
   void EnableVacuumSubassembly_start();
   void EnableVacuumSubassembly_finish();
 
-  void switchToAlignmentTab_PSS();
+  void PerformAlignmentPSS();
+
+  void TakeImage();
 
   void GoFromSensorMarkerToPickupXY_start();
   void GoFromSensorMarkerToPickupXY_finish();
@@ -121,7 +123,10 @@ class AssemblySubassemblyPickup : public QObject
   void EnableVacuumSubassembly_finished();
   void DisableVacuumSubassembly_finished();
 
-  void switchToAlignmentTab_PSS_request();
+  void perform_alignment_PSS_request();
+
+  void TakeImage_request();
+  void TakeImage_abort();
 
   void DBLogMessage(const QString);
 

--- a/assembly/assemblyCommon/AssemblySubassemblyPickupWidget.cc
+++ b/assembly/assemblyCommon/AssemblySubassemblyPickupWidget.cc
@@ -132,10 +132,23 @@ AssemblySubassemblyPickupWidget::AssemblySubassemblyPickupWidget(const AssemblyS
 
     AssemblyAssemblyActionWidget* tmp_wid = new AssemblyAssemblyActionWidget;
     tmp_wid->label()->setText(QString::number(pickup_step_N));
-    tmp_wid->button()->setText("Align PS-s to Motion Stage (Go to \"Alignment\" Tab and select \"PS-s Sensor\")");
+    tmp_wid->button()->setText("Take an Image and validate that the Fiducial Marker is within the Image");
     sub_pick_lay->addWidget(tmp_wid);
 
-    tmp_wid->connect_action(subassembly_pickup, SLOT(switchToAlignmentTab_PSS()), SIGNAL(switchToAlignmentTab_PSS_request()));
+    tmp_wid->connect_action(subassembly_pickup, SLOT(TakeImage()), SIGNAL(TakeImage_request()));
+  }
+  // ----------
+
+  // step: Align PSS to motion stage
+  {
+    ++pickup_step_N;
+
+    AssemblyAssemblyActionWidget* tmp_wid = new AssemblyAssemblyActionWidget;
+    tmp_wid->label()->setText(QString::number(pickup_step_N));
+    tmp_wid->button()->setText("Perform Alignment: PS-s to Motion Stage");
+    sub_pick_lay->addWidget(tmp_wid);
+
+    tmp_wid->connect_action(subassembly_pickup, SLOT(PerformAlignmentPSS()), SIGNAL(perform_alignment_PSS_request()));
   }
   // ----------
 


### PR DESCRIPTION
This PR brings two new or changed steps:
 * New step: "Take image ..." for identifying whether the fiducial marker is within the FOV. This action takes the image and switches to the `Image Viewer` tab.
 * Changed step: "Perform alignment" now does not only switch to the corresponding tab and selects the correct sensor, it also starts the alignment procedure itself.

This is used in ...
 * Validating stage reference marker position
 * 3x Alignment routine in assembly sequence
 * Subassembly pickup sequence

<img width="457" height="185" alt="image" src="https://github.com/user-attachments/assets/996ab612-d714-43ca-9763-3fc46e4abd09" />

Depends on #223 and #235 .

To Do:
* [x] Testing (@schuetzepaul )
* [x] Identify abort signal for alignment procedure (@schuetzepaul )