### PR TITLE
Database Improvements

### DIFF
--- a/assembly/assemblyCommon/AssemblyAssemblyV2.cc
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2.cc
@@ -312,6 +312,9 @@ void AssemblyAssemblyV2::ScanModuleID_start()
     if (!ok || Module_ID.isEmpty()){
         emit ScanModuleID_aborted();
         return;
+    } else if (!database_->validate_module_ID(Module_ID)) {
+        emit ScanModuleID_aborted();
+        return;
     } else {
         Module_ID_ = Module_ID;
         emit Module_ID_updated(Module_ID);

--- a/assembly/assemblyCommon/AssemblyAssemblyV2.cc
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2.cc
@@ -324,7 +324,8 @@ void AssemblyAssemblyV2::RegisterModuleID_start()
     NQLog("AssemblyAssemblyV2", NQLog::Spam) << "RegisterModuleID_start: "
     << "Attempting to register module ID in DB";
 
-    if(database_->register_module_name(Module_ID_, "OperatorName"))
+    auto operator_name = config_->getDefaultValue<std::string>("main", "Database_User", "OperatorName");
+    if(database_->register_module_name(Module_ID_, QString::fromStdString(operator_name)))
     {
         NQLog("AssemblyAssemblyV2", NQLog::Spam) << "RegisterModuleID_start: "
         << "Successfully registered module in DB";

--- a/assembly/assemblyCommon/DatabaseBrown.h
+++ b/assembly/assemblyCommon/DatabaseBrown.h
@@ -25,6 +25,7 @@ class DatabaseBrown : public VDatabase
       explicit DatabaseBrown(QObject* parent, QFileInfo file_path);
       ~DatabaseBrown();
 
+      bool validate_module_ID(QString) { return true; };
       bool register_module_name(QString, QString);
       bool MaPSA_to_BP(QString, QString, QString, QString="", QString="");
       bool PSs_to_spacers(QString, QString, QString="", QString="");

--- a/assembly/assemblyCommon/DatabaseDESY.cc
+++ b/assembly/assemblyCommon/DatabaseDESY.cc
@@ -59,10 +59,17 @@ bool DatabaseDESY::validate_module_ID(QString module_name)
     QRegularExpressionMatch match = re.match(module_name);
     if (match.hasMatch()) {
         QString flavour_str = match.captured("flavour");
-        auto flavour = flavour_str.toInt() / 10.;
+
+        std::set<QString> possible_flavours{"16", "26", "40"};
+        if(!possible_flavours.count(flavour_str)) {
+            error_message("\"register_module_name\" (registering): Module flavour is not valid. Possible flavours: 16, 26, 40.");
+            return false;
+        }
 
         ApplicationConfig* config = ApplicationConfig::instance();
+        auto flavour = flavour_str.toInt() / 10.;
         auto spacer_thickness = config->getValue<double>("parameters", "Thickness_Spacer");
+
         if(fabs(flavour - 0.8 - spacer_thickness) > 0.05) {
             error_message("\"register_module_name\" (registering): Module name does not match spacer thickness. Please check module name or spacer thickness.");
             return false;
@@ -71,7 +78,7 @@ bool DatabaseDESY::validate_module_ID(QString module_name)
         error_message("Module name does not meet conventions: PS_XX_DSY-YYYYY");
         return false;
     }
-    
+
     return true;
 }
 

--- a/assembly/assemblyCommon/DatabaseDESY.cc
+++ b/assembly/assemblyCommon/DatabaseDESY.cc
@@ -12,6 +12,8 @@
 
 #include <DatabaseDESY.h>
 
+#include <ApplicationConfig.h>
+
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonValue>
@@ -21,8 +23,10 @@
 #include <QEventLoop>
 #include <QMessageBox>
 #include <QTextDocumentFragment>
+#include <QRegularExpression>
 
 #include <iostream>
+#include <math.h>
 #include <nqlogger.h>
 
 DatabaseDESY::DatabaseDESY(QObject *parent, QString base_url, QString token)
@@ -48,6 +52,28 @@ DatabaseDESY::~DatabaseDESY()
 {
 }
 
+bool DatabaseDESY::validate_module_ID(QString module_name)
+{
+    // Check whether the module name meets the conventions
+    QRegularExpression re("PS_(?<flavour>\\d\\d)_DSY-\\d\\d\\d\\d\\d");
+    QRegularExpressionMatch match = re.match(module_name);
+    if (match.hasMatch()) {
+        QString flavour_str = match.captured("flavour");
+        auto flavour = flavour_str.toInt() / 10.;
+
+        ApplicationConfig* config = ApplicationConfig::instance();
+        auto spacer_thickness = config->getValue<double>("parameters", "Thickness_Spacer");
+        if(fabs(flavour - 0.8 - spacer_thickness) > 0.05) {
+            error_message("\"register_module_name\" (registering): Module name does not match spacer thickness. Please check module name or spacer thickness.");
+            return false;
+        }
+    } else {
+        error_message("Module name does not meet conventions: PS_XX_DSY-YYYYY");
+        return false;
+    }
+    
+    return true;
+}
 
 bool DatabaseDESY::register_module_name(QString module_name, QString operator_name)
 {

--- a/assembly/assemblyCommon/DatabaseDESY.h
+++ b/assembly/assemblyCommon/DatabaseDESY.h
@@ -27,6 +27,7 @@ class DatabaseDESY : public VDatabase
       explicit DatabaseDESY(QObject* parent, QString base_url, QString token);
       ~DatabaseDESY();
 
+      bool validate_module_ID(QString);
       bool register_module_name(QString, QString);
       bool MaPSA_to_BP(QString, QString, QString, QString, QString="");
       bool PSs_to_spacers(QString, QString, QString, QString="");

--- a/assembly/assemblyCommon/DatabaseDummy.cc
+++ b/assembly/assemblyCommon/DatabaseDummy.cc
@@ -27,6 +27,9 @@ DatabaseDummy::~DatabaseDummy()
     // Any connections to close?
 }
 
+bool DatabaseDummy::validate_module_ID(QString module_name) {
+    return true;
+}
 
 bool DatabaseDummy::register_module_name(QString module_name, QString operator_name)
 {

--- a/assembly/assemblyCommon/DatabaseDummy.h
+++ b/assembly/assemblyCommon/DatabaseDummy.h
@@ -23,6 +23,7 @@ class DatabaseDummy : public VDatabase
       explicit DatabaseDummy(QObject* parent);
       ~DatabaseDummy();
 
+      bool validate_module_ID(QString);
       bool register_module_name(QString, QString);
       bool MaPSA_to_BP(QString, QString, QString, QString, QString);
       bool PSs_to_spacers(QString, QString, QString, QString);

--- a/assembly/assemblyCommon/VDatabase.h
+++ b/assembly/assemblyCommon/VDatabase.h
@@ -24,6 +24,7 @@ class VDatabase : public QObject
       VDatabase(QObject* parent);
       ~VDatabase();
 
+      virtual bool validate_module_ID(QString) = 0;
       virtual bool register_module_name(QString, QString) = 0;
       virtual bool MaPSA_to_BP(QString, QString, QString, QString, QString) = 0;
       virtual bool PSs_to_spacers(QString, QString, QString, QString) = 0;


### PR DESCRIPTION
Improvements to the database implementation:

* A method has been added to the virtual database base class for validating the module ID
* This method is called when scanning/entering the module ID and aborts this step when it returns `false`
* For DESY, this validated that ...
  * the naming convention `PS_XX_DSY-YYYYY` is met
  * `XX` is either 16, 26 or 40
  * the spacer thickness does not deviate by more than 50 um from the nominal thickness for this flavour.
* The operator name is now not hardcoded anymore but can be set via the main config file (`Database_User`)

I tested this via the test database, so this is ready to merge.