### PR TITLE
Logging footprint

### DIFF
--- a/assembly/assemblyCommon/AssemblyObjectFinderPatRec.cc
+++ b/assembly/assemblyCommon/AssemblyObjectFinderPatRec.cc
@@ -368,7 +368,7 @@ void AssemblyObjectFinderPatRec::template_matching(const AssemblyObjectFinderPat
 
   NQLog("AssemblyObjectFinderPatRec", NQLog::Message) << "template_matching: created output directory: " << output_dir;
 
-  if(output_subdir != "")
+  if(output_subdir != "" && config_->getDefaultValue<int>("main", "Store_Images_PatRec", 2)>=2)
   {
     assembly::QDir_mkpath(output_subdir);
 
@@ -376,26 +376,29 @@ void AssemblyObjectFinderPatRec::template_matching(const AssemblyObjectFinderPat
   }
   // -----------
 
-  // Input images to PatRec
-  const std::string filepath_img_master        = output_dir+"/image_master_raw.png";
-  const std::string filepath_img_master_PatRec = output_dir+"/image_master_PatRec.png";
-  const std::string filepath_img_templa_PatRec = output_dir+"/image_template_PatRec.png";
+  if(config_->getDefaultValue<int>("main", "Store_Images_PatRec", 2)>=1)
+  {
+      // Input images to PatRec
+      const std::string filepath_img_master        = output_dir+"/image_master_raw.png";
+      const std::string filepath_img_master_PatRec = output_dir+"/image_master_PatRec.png";
+      const std::string filepath_img_templa_PatRec = output_dir+"/image_template_PatRec.png";
 
-  assembly::cv_imwrite(filepath_img_master, img_master);
+      assembly::cv_imwrite(filepath_img_master, img_master);
 
-  NQLog("AssemblyObjectFinderPatRec", NQLog::Spam) << "template_matching"
-     << ": saved master image to " << filepath_img_master;
+      NQLog("AssemblyObjectFinderPatRec", NQLog::Spam) << "template_matching"
+         << ": saved master image to " << filepath_img_master;
 
-  assembly::cv_imwrite(filepath_img_master_PatRec, img_master_PatRec);
+      assembly::cv_imwrite(filepath_img_master_PatRec, img_master_PatRec);
 
-  NQLog("AssemblyObjectFinderPatRec", NQLog::Spam) << "template_matching"
-     << ": saved PatRec-input master image to " << filepath_img_master_PatRec;
+      NQLog("AssemblyObjectFinderPatRec", NQLog::Spam) << "template_matching"
+         << ": saved PatRec-input master image to " << filepath_img_master_PatRec;
 
-  assembly::cv_imwrite(filepath_img_templa_PatRec, img_templa_PatRec);
+      assembly::cv_imwrite(filepath_img_templa_PatRec, img_templa_PatRec);
 
-  NQLog("AssemblyObjectFinderPatRec", NQLog::Spam) << "template_matching"
-     << ": saved PatRec-input template image to " << filepath_img_templa_PatRec;
-  // -----------
+      NQLog("AssemblyObjectFinderPatRec", NQLog::Spam) << "template_matching"
+         << ": saved PatRec-input template image to " << filepath_img_templa_PatRec;
+      // -----------
+  }
 
   // --- Template Matching
 
@@ -560,8 +563,11 @@ void AssemblyObjectFinderPatRec::template_matching(const AssemblyObjectFinderPat
   }
   // ---
 
-  const std::string filepath_img_master_copy = output_dir+"/image_master_PatRec_edited.png";
-  assembly::cv_imwrite(filepath_img_master_copy, img_master_copy);
+  if(config_->getDefaultValue<int>("main", "Store_Images_PatRec", 2)>=1)
+  {
+      const std::string filepath_img_master_copy = output_dir+"/image_master_PatRec_edited.png";
+      assembly::cv_imwrite(filepath_img_master_copy, img_master_copy);
+  }
 
   NQLog("AssemblyObjectFinderPatRec", NQLog::Spam) << "template_matching"
      << ": emitting signal \"PatRec_res_image_master_edited()\"";
@@ -662,7 +668,7 @@ void AssemblyObjectFinderPatRec::PatRec(double& fom, cv::Point& match_loc, const
 
   warpAffine(img_master_PatRec, img_master_PatRec_rot, rot_mat, img_master_PatRec.size(), cv::INTER_NEAREST, cv::BORDER_CONSTANT, avgPixelIntensity);
 
-  if(out_dir != "")
+  if(out_dir != "" && config_->getDefaultValue<int>("main", "Store_Images_PatRec", 2)>=2)
   {
     const std::string filepath_img_master_PatRec_rot = out_dir+"/image_master_PatRec_Rotation_"+std::to_string(angle_master)+".png";
 

--- a/assembly/assemblyCommon/AssemblyZFocusFinder.cc
+++ b/assembly/assemblyCommon/AssemblyZFocusFinder.cc
@@ -47,7 +47,7 @@ AssemblyZFocusFinder::AssemblyZFocusFinder(const QString& output_dir_prepath, co
   config_ = ApplicationConfig::instance();
   if(config_ == nullptr)
   {
-    NQLog("AssemblyObjectFinderPatRec", NQLog::Fatal) << "initialization error"
+    NQLog("AssemblyZFocusFinder", NQLog::Fatal) << "initialization error"
        << ": ApplicationConfig::instance() not initialized (null pointer), exiting constructor";
 
     return;

--- a/assembly/assemblyCommon/AssemblyZFocusFinder.cc
+++ b/assembly/assemblyCommon/AssemblyZFocusFinder.cc
@@ -11,7 +11,6 @@
 /////////////////////////////////////////////////////////////////////////////////
 
 #include <nqlogger.h>
-#include <ApplicationConfig.h>
 
 #include <AssemblyZFocusFinder.h>
 #include <AssemblyUtilities.h>
@@ -45,22 +44,22 @@ AssemblyZFocusFinder::AssemblyZFocusFinder(const QString& output_dir_prepath, co
  , output_dir_("")
 {
   // initialization
-  ApplicationConfig* config = ApplicationConfig::instance();
-  if(config == nullptr)
+  config_ = ApplicationConfig::instance();
+  if(config_ == nullptr)
   {
-    NQLog("AssemblyZFocusFinder", NQLog::Fatal) << "initialization error"
+    NQLog("AssemblyObjectFinderPatRec", NQLog::Fatal) << "initialization error"
        << ": ApplicationConfig::instance() not initialized (null pointer), exiting constructor";
 
     return;
   }
 
-  focus_pointN_max_ = config->getDefaultValue<int>   ("main", "AssemblyZFocusFinder_pointN_max", 200);
-  focus_pointN_     = config->getDefaultValue<int>   ("main", "AssemblyZFocusFinder_pointN"    ,  50);
+  focus_pointN_max_ = config_->getDefaultValue<int>   ("main", "AssemblyZFocusFinder_pointN_max", 200);
+  focus_pointN_     = config_->getDefaultValue<int>   ("main", "AssemblyZFocusFinder_pointN"    ,  50);
 
-  focus_zrange_max_ = config->getDefaultValue<double>("main", "AssemblyZFocusFinder_zrange_max", 3.0);
-  focus_zrange_     = config->getDefaultValue<double>("main", "AssemblyZFocusFinder_zrange"    , 0.5);
+  focus_zrange_max_ = config_->getDefaultValue<double>("main", "AssemblyZFocusFinder_zrange_max", 3.0);
+  focus_zrange_     = config_->getDefaultValue<double>("main", "AssemblyZFocusFinder_zrange"    , 0.5);
 
-  focus_stepsize_min_ = config->getDefaultValue<double>("main", "AssemblyZFocusFinder_stepsize_min", 0.005);
+  focus_stepsize_min_ = config_->getDefaultValue<double>("main", "AssemblyZFocusFinder_stepsize_min", 0.005);
 
   v_zrelm_vals_.clear();
   v_focus_vals_.clear();
@@ -408,10 +407,13 @@ void AssemblyZFocusFinder::process_image(const cv::Mat& img)
 
     zrelm_index_ = -1;
 
-    // save best-focus image
-    const std::string img_outpath = output_dir_+"/AssemblyZFocusFinder_best.png";
+    if(config_->getDefaultValue<int>("main", "Store_Images_ZFocusFinder", 2)>=1)
+    {
+        // save best-focus image
+        const std::string img_outpath = output_dir_+"/AssemblyZFocusFinder_best.png";
 
-    cv::imwrite(img_outpath, img);
+        cv::imwrite(img_outpath, img);
+    }
 
     NQLog("AssemblyZFocusFinder", NQLog::Spam) << "process_image"
        << ": emitting signal \"image_acquired\"";
@@ -422,9 +424,12 @@ void AssemblyZFocusFinder::process_image(const cv::Mat& img)
   {
     // --- generic z-focus step ---
 
-    // save image
-    const std::string img_outpath = output_dir_+"/AssemblyZFocusFinder_"+std::to_string(v_focus_vals_.size())+".png";
-    cv::imwrite(img_outpath, img);
+    if(config_->getDefaultValue<int>("main", "Store_Images_ZFocusFinder", 2)>=2)
+    {
+        // save image
+        const std::string img_outpath = output_dir_+"/AssemblyZFocusFinder_"+std::to_string(v_focus_vals_.size())+".png";
+        cv::imwrite(img_outpath, img);
+    }
 
     // save z-focus info
     AssemblyZFocusFinder::focus_info this_focus;

--- a/assembly/assemblyCommon/AssemblyZFocusFinder.h
+++ b/assembly/assemblyCommon/AssemblyZFocusFinder.h
@@ -15,6 +15,7 @@
 
 #include <AssemblyVUEyeCamera.h>
 #include <LStepExpressMotionManager.h>
+#include <ApplicationConfig.h>
 
 #include <QObject>
 #include <QString>
@@ -49,6 +50,8 @@ class AssemblyZFocusFinder : public QObject
   protected:
 
     QString output_dir_prepath_;
+
+    const ApplicationConfig* config_;
 
     const AssemblyVUEyeCamera*       camera_manager_;
     const LStepExpressMotionManager* motion_manager_;

--- a/assembly/assembly_Silicon.cfg
+++ b/assembly/assembly_Silicon.cfg
@@ -110,6 +110,10 @@ Metrology_PSP2_template_fpath    			share/assembly/psp_marker_new_rotate90_mirro
 Metrology_PSS1_template_fpath				share/assembly/SiDummyPSs_template_v01.png
 Metrology_PSS2_template_fpath    			share/assembly/SiDummyPSs_template_v01.png
 
+# Store images for Pattern Recognition and Z Focus Finder algorithms (0: none; 1: result; 2: all)
+Store_Images_PatRec         2
+Store_Images_ZFocusFinder   2
+
 # AssemblySmartMotionManager
 AssemblySmartMotionManager_steps_dZ   0.5,0.5,0.2,0.2,0.2,0.2,0.1,0.05,0.05
 AssemblySmartMotionManager_initial_step_up_dZ   1.0

--- a/assembly/assembly_glass.cfg
+++ b/assembly/assembly_glass.cfg
@@ -111,6 +111,10 @@ Metrology_PSP2_template_fpath    			share/assembly/markedglass_marker1_drawing_5
 Metrology_PSS1_template_fpath				share/assembly/markedglass_marker1_drawing_588x588_BL.png
 Metrology_PSS2_template_fpath    			share/assembly/markedglass_marker1_drawing_588x588_TL.png
 
+# Store images for Pattern Recognition and Z Focus Finder algorithms (0: none; 1: result; 2: all)
+Store_Images_PatRec         2
+Store_Images_ZFocusFinder   2
+
 # AssemblySmartMotionManager
 AssemblySmartMotionManager_steps_dZ   0.5,0.5,0.2,0.2,0.2,0.2,0.1,0.05,0.05
 AssemblySmartMotionManager_initial_step_up_dZ   1.0


### PR DESCRIPTION
Last one for today ...

This implements a configurable "logging level" for images.

Issue & Status Quo:
Many images are stored to disk during PatRec and ZFocusFinder, swamping the disk with a few 100 MB per module! This includes all rotated images during a PatRec, PatRec result images and all images during a ZFocusFinder scan.

This branch:
With the parameters `Store_Images_PatRec` and `Store_Images_ZFocusFinder`, the following options are toggled:
 * 2: all images are stored, just like the Status Quo
 * 1: only the results (ZFocus: best image, PatRec: original image (grey & B/W), template and image+rectangle) are stored
 * 0: no images are stored, only text files containing the results.

I would assume that for a normal assembly, we can reduce this to 1 for now and save a factor of 6 to 10 of disk space.