### PR TITLE
Alignment correction

### DIFF
--- a/assembly/assembly/parameters/Silicon.cfg
+++ b/assembly/assembly/parameters/Silicon.cfg
@@ -101,3 +101,9 @@ FromRefPointPlatformToSpacerEdge_dY        69.18
 # NB: although we do not rely on the actual dicing of the PSP's edges, we do use the nominal PSP corner position in the code's logic to position the PSP on the baseplate
 FromRefPointPlatformToPSPEdge_dX          11.13
 FromRefPointPlatformToPSPEdge_dY          70.08
+
+# distance: correction for PSP placement on Baseplate
+# This value can be derived from metrology results and corrects for a systematic shift in the alignment
+PSPToBaseplateCorrection_dX                 0.0
+PSPToBaseplateCorrection_dY                 0.0
+PSPToBaseplateCorrection_dA                 0.0

--- a/assembly/assembly/parameters/glass.cfg
+++ b/assembly/assembly/parameters/glass.cfg
@@ -92,3 +92,9 @@ FromRefPointPlatformToSpacerEdge_dY        69.18
 # distance: from ref-point on assembly platform to PSp ref. edge (in baseplate platform orientation)
 FromRefPointPlatformToPSPEdge_dX          11.13
 FromRefPointPlatformToPSPEdge_dY          70.08
+
+# distance: correction for PSP placement on Baseplate
+# This value can be derived from metrology results and corrects for a systematic shift in the alignment
+PSPToBaseplateCorrection_dX                 0.0
+PSPToBaseplateCorrection_dY                 0.0
+PSPToBaseplateCorrection_dA                 0.0

--- a/assembly/assemblyCommon/AssemblyAssemblyV2.cc
+++ b/assembly/assemblyCommon/AssemblyAssemblyV2.cc
@@ -1469,6 +1469,7 @@ void AssemblyAssemblyV2::GoToXYAPositionToGlueMaPSAToBaseplate_start()
    + config_->getValue<double>("parameters", "FromRefPointPlatformToPSPEdge_dX")
    + config_->getValue<double>("parameters", "FromPSPEdgeToPSPRefPoint_dX")
    + config_->getValue<double>("parameters", "FromSensorRefPointToSensorPickup_dX")
+   + config_->getValue<double>("parameters", "PSPToBaseplateCorrection_dX")
    - motion_->get_position_X();
 
   const double dy0 =
@@ -1476,12 +1477,14 @@ void AssemblyAssemblyV2::GoToXYAPositionToGlueMaPSAToBaseplate_start()
    + config_->getValue<double>("parameters", "FromRefPointPlatformToPSPEdge_dY")
    + config_->getValue<double>("parameters", "FromPSPEdgeToPSPRefPoint_dY")
    + config_->getValue<double>("parameters", "FromSensorRefPointToSensorPickup_dY")
+   + config_->getValue<double>("parameters", "PSPToBaseplateCorrection_dY")
    - motion_->get_position_Y();
 
   const double dz0 = 0.0;
 
   const double da0 =
      config_->getValue<double>("parameters", "RefPointPlatform_A")
+   + config_->getValue<double>("parameters", "PSPToBaseplateCorrection_dA")
    - motion_->get_position_A();
 
   connect(this, SIGNAL(move_relative_request(double, double, double, double)), motion_, SLOT(moveRelative(double, double, double, double)));

--- a/assembly/assemblyCommon/AssemblyParametersView.cc
+++ b/assembly/assemblyCommon/AssemblyParametersView.cc
@@ -447,6 +447,27 @@ AssemblyParametersView::AssemblyParametersView(QWidget* parent)
   button_moveRelRefDist6_  = new QPushButton(tr("Apply Relative Movement"));
   dist_lay->addWidget(button_moveRelRefDist6_, row_index, 9, Qt::AlignLeft);
 
+  // distance: correction for PSP placement on Baseplate
+  ++row_index;
+
+  tmp_tag = "PSPToBaseplateCorrection";
+  tmp_des = "Correction for PSP placement on Baseplate :";
+
+  map_lineEdit_[tmp_tag+"_dX"] = new QLineEdit(tr(""));
+  map_lineEdit_[tmp_tag+"_dY"] = new QLineEdit(tr(""));
+  map_lineEdit_[tmp_tag+"_dA"] = new QLineEdit(tr(""));
+
+  dist_lay->addWidget(new QLabel(tmp_des)     , row_index, 0, Qt::AlignLeft);
+  dist_lay->addWidget(new QLabel(tr("dX"))    , row_index, 1, Qt::AlignRight);
+  dist_lay->addWidget(this->get(tmp_tag+"_dX"), row_index, 2, Qt::AlignRight);
+  dist_lay->addWidget(new QLabel(tr("dY"))    , row_index, 3, Qt::AlignRight);
+  dist_lay->addWidget(this->get(tmp_tag+"_dY"), row_index, 4, Qt::AlignRight);
+  dist_lay->addWidget(new QLabel(tr("dA"))    , row_index, 7, Qt::AlignRight);
+  dist_lay->addWidget(this->get(tmp_tag+"_dA"), row_index, 8, Qt::AlignRight);
+
+  button_moveRelRefDist21_  = new QPushButton(tr("Apply Relative Movement"));
+  dist_lay->addWidget(button_moveRelRefDist21_, row_index, 9, Qt::AlignLeft);
+
   // distance: from best-focus z-position to pickup z-position
   ++row_index;
 
@@ -687,6 +708,7 @@ AssemblyParametersView::AssemblyParametersView(QWidget* parent)
   connect(button_moveRelRefDist18_ , SIGNAL(clicked()), this, SLOT(moveByRelRefDist18()));
   connect(button_moveRelRefDist19_ , SIGNAL(clicked()), this, SLOT(moveByRelRefDist19()));
   connect(button_moveRelRefDist20_ , SIGNAL(clicked()), this, SLOT(moveByRelRefDist20()));
+  connect(button_moveRelRefDist21_ , SIGNAL(clicked()), this, SLOT(moveByRelRefDist21()));
   connect(this , SIGNAL(click_moveByRelRefDist(int)), this, SLOT(askConfirmMoveByRelRefDist(int)));
 
   connect(config_, SIGNAL(valueChanged()), this, SLOT(copy_values()));
@@ -735,6 +757,7 @@ AssemblyParametersView::~AssemblyParametersView()
     disconnect(button_moveRelRefDist18_ , SIGNAL(clicked()), this, SLOT(moveByRelRefDist18()));
     disconnect(button_moveRelRefDist19_ , SIGNAL(clicked()), this, SLOT(moveByRelRefDist19()));
     disconnect(button_moveRelRefDist20_ , SIGNAL(clicked()), this, SLOT(moveByRelRefDist20()));
+    disconnect(button_moveRelRefDist21_ , SIGNAL(clicked()), this, SLOT(moveByRelRefDist21()));
     disconnect(this , SIGNAL(click_moveByRelRefDist(int)), this, SLOT(askConfirmMoveByRelRefDist(int)));
 }
 
@@ -1071,6 +1094,8 @@ void AssemblyParametersView::askConfirmMoveByRelRefDist(int refPoint)
         case 19: tmp_tag = "Sensor_PSS_deltaY";
             break;
         case 20: tmp_tag = "FromPickupHeightToGlueHeight";
+            break;
+        case 21: tmp_tag = "PSPToBaseplateCorrection";
             break;
         default: return;
     }

--- a/assembly/assemblyCommon/AssemblyParametersView.h
+++ b/assembly/assemblyCommon/AssemblyParametersView.h
@@ -55,7 +55,7 @@ class AssemblyParametersView : public QWidget
   QPushButton* paramIO_button_write_;
 
   QPushButton *button_moveAbsRefPos1_, *button_moveAbsRefPos2_, *button_moveAbsRefPos4_, *button_moveAbsRefPos5_;
-  QPushButton *button_moveRelRefDist1_, *button_moveRelRefDist2_, *button_moveRelRefDist3_, *button_moveRelRefDist4_, *button_moveRelRefDist5_, *button_moveRelRefDist6_, *button_moveRelRefDist7_, *button_moveRelRefDist8_, *button_moveRelRefDist9_, *button_moveRelRefDist10_, *button_moveRelRefDist11_, *button_moveRelRefDist12_, *button_moveRelRefDist13_, *button_moveRelRefDist14_, *button_moveRelRefDist15_, *button_moveRelRefDist16_, *button_moveRelRefDist17_, *button_moveRelRefDist18_, *button_moveRelRefDist19_, *button_moveRelRefDist20_;
+  QPushButton *button_moveRelRefDist1_, *button_moveRelRefDist2_, *button_moveRelRefDist3_, *button_moveRelRefDist4_, *button_moveRelRefDist5_, *button_moveRelRefDist6_, *button_moveRelRefDist7_, *button_moveRelRefDist8_, *button_moveRelRefDist9_, *button_moveRelRefDist10_, *button_moveRelRefDist11_, *button_moveRelRefDist12_, *button_moveRelRefDist13_, *button_moveRelRefDist14_, *button_moveRelRefDist15_, *button_moveRelRefDist16_, *button_moveRelRefDist17_, *button_moveRelRefDist18_, *button_moveRelRefDist19_, *button_moveRelRefDist20_, *button_moveRelRefDist21_;
 
   std::map<std::string, QLineEdit*> map_lineEdit_;
 
@@ -104,6 +104,7 @@ class AssemblyParametersView : public QWidget
   void moveByRelRefDist18() {emit click_moveByRelRefDist(18);};
   void moveByRelRefDist19() {emit click_moveByRelRefDist(19);};
   void moveByRelRefDist20() {emit click_moveByRelRefDist(20);};
+  void moveByRelRefDist21() {emit click_moveByRelRefDist(21);};
   void askConfirmMoveByRelRefDist(int);
 
  signals:


### PR DESCRIPTION
This adds the possibility to implement a configurable correction to the PSp to Baseplate alignment.
Such a correction can be applied in case the metrology shows a systematic shift of this alignment w.r.t. to the nominal position. The parameters default to zero, hence this is transparent in case this parameter is not altered.

* [ ] Check alignment results for modules > 10541